### PR TITLE
feat: Security docs + updates to starter headers + pass nonce to layouts

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -9,8 +9,7 @@ export default defineConfig({
       expressiveCode: {
         // themes: ["dracula"],
         shiki: {
-          
-          bundledLangs: ['bash', 'ts', 'tsx'],
+          bundledLangs: ["bash", "ts", "tsx"],
         },
       },
       title: "RedwoodSDK",
@@ -45,6 +44,7 @@ export default defineConfig({
             { label: "Storage", slug: "core/storage" },
             { label: "Queues", slug: "core/queues" },
             { label: "Authentication", slug: "core/authentication" },
+            { label: "Security", slug: "core/security" },
           ],
         },
         // {

--- a/docs/src/content/docs/core/security.mdx
+++ b/docs/src/content/docs/core/security.mdx
@@ -13,7 +13,7 @@ import {
 
 import importedCodeStandardHeaders from "../../../../../starters/standard/src/app/headers.ts?raw";
 
-## 🔐 Security Headers in the Standard Starter
+## 🔐 Security Headers
 
 The standard starter includes a set of security headers by default in [`app/headers.ts`](https://github.com/redwoodjs/sdk/blob/main/starters/standard/src/app/headers.ts). These help protect against common attacks like cross-site scripting (XSS), clickjacking, and data injection.
 
@@ -24,11 +24,57 @@ The standard starter includes a set of security headers by default in [`app/head
   collapse={"1-3, 29-59"}
 />
 
-### Changing CSP headers
+### Changing CSP (Content Security Policy) headers
 
-Sometimes you need to allow ...
+Sometimes you need to allow additional resources or modify the Content Security Policy (CSP) to accommodate third-party scripts, styles, or other assets. The CSP headers control what resources can be loaded and executed by your application.
+
+#### Adding trusted domains
+
+The default CSP in the starter focuses on the most critical security aspects. For many applications, this provides a good balance between security and functionality. When you need to integrate third-party resources, you can extend it like this:
+
+<Aside>
+  Your CSP should reflect your application's needs. Some apps require more
+  permissive policies to function properly, while security-critical applications
+  might need stricter controls. The key is understanding the tradeoffs and
+  making informed decisions. For more information, see the [MDN Content Security
+  Policy documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP).
+</Aside>
+
+```diff
+// In app/headers.ts
+headers.set(
+  "Content-Security-Policy",
+- `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; object-src 'none';`,
++ `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com https://trusted-scripts.example.com; frame-src https://challenges.cloudflare.com; img-src 'self' https://images.example.com; object-src 'none';`,
+);
+```
 
 #### Using `nonce` for inline scripts
+
+Sometimes you need to include inline scripts in your application, but Content Security Policy (CSP) blocks them by default for security reasons. The `nonce` attribute provides a secure way to allow specific inline scripts to run.
+
+You can get at it in layouts or page components rendered by the [router](./routing), using `rw.nonce`.
+
+```tsx
+export const Document = ({ rw, children }) => (
+  <html lang="en">
+    <head><!-- ... --></head>
+    <body>
+      <div id="root">{children}</div>
+
+      <!-- Set the nonce the inline script -->
+      <script nonce={row.nonce}>/* ... */</script>
+    </body>
+  </html>
+);
+
+export default defineApp<Context>([
+  // ...
+  layout(Document, [
+    // ...
+  ]),
+]);
+```
 
 ### Lifting device permission restrictions
 

--- a/docs/src/content/docs/core/security.mdx
+++ b/docs/src/content/docs/core/security.mdx
@@ -1,0 +1,52 @@
+---
+title: Security
+description: Learn about security headers used in the standard starter, what they do, and how to configure them for your app.
+---
+
+import {
+  Aside,
+  Tabs,
+  TabItem,
+  LinkCard,
+  Code,
+} from "@astrojs/starlight/components";
+
+import importedCodeStandardHeaders from "../../../../../starters/standard/src/app/headers.ts?raw";
+
+## 🔐 Security Headers in the Standard Starter
+
+The standard starter includes a set of security headers by default in [`app/headers.ts`](https://github.com/redwoodjs/sdk/blob/main/starters/standard/src/app/headers.ts). These help protect against common attacks like cross-site scripting (XSS), clickjacking, and data injection.
+
+<Code
+  language="typescript"
+  title="src/app/pages/auth/LoginPage.tsx"
+  code={importedCodeStandardHeaders}
+  collapse={"1-3, 29-59"}
+/>
+
+### Changing CSP headers
+
+Sometimes you need to allow ...
+
+#### Using `nonce` for inline scripts
+
+### Lifting device permission restrictions
+
+Sometimes you need to allow your web application to access device features like the camera, microphone, or geolocation. These permissions are controlled by the `Permissions-Policy` header.
+
+By default, the standard starter includes restrictive permissions settings for security reasons.
+
+To enable device access, you'll need to modify the `Permissions-Policy` header in your [`app/headers.ts`](https://github.com/redwoodjs/sdk/blob/main/starters/standard/src/) file:
+
+```diff
+// In app/headers.ts
+headers.set(
+  "Permissions-Policy",
+-  "geolocation=(), microphone=(), camera=()",
++  "geolocation=self, microphone=self, camera=self"
+);
+```
+
+The `self` keyword allows the feature to be used only by your own domain.
+
+For a complete reference, see the [MDN Permissions Policy documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy).

--- a/docs/src/content/docs/core/security.mdx
+++ b/docs/src/content/docs/core/security.mdx
@@ -21,7 +21,7 @@ The standard starter includes a set of security headers by default in [`app/head
   language="typescript"
   title="src/app/pages/auth/LoginPage.tsx"
   code={importedCodeStandardHeaders}
-  collapse={"1-3, 29-59"}
+  collapse={"1-3"}
 />
 
 ### Changing CSP (Content Security Policy) headers
@@ -44,16 +44,21 @@ The default CSP in the starter focuses on the most critical security aspects. Fo
 // In app/headers.ts
 headers.set(
   "Content-Security-Policy",
-- `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; object-src 'none';`,
-+ `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com https://trusted-scripts.example.com; frame-src https://challenges.cloudflare.com; img-src 'self' https://images.example.com; object-src 'none';`,
+- `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; frame-src https://challenges.cloudflare.com; object-src 'none';`,
++ `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com https://trusted-scripts.example.com; style-src 'self' 'unsafe-inline'; frame-src https://challenges.cloudflare.com; img-src 'self' https://images.example.com; object-src 'none';`,
 );
 ```
 
 #### Using `nonce` for inline scripts
 
-Sometimes you need to include inline scripts in your application, but Content Security Policy (CSP) blocks them by default for security reasons. The `nonce` attribute provides a secure way to allow specific inline scripts to run.
+Sometimes you need to include inline scripts in your application, but Content Security Policy (CSP) blocks them by default for security reasons. RedwoodJS automatically generates a fresh, cryptographically secure nonce value for each request You can access this nonce in layouts or page components rendered by the [router](./routing), using `rw.nonce`.
 
-You can get at it in layouts or page components rendered by the [router](./routing), using `rw.nonce`.
+<Aside type="caution">
+  Only use the nonce attribute for trusted inline scripts that you have full
+  control over. Adding nonces to third-party or user-generated scripts defeats
+  the purpose of CSP protection and could expose your application to cross-site
+  scripting (XSS) attacks.
+</Aside>
 
 ```tsx
 export const Document = ({ rw, children }) => (

--- a/sdk/src/runtime/lib/router.ts
+++ b/sdk/src/runtime/lib/router.ts
@@ -12,21 +12,30 @@ export type RouteContext<
   rw: RwContext<TContext>;
 };
 
-type PageProps<TContext> = Omit<
+export type PageProps<TContext> = Omit<
   RouteContext<TContext>,
-  "rw" | "request" | "headers"
->;
+  "request" | "headers" | "rw"
+> & { rw: { nonce: string } };
+
+export type LayoutProps<TContext> = PageProps<TContext> & {
+  children: React.ReactNode;
+};
+
+export type RenderPageParams<TContext> = {
+  Page: React.FC<Record<string, any>>;
+  props: PageProps<TContext>;
+  actionResult: unknown;
+  Layout: React.FC<LayoutProps<TContext>>;
+};
+
+export type RenderPage<TContext> = (
+  params: RenderPageParams<TContext>,
+) => Promise<Response>;
 
 export type RwContext<TContext> = {
   nonce: string;
-  Layout: React.FC<{ children: React.ReactNode }>;
-  renderPage: (params: {
-    nonce: string;
-    Page: React.FC<Record<string, any>>;
-    props: PageProps<TContext>;
-    actionResult: unknown;
-    Layout: React.FC<{ children: React.ReactNode }>;
-  }) => Promise<Response>;
+  Layout: React.FC<LayoutProps<TContext>>;
+  renderPage: RenderPage<TContext>;
   handleAction: (ctx: RouteContext<TContext>) => Promise<unknown>;
 };
 
@@ -195,9 +204,13 @@ export function defineRoutes<TContext = Record<string, any>>(
         if (isRouteComponent(h)) {
           const actionResult = await rw.handleAction(routeContext);
           const serializedEnv = serializeEnv(env);
-          const props = { params, env: serializedEnv, ctx };
+          const props = {
+            params,
+            env: serializedEnv,
+            ctx,
+            rw: { nonce: rw.nonce },
+          };
           return await rw.renderPage({
-            nonce: rw.nonce,
             Page: h as React.FC<Record<string, any>>,
             props,
             actionResult,

--- a/starters/drizzle/src/app/headers.ts
+++ b/starters/drizzle/src/app/headers.ts
@@ -25,14 +25,6 @@ export const setCommonHeaders =
     );
 
     // Defines trusted sources for content loading and script execution:
-    // - Only loads resources from same origin ('self') and Cloudflare Turnstile
-    // - Only runs scripts from same origin, trusted inline scripts with nonce, and Turnstile
-    // - Allows frames from Cloudflare Turnstile
-    // - Blocks all plugins/embedded objects
-    //
-    // Usage:
-    // - Add other origins to this list (space separated) if you want to allow them
-    // - Add 'nonce=${nonce}' to inline <script> tags you trust
     headers.set(
       "Content-Security-Policy",
       `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; frame-src https://challenges.cloudflare.com; object-src 'none';`,

--- a/starters/drizzle/src/app/headers.ts
+++ b/starters/drizzle/src/app/headers.ts
@@ -35,6 +35,6 @@ export const setCommonHeaders =
     // - Add 'nonce=${nonce}' to inline <script> tags you trust
     headers.set(
       "Content-Security-Policy",
-      `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; object-src 'none';`,
+      `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; frame-src https://challenges.cloudflare.com; object-src 'none';`,
     );
   };

--- a/starters/minimal/src/app/headers.ts
+++ b/starters/minimal/src/app/headers.ts
@@ -25,14 +25,6 @@ export const setCommonHeaders =
     );
 
     // Defines trusted sources for content loading and script execution:
-    // - Only loads resources from same origin ('self') and Cloudflare Turnstile
-    // - Only runs scripts from same origin, trusted inline scripts with nonce, and Turnstile
-    // - Allows frames from Cloudflare Turnstile
-    // - Blocks all plugins/embedded objects
-    //
-    // Usage:
-    // - Add other origins to this list (space separated) if you want to allow them
-    // - Add 'nonce=${nonce}' to inline <script> tags you trust
     headers.set(
       "Content-Security-Policy",
       `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; frame-src https://challenges.cloudflare.com; object-src 'none';`,

--- a/starters/minimal/src/app/headers.ts
+++ b/starters/minimal/src/app/headers.ts
@@ -35,6 +35,6 @@ export const setCommonHeaders =
     // - Add 'nonce=${nonce}' to inline <script> tags you trust
     headers.set(
       "Content-Security-Policy",
-      `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; object-src 'none';`,
+      `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; frame-src https://challenges.cloudflare.com; object-src 'none';`,
     );
   };

--- a/starters/passkey-auth/src/app/headers.ts
+++ b/starters/passkey-auth/src/app/headers.ts
@@ -25,14 +25,6 @@ export const setCommonHeaders =
     );
 
     // Defines trusted sources for content loading and script execution:
-    // - Only loads resources from same origin ('self') and Cloudflare Turnstile
-    // - Only runs scripts from same origin, trusted inline scripts with nonce, and Turnstile
-    // - Allows frames from Cloudflare Turnstile
-    // - Blocks all plugins/embedded objects
-    //
-    // Usage:
-    // - Add other origins to this list (space separated) if you want to allow them
-    // - Add 'nonce=${nonce}' to inline <script> tags you trust
     headers.set(
       "Content-Security-Policy",
       `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; frame-src https://challenges.cloudflare.com; object-src 'none';`,

--- a/starters/passkey-auth/src/app/headers.ts
+++ b/starters/passkey-auth/src/app/headers.ts
@@ -35,6 +35,6 @@ export const setCommonHeaders =
     // - Add 'nonce=${nonce}' to inline <script> tags you trust
     headers.set(
       "Content-Security-Policy",
-      `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; object-src 'none';`,
+      `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; frame-src https://challenges.cloudflare.com; object-src 'none';`,
     );
   };

--- a/starters/prisma/src/app/headers.ts
+++ b/starters/prisma/src/app/headers.ts
@@ -25,14 +25,6 @@ export const setCommonHeaders =
     );
 
     // Defines trusted sources for content loading and script execution:
-    // - Only loads resources from same origin ('self') and Cloudflare Turnstile
-    // - Only runs scripts from same origin, trusted inline scripts with nonce, and Turnstile
-    // - Allows frames from Cloudflare Turnstile
-    // - Blocks all plugins/embedded objects
-    //
-    // Usage:
-    // - Add other origins to this list (space separated) if you want to allow them
-    // - Add 'nonce=${nonce}' to inline <script> tags you trust
     headers.set(
       "Content-Security-Policy",
       `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; frame-src https://challenges.cloudflare.com; object-src 'none';`,

--- a/starters/prisma/src/app/headers.ts
+++ b/starters/prisma/src/app/headers.ts
@@ -35,6 +35,6 @@ export const setCommonHeaders =
     // - Add 'nonce=${nonce}' to inline <script> tags you trust
     headers.set(
       "Content-Security-Policy",
-      `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; object-src 'none';`,
+      `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; frame-src https://challenges.cloudflare.com; object-src 'none';`,
     );
   };

--- a/starters/sessions/src/app/headers.ts
+++ b/starters/sessions/src/app/headers.ts
@@ -25,14 +25,6 @@ export const setCommonHeaders =
     );
 
     // Defines trusted sources for content loading and script execution:
-    // - Only loads resources from same origin ('self') and Cloudflare Turnstile
-    // - Only runs scripts from same origin, trusted inline scripts with nonce, and Turnstile
-    // - Allows frames from Cloudflare Turnstile
-    // - Blocks all plugins/embedded objects
-    //
-    // Usage:
-    // - Add other origins to this list (space separated) if you want to allow them
-    // - Add 'nonce=${nonce}' to inline <script> tags you trust
     headers.set(
       "Content-Security-Policy",
       `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; frame-src https://challenges.cloudflare.com; object-src 'none';`,

--- a/starters/sessions/src/app/headers.ts
+++ b/starters/sessions/src/app/headers.ts
@@ -35,6 +35,6 @@ export const setCommonHeaders =
     // - Add 'nonce=${nonce}' to inline <script> tags you trust
     headers.set(
       "Content-Security-Policy",
-      `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; object-src 'none';`,
+      `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; frame-src https://challenges.cloudflare.com; object-src 'none';`,
     );
   };

--- a/starters/standard/src/app/headers.ts
+++ b/starters/standard/src/app/headers.ts
@@ -25,14 +25,6 @@ export const setCommonHeaders =
     );
 
     // Defines trusted sources for content loading and script execution:
-    // - Only loads resources from same origin ('self') and Cloudflare Turnstile
-    // - Only runs scripts from same origin, trusted inline scripts with nonce, and Turnstile
-    // - Allows frames from Cloudflare Turnstile
-    // - Blocks all plugins/embedded objects
-    //
-    // Usage:
-    // - Add other origins to this list (space separated) if you want to allow them
-    // - Add 'nonce=${nonce}' to inline <script> tags you trust
     headers.set(
       "Content-Security-Policy",
       `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; frame-src https://challenges.cloudflare.com; object-src 'none';`,

--- a/starters/standard/src/app/headers.ts
+++ b/starters/standard/src/app/headers.ts
@@ -35,6 +35,6 @@ export const setCommonHeaders =
     // - Add 'nonce=${nonce}' to inline <script> tags you trust
     headers.set(
       "Content-Security-Policy",
-      `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; object-src 'none';`,
+      `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; frame-src https://challenges.cloudflare.com; object-src 'none';`,
     );
   };


### PR DESCRIPTION
* Adds basic security docs explaining what headers we set, where to find them, how to work with them, and how to change them.
* Updates starter headers to allow for inline styles: workerd seems to add them for `Response()`s + it is arguably an acceptable tradeoff to allow for inline styles (compared to inline scripts, for e.g.)
* Allow layouts (e.g. `Document`) to take in a nonce - users will likely need this for their inline scripts