### PR TITLE
fix: Avoid env exposure for client-based pages

### DIFF
--- a/sdk/src/runtime/register/worker.ts
+++ b/sdk/src/runtime/register/worker.ts
@@ -25,6 +25,7 @@ export function registerClientReference<Target extends Record<string, any>>(id: 
     {
       ...Object.getOwnPropertyDescriptors(reference),
       $$async: { value: true },
+      $$isClientReference: { value: true },
     },
   );
 }

--- a/sdk/src/runtime/worker.tsx
+++ b/sdk/src/runtime/worker.tsx
@@ -45,7 +45,7 @@ export const defineApp = <Context,>(routes: Route<Context>[]) => {
 
         const renderPage = async ({
           Page,
-          props,
+          props: givenProps,
           actionResult,
           Layout,
         }: {
@@ -54,6 +54,15 @@ export const defineApp = <Context,>(routes: Route<Context>[]) => {
           actionResult: unknown,
           Layout: React.FC<{ children: React.ReactNode }>
         }) => {
+          let props = givenProps;
+
+          // context(justinvdm, 25 Feb 2025): If the page is a client reference, we need to avoid passing
+          // down props the client shouldn't get (e.g. env). For safety, we pick the allowed props explicitly.
+          if (Object.prototype.hasOwnProperty.call(Page, "$$isClientReference")) {
+            const { ctx, params } = givenProps;
+            props = { ctx, params };
+          }
+
           const rscPayloadStream = renderToRscStream({
             node: <Page {...props} />,
             actionResult: actionResult instanceof Response ? null : actionResult,


### PR DESCRIPTION
## Problem
When rendering page components (the "root" component for a page), we provide it with props that includes `env`. This is fine when the page component is a worker-rendered RSC component, but not fine when the page component is a `use client` component - in the latter case, we are exposing `env` to the browser.

## Solution
Detect if page component is a client component. If it is, pass only `params` and `ctx` as props.

**note** We still need to be careful to not provide anything in ctx that we do not want shown to the browser. I'm not sure if it would be better for us to not pass `ctx` down either. But then we maybe want to prevent page components from being `use client` components in the first place. Or maybe we can make it clear in docs that ctx passed to client side?