### PR TITLE
fix: Avoid unnecessary passing of Context type param for routes

### DIFF
--- a/sdk/src/runtime/lib/router.ts
+++ b/sdk/src/runtime/lib/router.ts
@@ -199,7 +199,7 @@ export function defineRoutes<TContext = Record<string, any>>(
   };
 }
 
-export function route<TContext>(
+export function route<TContext = any>(
   path: string,
   handler: RouteHandler<TContext>,
 ): RouteDefinition<TContext> {
@@ -213,13 +213,13 @@ export function route<TContext>(
   };
 }
 
-export function index<TContext>(
+export function index<TContext = any>(
   handler: RouteHandler<TContext>,
 ): RouteDefinition<TContext> {
   return route("/", handler);
 }
 
-export function prefix<TContext>(
+export function prefix<TContext = any>(
   prefix: string,
   routes: ReturnType<typeof route<TContext>>[],
 ): RouteDefinition<TContext>[] {
@@ -231,7 +231,7 @@ export function prefix<TContext>(
   });
 }
 
-export function layout<TContext>(
+export function layout<TContext = any>(
   Layout: React.FC<{ children: React.ReactNode }>,
   routes: Route<TContext>[],
 ): Route<TContext>[] {

--- a/starters/passkey-auth/src/app/pages/auth/routes.ts
+++ b/starters/passkey-auth/src/app/pages/auth/routes.ts
@@ -1,9 +1,8 @@
-import { route, RouteDefinition } from '@redwoodjs/sdk/router';
+import { route } from '@redwoodjs/sdk/router';
 import { LoginPage } from "./LoginPage";
 import { sessions } from '@/session/store';
-import { Context } from '@/worker';
 
-export const authRoutes: RouteDefinition<Context>[] = [
+export const authRoutes = [
   route('/login', [
     LoginPage
   ]),

--- a/starters/passkey-auth/src/worker.tsx
+++ b/starters/passkey-auth/src/worker.tsx
@@ -28,8 +28,7 @@ export default defineApp<Context>([
       });
     }
   },
-  // todo: Figure out why I'm needing to provide route type param each time
-  layout<Context>(Document, [
+  layout(Document, [
     index([
         ({ ctx }) => {
           if (!ctx.user) {
@@ -41,6 +40,6 @@ export default defineApp<Context>([
         },
         Home,
     ]),
-    prefix<Context>("/user", authRoutes),
+    prefix("/user", authRoutes),
   ])
 ])

--- a/starters/sessions/src/app/pages/auth/routes.ts
+++ b/starters/sessions/src/app/pages/auth/routes.ts
@@ -1,9 +1,8 @@
-import { route, RouteDefinition } from '@redwoodjs/sdk/router';
+import { route } from '@redwoodjs/sdk/router';
 import { LoginPage } from "./LoginPage";
 import { sessions } from '@/session/store';
-import { Context } from '@/worker';
 
-export const authRoutes: RouteDefinition<Context>[] = [
+export const authRoutes = [
   route('/login', [
     LoginPage
   ]),

--- a/starters/sessions/src/worker.tsx
+++ b/starters/sessions/src/worker.tsx
@@ -17,11 +17,10 @@ export default defineApp<Context>([
     setupSessionStore(env);
     ctx.session = await sessions.load(request);
   },
-  // todo: Figure out why I'm needing to provide route type param each time
-  layout<Context>(Document, [
+  layout(Document, [
     index([
         Home,
     ]),
-    prefix<Context>("/user", authRoutes),
+    prefix("/user", authRoutes),
   ])
 ])


### PR DESCRIPTION
## Changes
### 1. Removed unnecessary passing of `Context` param
The session and passkey-auth starters had a bunch of unnecessary passing of `Context` param to route API methods, for example:

```ts
export default defineApp<Context>([
  async ({ env, ctx, request }) => {
    setupSessionStore(env);
    ctx.session = await sessions.load(request);
  },
  // >>> Context here not needing to be passed
  layout<Context>(Document, [
    index([
        Home,
    ]),
    // >>> also here
    prefix<Context>("/user", authRoutes),
  ])
])
```

At some point we needed these, but we don't seem to need it anymore (without losing type information). TBH I'm not sure what changed, but glad we don't need to do this anymore regardless.

### 2. Remove unnecessary explicit type annotations for routes
#### Problem
We were needing add explicit type annotations for arrays of routes, in order for ts to accept them being provided as part of `defineApp`, e.g.

```ts
const authRoutes: RouteDefinition<Context> = [...]
```

This is because the default for the `Context` type param is `undefined` when it cannot not be inferred (which happens for the array-of-routes case here).

#### Solution
To solve this, we default `Context` type param to `any` in the routing API's methods. This way:
* when it can be inferred, the inferred type is used
* if it cannot be inferred, we also might not need to care (e.g. if routes are referencing `ctx`), so rather default to `any` to avoid needing to add explicit type annotations
* if it cannot be inferred, in the cases where do need to care, we still can pass the type explicitly