### PR TITLE
fix: Ensure custom react build is copied in deployments too

### DIFF
--- a/sdk/src/vite/customReactBuildPlugin.mts
+++ b/sdk/src/vite/customReactBuildPlugin.mts
@@ -1,4 +1,3 @@
-
 import { resolve } from "path";
 import { mkdirp, copy } from "fs-extra";
 import { Plugin } from "vite";
@@ -6,14 +5,34 @@ import { VENDOR_DIST_DIR } from "../lib/constants.mjs";
 
 const copyReactFiles = async (viteDistDir: string) => {
     await mkdirp(viteDistDir);
-    await copy(resolve(VENDOR_DIST_DIR, "react.js"), resolve(viteDistDir, 'react.js'));
-    await copy(resolve(VENDOR_DIST_DIR, "react.js.map"), resolve(viteDistDir, 'react.js.map'));
-    await copy(resolve(VENDOR_DIST_DIR, "react-dom-server-edge.js"), resolve(viteDistDir, "react-dom-server-edge.js"));
-    await copy(resolve(VENDOR_DIST_DIR, "react-dom-server-edge.js.map"), resolve(viteDistDir, "react-dom-server-edge.js.map"));
-}
+    await copy(
+        resolve(VENDOR_DIST_DIR, "react.js"),
+        resolve(viteDistDir, "react.js"),
+    );
+    await copy(
+        resolve(VENDOR_DIST_DIR, "react.js.map"),
+        resolve(viteDistDir, "react.js.map"),
+    );
+    await copy(
+        resolve(VENDOR_DIST_DIR, "react-dom-server-edge.js"),
+        resolve(viteDistDir, "react-dom-server-edge.js"),
+    );
+    await copy(
+        resolve(VENDOR_DIST_DIR, "react-dom-server-edge.js.map"),
+        resolve(viteDistDir, "react-dom-server-edge.js.map"),
+    );
+};
 
-export const customReactBuildPlugin = async ({ projectRootDir }: { projectRootDir: string }): Promise<Plugin> => {
-    const viteDistDir = resolve(projectRootDir, "node_modules", ".vite_redwoodsdk");
+export const customReactBuildPlugin = async ({
+    projectRootDir,
+}: {
+    projectRootDir: string;
+}): Promise<Plugin> => {
+    const viteDistDir = resolve(
+        projectRootDir,
+        "node_modules",
+        ".vite_redwoodsdk",
+    );
     await copyReactFiles(viteDistDir);
     return {
         name: "custom-react-build-plugin",
@@ -23,10 +42,22 @@ export const customReactBuildPlugin = async ({ projectRootDir }: { projectRootDi
         },
         async configureServer() {
             await mkdirp(viteDistDir);
-            await copy(resolve(VENDOR_DIST_DIR, "react.js"), resolve(viteDistDir, 'react.js'));
-            await copy(resolve(VENDOR_DIST_DIR, "react.js.map"), resolve(viteDistDir, 'react.js.map'));
-            await copy(resolve(VENDOR_DIST_DIR, "react-dom-server-edge.js"), resolve(viteDistDir, "react-dom-server-edge.js"));
-            await copy(resolve(VENDOR_DIST_DIR, "react-dom-server-edge.js.map"), resolve(viteDistDir, "react-dom-server-edge.js.map"));
+            await copy(
+                resolve(VENDOR_DIST_DIR, "react.js"),
+                resolve(viteDistDir, "react.js"),
+            );
+            await copy(
+                resolve(VENDOR_DIST_DIR, "react.js.map"),
+                resolve(viteDistDir, "react.js.map"),
+            );
+            await copy(
+                resolve(VENDOR_DIST_DIR, "react-dom-server-edge.js"),
+                resolve(viteDistDir, "react-dom-server-edge.js"),
+            );
+            await copy(
+                resolve(VENDOR_DIST_DIR, "react-dom-server-edge.js.map"),
+                resolve(viteDistDir, "react-dom-server-edge.js.map"),
+            );
         },
         resolveId(id) {
             if (id === "react") {
@@ -48,15 +79,23 @@ export const customReactBuildPlugin = async ({ projectRootDir }: { projectRootDi
                                         build.onResolve({ filter: /^react$/ }, (args) => {
                                             return { path: resolve(viteDistDir, "react.js") };
                                         });
-                                        build.onResolve({ filter: /^react-dom\/server\.edge$/ }, (args) => {
-                                            return { path: resolve(viteDistDir, "react-dom-server-edge.js") };
-                                        });
+                                        build.onResolve(
+                                            { filter: /^react-dom\/server\.edge$/ },
+                                            (args) => {
+                                                return {
+                                                    path: resolve(
+                                                        viteDistDir,
+                                                        "react-dom-server-edge.js",
+                                                    ),
+                                                };
+                                            },
+                                        );
                                     },
                                 },
                             ],
-                        }
-                    }
-                }
+                        },
+                    },
+                },
             },
         }),
     };

--- a/sdk/src/vite/customReactBuildPlugin.mts
+++ b/sdk/src/vite/customReactBuildPlugin.mts
@@ -4,8 +4,17 @@ import { mkdirp, copy } from "fs-extra";
 import { Plugin } from "vite";
 import { VENDOR_DIST_DIR } from "../lib/constants.mjs";
 
-export const customReactBuildPlugin = ({ projectRootDir }: { projectRootDir: string }): Plugin => {
+const copyReactFiles = async (viteDistDir: string) => {
+    await mkdirp(viteDistDir);
+    await copy(resolve(VENDOR_DIST_DIR, "react.js"), resolve(viteDistDir, 'react.js'));
+    await copy(resolve(VENDOR_DIST_DIR, "react.js.map"), resolve(viteDistDir, 'react.js.map'));
+    await copy(resolve(VENDOR_DIST_DIR, "react-dom-server-edge.js"), resolve(viteDistDir, "react-dom-server-edge.js"));
+    await copy(resolve(VENDOR_DIST_DIR, "react-dom-server-edge.js.map"), resolve(viteDistDir, "react-dom-server-edge.js.map"));
+}
+
+export const customReactBuildPlugin = async ({ projectRootDir }: { projectRootDir: string }): Promise<Plugin> => {
     const viteDistDir = resolve(projectRootDir, "node_modules", ".vite_redwoodsdk");
+    await copyReactFiles(viteDistDir);
     return {
         name: "custom-react-build-plugin",
         enforce: "pre",


### PR DESCRIPTION
#144 fixed usage of react builds for the new redwoodsdk package for the `vite dev` case. We needed to have the same fix apply also for `vite build` for deployments.