### PR TITLE
fix: Fix useClient transform for non-inlined exports

### DIFF
--- a/sdk/src/vite/useClientPlugin.mts
+++ b/sdk/src/vite/useClientPlugin.mts
@@ -32,7 +32,10 @@ import { registerClientReference } from "@redwoodjs/sdk/worker";
 
         for (const e of exports) {
           if (e.ln != null) {
-            s.update(e.s, e.e, `${e.ln}SSR`);
+            s.replaceAll(
+              new RegExp(`((?:const|function|let|var)\\s+)(${e.ln})\\b`, 'g'),
+              `$1${e.ln}SSR`
+            );
 
             s.append(`\
 export const ${e.ln} = registerClientReference(${JSON.stringify(relativeId)}, ${JSON.stringify(e.ln)}, ${e.ln}SSR);


### PR DESCRIPTION
## Problem
Part of our 'use client' transformations for worker-side code involves renaming components to include an `SSR` suffix. After #126, we do this transformation by locating the line+column where the `export` is. This is fine for inlined exports (`export function Foo() {...}`) but breaks for grouped exports (`function Foo() {}; export { Foo }`).

## Solution
Find where the function is defined and replace it there.
