### PR TITLE
fix: Avoid while loop for `pnpm dev`

### DIFF
--- a/experiments/billable/package.json
+++ b/experiments/billable/package.json
@@ -12,7 +12,7 @@
     "build": "vite build",
     "migrate:dev": "wrangler d1 migrations apply DB --local",
     "migrate:prd": "wrangler d1 migrations apply DB --remote",
-    "dev": "while true; do NODE_ENV=development vite dev; [ $? -eq 0 ] || break; done",
+    "dev": "NODE_ENV=${NODE_ENV:-development} vite dev",
     "dev:init": "rw-scripts dev-init",
     "seed": "pnpm worker:run ./src/scripts/seed.ts",
     "migrate:new": "rw-scripts migrate-new",

--- a/experiments/cutable/package.json
+++ b/experiments/cutable/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "migrate:dev": "wrangler d1 migrations apply DB --local",
     "migrate:prd": "wrangler d1 migrations apply DB --remote",
-    "dev": "while true; do NODE_ENV=development vite dev; [ $? -eq 0 ] || break; done",
+    "dev": "NODE_ENV=${NODE_ENV:-development} vite dev",
     "dev:init": "rw-scripts dev-init",
     "seed": "pnpm worker:run ./src/scripts/seed.ts",
     "migrate:new": "rw-scripts migrate-new",

--- a/experiments/yt-dos/package.json
+++ b/experiments/yt-dos/package.json
@@ -10,7 +10,7 @@
   "private": true,
   "scripts": {
     "build": "vite build",
-    "dev": "while true; do NODE_ENV=development vite dev; [ $? -eq 0 ] || break; done",
+    "dev": "NODE_ENV=${NODE_ENV:-development} vite dev",
     "dev:init": "rw-scripts dev-init",
     "worker:run": "rw-scripts worker-run",
     "clean": "pnpm build && pnpm clean:vendor",

--- a/experiments/zoomshare/package.json
+++ b/experiments/zoomshare/package.json
@@ -10,7 +10,7 @@
   "private": true,
   "scripts": {
     "build": "vite build",
-    "dev": "while true; do NODE_ENV=development vite dev; [ $? -eq 0 ] || break; done",
+    "dev": "NODE_ENV=${NODE_ENV:-development} vite dev",
     "dev:init": "rw-scripts dev-init",
     "worker:run": "rw-scripts worker-run",
     "clean": "pnpm build && pnpm clean:vendor",

--- a/starters/drizzle/package.json
+++ b/starters/drizzle/package.json
@@ -10,7 +10,7 @@
   "private": true,
   "scripts": {
     "build": "vite build",
-    "dev": "while true; do NODE_ENV=development vite dev; [ $? -eq 0 ] || break; done",
+    "dev": "NODE_ENV=${NODE_ENV:-development} vite dev",
     "dev:init": "rw-scripts dev-init",
     "worker:run": "rw-scripts worker-run",
     "clean": "pnpm build && pnpm clean:vendor",

--- a/starters/minimal/package.json
+++ b/starters/minimal/package.json
@@ -10,7 +10,7 @@
   "private": true,
   "scripts": {
     "build": "vite build",
-    "dev": "while true; do NODE_ENV=development vite dev; [ $? -eq 0 ] || break; done",
+    "dev": "NODE_ENV=${NODE_ENV:-development} vite dev",
     "dev:init": "rw-scripts dev-init",
     "worker:run": "rw-scripts worker-run",
     "clean": "pnpm build && pnpm clean:vendor",

--- a/starters/passkey-auth/package.json
+++ b/starters/passkey-auth/package.json
@@ -10,7 +10,7 @@
   "private": true,
   "scripts": {
     "build": "vite build",
-    "dev": "while true; do NODE_ENV=development vite dev; [ $? -eq 0 ] || break; done",
+    "dev": "NODE_ENV=${NODE_ENV:-development} vite dev",
     "dev:init": "rw-scripts dev-init",
     "worker:run": "rw-scripts worker-run",
     "clean": "pnpm build && pnpm clean:vendor",

--- a/starters/prisma/package.json
+++ b/starters/prisma/package.json
@@ -10,7 +10,7 @@
   "private": true,
   "scripts": {
     "build": "vite build",
-    "dev": "while true; do NODE_ENV=development vite dev; [ $? -eq 0 ] || break; done",
+    "dev": "NODE_ENV=${NODE_ENV:-development} vite dev",
     "dev:init": "rw-scripts dev-init",
     "worker:run": "rw-scripts worker-run",
     "clean": "pnpm build && pnpm clean:vendor",

--- a/starters/sessions/package.json
+++ b/starters/sessions/package.json
@@ -10,7 +10,7 @@
   "private": true,
   "scripts": {
     "build": "vite build",
-    "dev": "while true; do NODE_ENV=development vite dev; [ $? -eq 0 ] || break; done",
+    "dev": "NODE_ENV=${NODE_ENV:-development} vite dev",
     "dev:init": "rw-scripts dev-init",
     "worker:run": "rw-scripts worker-run",
     "clean": "pnpm build && pnpm clean:vendor",


### PR DESCRIPTION
## Context
Early implementations of the sdk relied on us having `vite dev` in a ` while true` bash loop, as a way to ensure changes to configuration restarted the dev server.

We don't need this anymore, but the starters still have this remnant around. This PR removes it so that `pnpm dev` is basically `pnpm vite dev`