### PR TITLE
fix: Resolve to build script paths

### DIFF
--- a/sdk/bin/rw-scripts.mjs
+++ b/sdk/bin/rw-scripts.mjs
@@ -2,10 +2,7 @@
 
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { $ as $base } from 'execa';
-
-// todo(justinvdm, 2025-02-09): Set this only when in this monorepo
-process.env.RW_DEV = "1";
+import { $ as $base } from "execa";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -21,9 +18,7 @@ const $ = $base({
   reject: false,
   env: {
     PATH: `${process.env.PATH}:${BIN_DIR}`,
-  }
-})
+  },
+});
 
-const [runner, containingDir, extension] = process.env.RW_DEV ? ['tsx', 'src', 'mts'] : ['node', 'dist', 'mjs']
-
-$`${runner} ${path.resolve(ROOT_DIR, containingDir, 'scripts', SCRIPT_NAME)}.${extension} ${ARGS.slice(1).join(" ")}`;
+$`node ${path.resolve(ROOT_DIR, "dist", "scripts", SCRIPT_NAME)}.mjs ${ARGS.slice(1).join(" ")}`;

--- a/sdk/src/scripts/migrate-new.mts
+++ b/sdk/src/scripts/migrate-new.mts
@@ -1,4 +1,4 @@
-import snakeCase from "lodash/snakeCase";
+import snakeCase from "lodash/snakeCase.js";
 import { $ } from "../lib/$.mjs";
 import { readdir } from "fs/promises";
 import { resolve } from "path";


### PR DESCRIPTION
We have a script runner (`rw-scripts.mjs`) for running scripts we define in the sdk (e.g. `migrate:new`). This runner was hardcoded to use the sdk's `src` scripts, with the idea being we'd remove that hardcoding once we release the sdk. I just forgot to actually do that 🤦