### PR TITLE
fix: Cookies should not be Secure in dev

### DIFF
--- a/sdk/src/runtime/lib/auth/session.ts
+++ b/sdk/src/runtime/lib/auth/session.ts
@@ -42,8 +42,16 @@ export const createSessionCookie = ({
 }: {
   sessionId: string;
   maxAge?: number | true;
-}) =>
-  `session_id=${sessionId}; Path=/; HttpOnly; Secure; SameSite=Lax${maxAge != null ? `; Max-Age=${maxAge === true ? MAX_SESSION_DURATION / 1000 : maxAge}` : ""}`;
+}) => {
+  const isViteDev =
+    typeof import.meta.env !== "undefined" && import.meta.env.DEV;
+
+  return `session_id=${sessionId}; Path=/; HttpOnly; ${isViteDev ? "" : "Secure; "}SameSite=Lax${
+    maxAge != null
+      ? `; Max-Age=${maxAge === true ? MAX_SESSION_DURATION / 1000 : maxAge}`
+      : ""
+  }`;
+};
 
 export const signSessionId = async ({
   unsignedSessionId,


### PR DESCRIPTION
Fixes #140 

## Changes
* In dev, we exclude `Secure` from cookie attributes
* We now allow for custom cookie definition for sessions

```ts
const sessionStore = defineDurableSession({
  // ...
  cookieName: "user_session",
  createCookie: ({ name, sessionId, maxAge }) => `${name}=${sessionId}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=${maxAge ?? (7 * 24 * 60 * 60)}`
});
```