### PR TITLE
fix: Get react working for published sdk

### DIFF
--- a/sdk/src/vite/customReactBuildPlugin.mts
+++ b/sdk/src/vite/customReactBuildPlugin.mts
@@ -1,50 +1,54 @@
-import { resolve } from "path";
-import { Plugin } from "vite";
 
+import { resolve } from "path";
+import { mkdirp, copy } from "fs-extra";
+import { Plugin } from "vite";
 import { VENDOR_DIST_DIR } from "../lib/constants.mjs";
 
-export const customReactBuildPlugin = (): Plugin => {
-  return {
-    name: "custom-react-build-plugin",
-    enforce: "pre",
-
-    applyToEnvironment: (environment) => {
-      return environment.name === "worker";
-    },
-
-    resolveId(id) {
-      if (id === "react") {
-        return resolve(VENDOR_DIST_DIR, "react.js");
-      }
-
-      if (id === "react-dom/server.edge" || id === "react-dom/server") {
-        return resolve(VENDOR_DIST_DIR, "react-dom-server-edge.js");
-      }
-    },
-
-    config: () => ({
-      environments: {
-        worker: {
-          optimizeDeps: {
-            esbuildOptions: {
-              plugins: [
-                {
-                  name: "rewrite-react-imports",
-                  setup(build) {
-                    build.onResolve({ filter: /^react$/ }, (args) => {
-                      return { path: resolve(VENDOR_DIST_DIR, "react.js") };
-                    });
-
-                    build.onResolve({ filter: /^react-dom\/server\.edge$/ }, (args) => {
-                      return { path: resolve(VENDOR_DIST_DIR, "react-dom-server-edge.js") };
-                    });
-                  },
-                },
-              ],
+export const customReactBuildPlugin = ({ projectRootDir }: { projectRootDir: string }): Plugin => {
+    const viteDistDir = resolve(projectRootDir, "node_modules", ".vite_redwoodsdk");
+    return {
+        name: "custom-react-build-plugin",
+        enforce: "pre",
+        applyToEnvironment: (environment) => {
+            return environment.name === "worker";
+        },
+        async configureServer() {
+            await mkdirp(viteDistDir);
+            await copy(resolve(VENDOR_DIST_DIR, "react.js"), resolve(viteDistDir, 'react.js'));
+            await copy(resolve(VENDOR_DIST_DIR, "react.js.map"), resolve(viteDistDir, 'react.js.map'));
+            await copy(resolve(VENDOR_DIST_DIR, "react-dom-server-edge.js"), resolve(viteDistDir, "react-dom-server-edge.js"));
+            await copy(resolve(VENDOR_DIST_DIR, "react-dom-server-edge.js.map"), resolve(viteDistDir, "react-dom-server-edge.js.map"));
+        },
+        resolveId(id) {
+            if (id === "react") {
+                return resolve(viteDistDir, "react.js");
             }
-          }
-        }
-      },
-    }),
-  };
+            if (id === "react-dom/server.edge" || id === "react-dom/server") {
+                return resolve(viteDistDir, "react-dom-server-edge.js");
+            }
+        },
+        config: () => ({
+            environments: {
+                worker: {
+                    optimizeDeps: {
+                        esbuildOptions: {
+                            plugins: [
+                                {
+                                    name: "rewrite-react-imports",
+                                    setup(build) {
+                                        build.onResolve({ filter: /^react$/ }, (args) => {
+                                            return { path: resolve(viteDistDir, "react.js") };
+                                        });
+                                        build.onResolve({ filter: /^react-dom\/server\.edge$/ }, (args) => {
+                                            return { path: resolve(viteDistDir, "react-dom-server-edge.js") };
+                                        });
+                                    },
+                                },
+                            ],
+                        }
+                    }
+                }
+            },
+        }),
+    };
 };


### PR DESCRIPTION
## Context
We use a custom react build (which we build ourselves as part of the sdk's build steps), in order to have RSC and SSR react be possible in the same runtime (since we need them both to be able to run in the same cloudflare worker instance).

In order to make this possible, we have some vite plugin logic for making sure all react imports point to this custom build. This needs to be done both for vite's own resolution (when react imports happen in the application), as well as esbuild's in the case of vite's optimizeDeps step (vite uses esbuild to optimize deps, which includes de-cjs-ifying them).

Finally, we have `@cloudflare/vite-plugin`, which takes each imports to each module (including the custom react build), and evaluates the corresponding loaded code inside of miniflare. `@cloudflare/vite-plugin` has a logic branch which checks for modules that are in `node_modules` but not in `node_modules/.vite` ([code](https://github.com/cloudflare/workers-sdk/blob/d1d5b5313a60713c84f212edd7f1c7fe32e3e593/packages/vite-plugin-cloudflare/src/runner-worker/module-runner.ts#L55)). It does this to make sure deps have gone through optimizeDeps before ending up being something that will be evaluated in miniflare.

## Problem
The problem comes in when `@cloudflare/vite-plugin` sees imports to the custom react build. Since it only allows files in `node_modules` to be imported if they are in `node_modules/.vite` (i.e. they are optimized deps), it does not allow the custom react build through, since it is in a different path (e.g. `node_modules/redwoodsdk/vendor/dist/react.js`). 

This wasn't an issue before, since we used redwoodsdk in the same monorepo workspace, and so after the resolved symlink for redwoodsdk, the path to the react build would not be in `node_modules`, and it would not reach the branch where `@cloudflare/vite-plugin` disallows the import to happen ([code](https://github.com/cloudflare/workers-sdk/blob/d1d5b5313a60713c84f212edd7f1c7fe32e3e593/packages/vite-plugin-cloudflare/src/runner-worker/module-runner.ts#L55)).

## Solution
Since the relevant `@cloudflare/vite-plugin` logic looks like this:
```ts
!module.file.includes("/node_modules/.vite")
```

We copy across the custom react build to `/node_modules/.vite_redwoodsdk/react.js`, and have esbuild resolve react imports to this path.

This is a hack of course, and relies on internal logic CF's plugin that might change. That's not great. I couldn't find other ways that worked unfortunately: I tried various ways to get esbuild to resolve react imports to a place that could also be optimized, such that the actual custom react build would be optimized and end up in `/node_modules/.vite/`. This included using export specifiers to the react build (e.g. `redwoodsdk/react`) - problem there is esbuild wants a full, resolved path when hooking into the module resolution. I also tried many other configurations and ways to get around this, but ultimately none worked, and they were all more complicated than the solution in this PR.