### PR TITLE
fix: Invalidate prisma client optimizeDeps cache entry when running vite dev

### DIFF
--- a/sdk/src/vite/invalidateViteDepsCacheEntry.mts
+++ b/sdk/src/vite/invalidateViteDepsCacheEntry.mts
@@ -1,0 +1,24 @@
+import { resolve } from "node:path";
+import snakeCase from "lodash/snakeCase.js";
+import { remove } from "fs-extra";
+
+export const invalidateViteDepsCacheEntry = async ({
+  projectRootDir,
+  environment,
+  entry,
+}: {
+  projectRootDir: string;
+  environment: "client" | "worker";
+  entry: string;
+}) => {
+  const suffix = environment === "worker" ? "_worker" : "";
+  const viteDepsCachePath = resolve(
+    projectRootDir,
+    "node_modules",
+    ".vite",
+    `deps${suffix}`,
+    `${snakeCase(entry)}.js`,
+  );
+  await remove(viteDepsCachePath);
+  await remove(`${viteDepsCachePath}.map`);
+};


### PR DESCRIPTION
## Context
We need to use vite optimizeDeps for all dependencies to work with @cloudflare/vite-plugin. The thing is, @prisma/client has generated code, so users end up with a stale @prisma/client when they change their Prisma schema and regenerate the client until they clear out node_modules/.vite. We can’t exclude @prisma/client from optimizeDeps since we need it there for @cloudflare/vite-plugin to work, but we can manually invalidate just its own dependencies cache entry.