### PR TITLE
fix: export default function for "use client"

### DIFF
--- a/sdk/src/vite/useClientPlugin.mts
+++ b/sdk/src/vite/useClientPlugin.mts
@@ -100,7 +100,7 @@ import { registerClientReference } from "@redwoodjs/sdk/worker";
 
     // Add a separate pattern for named default function exports
     const namedDefaultExportRegex =
-      /export\s+default\s+(?:async\s+)?function\s+(\w+)\s*\([^)]*\)\s*{[^}]*}/g;
+      /export\s+default\s+(?:async\s+)?function\s+(\w+)\s*(\([^)]*\))\s*({[^}]*})/g;
 
     // Update the defaultExportRegex handling for anonymous arrow functions
     const anonymousDefaultExportRegex =
@@ -120,9 +120,9 @@ import { registerClientReference } from "@redwoodjs/sdk/worker";
     }
 
     // Don't remove named default exports as they're handled by the function transformation
-    s.replaceAll(namedDefaultExportRegex, (match, name) => {
+    s.replaceAll(namedDefaultExportRegex, (match, name, params, body) => {
       const isAsync = match.includes("async");
-      return `${isAsync ? "async " : ""}function ${name}SSR${match.slice(match.indexOf("{"))}`;
+      return `${isAsync ? "async " : ""}function ${name}SSR${params}${body}`;
     });
 
     // Update the anonymous default export handling

--- a/sdk/src/vite/useClientPlugin.test.mts
+++ b/sdk/src/vite/useClientPlugin.test.mts
@@ -415,13 +415,13 @@ export default async () => {
     expect(
       await transform(`"use client"
 
-export default function Component() {
+export default function Component({ prop1, prop2 }) {
   return jsx('div', { children: 'Hello' });
 }`),
     ).toMatchInlineSnapshot(`
       "
       import { registerClientReference } from "@redwoodjs/sdk/worker";
-      function ComponentSSR{
+      function ComponentSSR({ prop1, prop2 }){
         return jsx('div', { children: 'Hello' });
       }
 
@@ -444,7 +444,7 @@ export default async function Component() {
     ).toMatchInlineSnapshot(`
       "
       import { registerClientReference } from "@redwoodjs/sdk/worker";
-      async function ComponentSSR{
+      async function ComponentSSR(){
         return jsx('div', { children: 'Hello' });
       }
 
@@ -662,7 +662,7 @@ export { Fourth as AnotherName }`),
         return jsx('div', { children: 'Fourth' });
       }
 
-      function MainSSR{
+      function MainSSR(){
         return jsx('div', { children: 'Main' });
       }
 


### PR DESCRIPTION
There was a bug in how we were transforming "use client" modules for the case of `export default function`