### PR TITLE
fix: Logout for auth starters

### DIFF
--- a/sdk/src/runtime/lib/auth/session.ts
+++ b/sdk/src/runtime/lib/auth/session.ts
@@ -34,7 +34,7 @@ const arrayBufferToHex = (buffer: ArrayBuffer): string => {
 }
 
 export const createSessionCookie = ({ sessionId, maxAge }: { sessionId: string, maxAge?: number | true }) =>
-  `session_id=${sessionId}; Path=/; HttpOnly; Secure; SameSite=Lax${maxAge ? `; Max-Age=${maxAge === true ? MAX_SESSION_DURATION / 1000 : maxAge}` : ''}`;
+  `session_id=${sessionId}; Path=/; HttpOnly; Secure; SameSite=Lax${maxAge != null ? `; Max-Age=${maxAge === true ? MAX_SESSION_DURATION / 1000 : maxAge}` : ''}`;
 
 export const signSessionId = async ({ unsignedSessionId, secretKey }: { unsignedSessionId: string, secretKey: string }) => {
   const encoder = new TextEncoder();
@@ -135,6 +135,7 @@ export const defineSessionStore = <Session, SessionInputData>({
     if (sessionId) {
       await unset(sessionId);
     }
+    console.log('## remove', createSessionCookie({ sessionId: '', maxAge: 0 }))
     headers.set("Set-Cookie", createSessionCookie({ sessionId: '', maxAge: 0 }));
   };
 

--- a/sdk/src/runtime/lib/auth/session.ts
+++ b/sdk/src/runtime/lib/auth/session.ts
@@ -135,7 +135,6 @@ export const defineSessionStore = <Session, SessionInputData>({
     if (sessionId) {
       await unset(sessionId);
     }
-    console.log('## remove', createSessionCookie({ sessionId: '', maxAge: 0 }))
     headers.set("Set-Cookie", createSessionCookie({ sessionId: '', maxAge: 0 }));
   };
 

--- a/starters/passkey-auth/src/app/pages/auth/LoginPage.tsx
+++ b/starters/passkey-auth/src/app/pages/auth/LoginPage.tsx
@@ -43,7 +43,7 @@ export function LoginPage() {
 
   return (
     <>
-      <input type="text" value={username} onChange={(e) => setUsername(e.target.value)} />
+      <input type="text" value={username} onChange={(e) => setUsername(e.target.value)} placeholder="Username" />
       <button onClick={handlePerformPasskeyLogin} disabled={isPending}>
         {isPending ? (
           <>

--- a/starters/passkey-auth/src/app/pages/auth/routes.ts
+++ b/starters/passkey-auth/src/app/pages/auth/routes.ts
@@ -7,9 +7,9 @@ export const authRoutes: RouteDefinition<Context>[] = [
   route('/login', [
     LoginPage
   ]),
-  route('/logout', function ({ request }) {
+  route('/logout', async function ({ request }) {
     const headers = new Headers();
-    sessions.remove(request, headers);
+    await sessions.remove(request, headers);
     headers.set('Location', '/');
 
     return new Response(null, {

--- a/starters/sessions/src/app/pages/auth/routes.ts
+++ b/starters/sessions/src/app/pages/auth/routes.ts
@@ -7,8 +7,9 @@ export const authRoutes: RouteDefinition<Context>[] = [
   route('/login', [
     LoginPage
   ]),
-  route('/logout', function ({ request, headers }) {
-    sessions.remove(request, headers);
+  route('/logout', async function ({ request }) {
+    const headers = new Headers();
+    await sessions.remove(request, headers);
     headers.set('Location', '/');
 
     return new Response(null, {


### PR DESCRIPTION
## Context
There were two issues:
1. there was an issue in the session cookie creation logic which was causing it to not set `maxAge` to `0` when removing the cookie
2. the auth starters were not `await`-ing `session.remove()`