### PR TITLE
fix: SSR component transformation for 'use client'

### DIFF
--- a/sdk/src/vite/useClientPlugin.mts
+++ b/sdk/src/vite/useClientPlugin.mts
@@ -32,7 +32,10 @@ import { registerClientReference } from "@redwoodjs/sdk/worker";
 
         for (const e of exports) {
           if (e.ln != null) {
-            s.replaceAll(e.ln, `${e.ln}SSR`);
+            s.replaceAll(
+              new RegExp(`(export\\s+(?:const|function|let|var)\\s+)(${e.ln})\\b`, 'g'),
+              `$1${e.ln}SSR`
+            );
 
             s.append(`\
 export const ${e.ln} = registerClientReference(${JSON.stringify(relativeId)}, ${JSON.stringify(e.ln)}, ${e.ln}SSR);

--- a/sdk/src/vite/useClientPlugin.mts
+++ b/sdk/src/vite/useClientPlugin.mts
@@ -32,10 +32,7 @@ import { registerClientReference } from "@redwoodjs/sdk/worker";
 
         for (const e of exports) {
           if (e.ln != null) {
-            s.replaceAll(
-              new RegExp(`(export\\s+(?:const|function|let|var)\\s+)(${e.ln})\\b`, 'g'),
-              `$1${e.ln}SSR`
-            );
+            s.update(e.s, e.e, `${e.ln}SSR`);
 
             s.append(`\
 export const ${e.ln} = registerClientReference(${JSON.stringify(relativeId)}, ${JSON.stringify(e.ln)}, ${e.ln}SSR);


### PR DESCRIPTION
## Problem
Part of our 'use client' transformations for worker-side code involves renaming components to include an `SSR` suffix. The way we were (I was) doing this was naiive - we'd basically do a `replaceAll()` for the components name 🙈. So if you had "Word" as a component name, and it had copy "Word" in it, both the component name (expected) and the copy (unexpected) would be transformed to "WordSSR". This in turn would cause a react hydration issue since the SSR'd code would render this copy, while the client side code would still render "Word".

## Solution
We already know the line+column positions of the export we want to add the suffix too, we just need to use it.

## Screenshots

### Before
<img width="879" alt="Screenshot 2025-02-25 at 21 33 48" src="https://github.com/user-attachments/assets/b4db677a-c8a4-491e-be5a-6462bae0b847" />

### After
<img width="880" alt="Screenshot 2025-02-25 at 21 34 20" src="https://github.com/user-attachments/assets/d0d62196-ac67-4db2-a9dc-1b449b99abf3" />
