### PR TITLE
fix: Support grouped exports with "use client"

### DIFF
--- a/sdk/src/vite/useClientPlugin.mts
+++ b/sdk/src/vite/useClientPlugin.mts
@@ -30,18 +30,90 @@ import { registerClientReference } from "redwoodsdk/worker";
 `);
 
         const [_, exports] = parse(code);
+        const functionExports = new Set();
+        const inlineExportedFunctions = new Set();
 
+        // First, collect all function exports
         for (const e of exports) {
           if (e.ln != null) {
-            s.replaceAll(
-              new RegExp(`((?:const|function|let|var)\\s+)(${e.ln})\\b`, "g"),
-              `$1${e.ln}SSR`,
-            );
+            // Check if it's a function declaration
+            const isFunctionDeclaration = new RegExp(
+              `(export\\s+)?(function\\s+${e.ln}\\b|const\\s+${e.ln}\\s*=\\s*\\(.*\\)\\s*=>|const\\s+${e.ln}\\s*=\\s*function\\s*\\()`,
+            ).test(code);
 
-            s.append(`\
-export const ${e.ln} = registerClientReference(${JSON.stringify(relativeId)}, ${JSON.stringify(e.ln)}, ${e.ln}SSR);
-`);
+            if (isFunctionDeclaration) {
+              functionExports.add(e.ln);
+
+              // Check if it's an inline export
+              const isInlineExport = new RegExp(
+                `export\\s+(const|function)\\s+${e.ln}\\b`,
+              ).test(code);
+              if (isInlineExport) {
+                inlineExportedFunctions.add(e.ln);
+              }
+            }
           }
+        }
+
+        // Now process the code to find and transform each function
+        for (const name of functionExports) {
+          // Find function declarations and transform them
+          const functionRegex = new RegExp(
+            `(export\\s+)?(function\\s+)(${name})\\b([\\s\\S]*?{[\\s\\S]*?})`,
+            "g",
+          );
+          let match;
+
+          while ((match = functionRegex.exec(code)) !== null) {
+            const fullMatch = match[0];
+            const hasExport = !!match[1];
+            const functionBody = match[4];
+            const startPos = match.index;
+            const endPos = startPos + fullMatch.length;
+
+            // Replace with SSR version
+            s.overwrite(
+              startPos,
+              endPos,
+              `${match[2]}${name}SSR${functionBody}\n\nconst ${name} = registerClientReference(${JSON.stringify(relativeId)}, ${JSON.stringify(name)}, ${name}SSR);`,
+            );
+          }
+
+          // Find arrow functions and transform them
+          const arrowRegex = new RegExp(
+            `(export\\s+)?(const\\s+)(${name})(\\s*=.*?=>.*?[;\\n])`,
+            "g",
+          );
+
+          while ((match = arrowRegex.exec(code)) !== null) {
+            const fullMatch = match[0];
+            const hasExport = !!match[1];
+            const arrowBody = match[4];
+            const startPos = match.index;
+            const endPos = startPos + fullMatch.length;
+
+            // Replace with SSR version
+            s.overwrite(
+              startPos,
+              endPos,
+              `${match[2]}${name}SSR${arrowBody}\n\nconst ${name} = registerClientReference(${JSON.stringify(relativeId)}, ${JSON.stringify(name)}, ${name}SSR);`,
+            );
+          }
+        }
+
+        // Add a grouped export at the end for SSR versions
+        const ssrExportNames = Array.from(functionExports).map(
+          (name) => `${name}SSR`,
+        );
+
+        if (ssrExportNames.length > 0) {
+          s.append(`\nexport { ${ssrExportNames.join(", ")} };\n`);
+        }
+
+        if (inlineExportedFunctions.size > 0) {
+          s.append(
+            `\nexport { ${Array.from(inlineExportedFunctions).join(", ")} };\n`,
+          );
         }
       }
 


### PR DESCRIPTION
## Problem

Previously, our `useClientPlugin` only supported inline exports (e.g., `export function Component()` or `export const Component = ...`). However, it didn't properly handle grouped exports (e.g., `export { Component, OtherComponent }`). This limitation meant that components using grouped exports weren't being properly transformed for client/server rendering.

## Solution

This PR enhances the `useClientPlugin` to support both inline and grouped exports:

1. We now identify all function exports and track which ones were inline exported
2. For each function, we:
   - Rename it with an SSR suffix
   - Add a client reference registration that uses the original name
3. We export all SSR versions at the end of the file
4. We only re-export functions that were originally inline exported (since grouped exports are preserved)

This approach ensures that:
- Functions in grouped exports continue to work through their original export statements
- Functions that were inline exported are properly re-exported
- All SSR versions are exported for server-side rendering
- Client references are correctly registered for all functions

The plugin now correctly handles both export styles, providing a more robust solution for the "use client" directive.