### PR TITLE
fix: Avoid placeholder keys in wrangler.jsonc

### DIFF
--- a/starters/passkey-auth/README.md
+++ b/starters/passkey-auth/README.md
@@ -36,6 +36,29 @@ Copy the database ID provided and paste it into your project's `wrangler.jsonc` 
 }
 ```
 
+### Setting up Session Secret Key
+
+For production, generate a strong SECRET_KEY for signing session IDs. You can generate a secure random key using OpenSSL:
+
+```shell
+# Generate a 32-byte random key and encode it as base64
+openssl rand -base64 32
+```
+
+Then set this key as a Cloudflare secret:
+
+```shell
+wrangler secret put SECRET_KEY
+```
+
+For **local development**, set this secret key in a `.env` file in your project root:
+
+```env
+SECRET_KEY=your-development-secret-key
+```
+
+Never use the same secret key for development and production environments, and avoid committing your secret keys to version control.
+
 ### Setting up Cloudflare Turnstile (Bot Protection)
 
 1. Visit [Cloudflare Turnstile Dashboard](https://dash.cloudflare.com/?to=/:account/turnstile).

--- a/starters/passkey-auth/wrangler.jsonc
+++ b/starters/passkey-auth/wrangler.jsonc
@@ -34,9 +34,6 @@
 
   // Environment variables
   "vars": {
-    "SECRET_KEY": "_",
-    // >>> Replace this with your own Cloudflare Turnstile secret key
-    "TURNSTILE_SECRET_KEY": "1x0000000000000000000000000000000AA",
     "APP_NAME": "__change_me__",
     "RP_ID": "localhost",
   },

--- a/starters/sessions/README.md
+++ b/starters/sessions/README.md
@@ -40,13 +40,35 @@ Within your project's `wrangler.jsonc` file, replace the placeholder values. For
     }
   ],
   "vars": {
-    "SECRET_KEY": "SECRET_KEY_FOR_LOCAL_DEVELOPMENT",
     "APP_URL": "https://my-project-name.example.com"
   }
 }
 ```
 
-For deployments, make use of [cloudflare secrets](https://developers.cloudflare.com/workers/configuration/secrets/) for the `SECRET_KEY`.
+### Setting up Session Secret Key
+
+For production, generate a strong SECRET_KEY for signing session IDs. You can generate a secure random key using OpenSSL:
+
+```shell
+# Generate a 32-byte random key and encode it as base64
+openssl rand -base64 32
+```
+
+Then set this key as a Cloudflare secret:
+
+```shell
+wrangler secret put SECRET_KEY
+```
+
+For **local development**, set this secret key in a `.env` file in your project root:
+
+```env
+SECRET_KEY=your-development-secret-key
+```
+
+Never use the same secret key for development and production environments, and avoid committing your secret keys to version control.
+
+### Start it up
 
 Start your development server:
 

--- a/starters/sessions/wrangler.jsonc
+++ b/starters/sessions/wrangler.jsonc
@@ -33,9 +33,7 @@
   },
 
   // Environment variables
-  "vars": {
-    "SECRET_KEY": "_",
-  },
+  "vars": {},
 
   // Migrations configuration
   "migrations": [

--- a/starters/standard/README.md
+++ b/starters/standard/README.md
@@ -1,6 +1,6 @@
-# Standard RedwoodSDK Starter
+# Standard RedwoodJS Starter
 
-This starter provides a comprehensive RedwoodSDK-based implementation that includes passkey authentication using WebAuthn, session management, database integration with Prisma, and file storage with Cloudflare R2. It serves as a fully integrated starting point for Redwood apps, consolidating various essential features into one package.
+This starter provides a comprehensive RedwoodJS-based implementation that includes passkey authentication using WebAuthn, session management, database integration with Prisma, and file storage with Cloudflare R2. It serves as a fully integrated starting point for Redwood apps, consolidating various essential features into one package.
 
 Create your new project:
 
@@ -36,6 +36,29 @@ Copy the database ID provided and paste it into your project's `wrangler.jsonc` 
 }
 ```
 
+### Setting up Session Secret Key
+
+For production, generate a strong SECRET_KEY for signing session IDs. You can generate a secure random key using OpenSSL:
+
+```shell
+# Generate a 32-byte random key and encode it as base64
+openssl rand -base64 32
+```
+
+Then set this key as a Cloudflare secret:
+
+```shell
+wrangler secret put SECRET_KEY
+```
+
+For **local development**, set this secret key in a `.env` file in your project root:
+
+```env
+SECRET_KEY=your-development-secret-key
+```
+
+Never use the same secret key for development and production environments, and avoid committing your secret keys to version control.
+
 ### Setting up Cloudflare Turnstile (Bot Protection)
 
 1. Visit [Cloudflare Turnstile Dashboard](https://dash.cloudflare.com/?to=/:account/turnstile).
@@ -65,6 +88,14 @@ TURNSTILE_SECRET_KEY=1x0000000000000000000000000000000AA
 ```
 
 (Your development environment automatically uses a test site key provided by the framework.)
+
+### Start it up
+
+Start your development server:
+
+```shell
+pnpm dev
+```
 
 ## Important Security Considerations
 

--- a/starters/standard/wrangler.jsonc
+++ b/starters/standard/wrangler.jsonc
@@ -34,9 +34,6 @@
 
   // Environment variables
   "vars": {
-    "SECRET_KEY": "_",
-    // >>> Replace this with your own Cloudflare Turnstile secret key
-    "TURNSTILE_SECRET_KEY": "1x0000000000000000000000000000000AA",
     "APP_NAME": "__change_me__",
     "RP_ID": "localhost",
   },


### PR DESCRIPTION
Removes secret keys from starters' `wrangler.jsonc` configs, and documents in READMEs how to add these instead in dev and deployments.