### PR TITLE
chore: Rename RouteContext to RouteOptions

### DIFF
--- a/docs/src/content/docs/core/react-server-components.mdx
+++ b/docs/src/content/docs/core/react-server-components.mdx
@@ -57,8 +57,10 @@ and renders the todos.
 ```
 
 <Aside type="tip" title="Suspense">
-When a server component is async, you'll able to wrap it in a `Suspense` boundary. This will allow you to show a loading state while the data is being fetched.  
-</Aside> 
+  When a server component is async, you'll able to wrap it in a `Suspense`
+  boundary. This will allow you to show a loading state while the data is being
+  fetched.
+</Aside>{" "}
 
 ## Server Functions
 
@@ -67,7 +69,7 @@ Allow you to execute code on the server from a client component.
 ```tsx title="@/pages/todos/functions.tsx" mark={1}
 "use server";
 
-export async function addTodo(formData: FormData, ctx: Context) {
+export async function addTodo(formData: FormData, { ctx }: RouteOptions) {
   const title = formData.get("title");
   await db.todo.create({ data: { title, userId: ctx.user.id } });
 }

--- a/docs/src/content/docs/core/routing.mdx
+++ b/docs/src/content/docs/core/routing.mdx
@@ -96,7 +96,7 @@ defineApp([
 ])
 
 ---
-The request handler function has the following parameters:
+The request handler function takes in the following options:
 1. `request`: The request object.
 2. `params`: The matched parameters from the request URL.
 3. `env`: The Cloudflare environment.

--- a/experiments/ai-stream/src/app/pages/Chat/functions.ts
+++ b/experiments/ai-stream/src/app/pages/Chat/functions.ts
@@ -1,9 +1,12 @@
 "use server";
 
-import { RouteContext } from "@redwoodjs/sdk/router";
+import { RouteOptions } from "@redwoodjs/sdk/router";
 
-export async function sendMessage(message: string, ctx?: RouteContext) {
-  const response = await ctx!.env.AI.run("@cf/meta/llama-3.1-8b-instruct", {
+export async function sendMessage(
+  message: string,
+  ...[{ env }]: [RouteOptions]
+) {
+  const response = await env.AI.run("@cf/meta/llama-3.1-8b-instruct", {
     prompt: message,
     stream: true,
   });

--- a/experiments/ai-stream/src/app/pages/Chat/functions.ts
+++ b/experiments/ai-stream/src/app/pages/Chat/functions.ts
@@ -1,12 +1,9 @@
 "use server";
 
-import { RouteOptions } from "@redwoodjs/sdk/router";
+import { HandlerOptions } from "@redwoodjs/sdk/router";
 
-export async function sendMessage(
-  message: string,
-  ...[{ env }]: [RouteOptions]
-) {
-  const response = await env.AI.run("@cf/meta/llama-3.1-8b-instruct", {
+export async function sendMessage(message: string, opts?: HandlerOptions) {
+  const response = await opts!.env.AI.run("@cf/meta/llama-3.1-8b-instruct", {
     prompt: message,
     stream: true,
   });

--- a/experiments/billable/src/app/pages/Home/HomePage.tsx
+++ b/experiments/billable/src/app/pages/Home/HomePage.tsx
@@ -1,7 +1,7 @@
-import { RouteContext } from "@redwoodjs/sdk/worker";
+import { RouteOptions } from "@redwoodjs/sdk/worker";
 import { Layout } from "../Layout";
 import { InvoiceForm } from "../invoice/DetailPage/InvoiceForm";
-export default function HomePage({ ctx }: RouteContext) {
+export default function HomePage({ ctx }: RouteOptions) {
   return (
     <Layout ctx={ctx}>
       <InvoiceForm

--- a/experiments/billable/src/app/pages/auth/LoginPage.tsx
+++ b/experiments/billable/src/app/pages/auth/LoginPage.tsx
@@ -16,20 +16,20 @@ import {
 } from "../../components/ui/input-otp";
 import { link } from "../../shared/links";
 
-export function LoginPage(ctx: RouteOptions) {
+export function LoginPage(opts: RouteOptions) {
   const [email, setEmail] = useState("peter@redwoodjs.com");
   const [isPending, startTransition] = useTransition();
   const [success, setSuccess] = useState(false);
 
   const handleSendEmail = () => {
     startTransition(async () => {
-      await emailLoginLink(email, ctx);
+      await emailLoginLink(email);
       setSuccess(true);
     });
   };
 
   return (
-    <Layout ctx={ctx.ctx}>
+    <Layout ctx={opts.ctx}>
       <div className="space-y-2 py-4">
         <h4 className="font-medium leading-none">
           Continue with Email Address

--- a/experiments/billable/src/app/pages/auth/LoginPage.tsx
+++ b/experiments/billable/src/app/pages/auth/LoginPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { RouteContext } from "@redwoodjs/sdk/router";
+import { RouteOptions } from "@redwoodjs/sdk/router";
 import { Loader2 } from "lucide-react";
 
 import { useState, useTransition } from "react";
@@ -16,7 +16,7 @@ import {
 } from "../../components/ui/input-otp";
 import { link } from "../../shared/links";
 
-export function LoginPage(ctx: RouteContext) {
+export function LoginPage(ctx: RouteOptions) {
   const [email, setEmail] = useState("peter@redwoodjs.com");
   const [isPending, startTransition] = useTransition();
   const [success, setSuccess] = useState(false);

--- a/experiments/billable/src/app/pages/auth/functions.ts
+++ b/experiments/billable/src/app/pages/auth/functions.ts
@@ -3,7 +3,7 @@
 import { Resend } from "resend";
 import { link } from "../../shared/links";
 import { db } from "src/db";
-import { RouteContext } from "@redwoodjs/sdk/router";
+import { RouteOptions } from "@redwoodjs/sdk/router";
 
 export async function generateAuthToken(email: string) {
   const authToken = Math.floor(100000 + Math.random() * 900000).toString();
@@ -23,9 +23,9 @@ export async function generateAuthToken(email: string) {
   return authToken;
 }
 
-export async function emailLoginLink(email: string, ctx: RouteContext) {
+export async function emailLoginLink(email: string, opts: RouteOptions) {
   const token = await generateAuthToken(email);
-  const { env } = ctx;
+  const { env } = opts;
   const loginUrl = `${env.APP_URL}${link("/user/auth")}?token=${token}&email=${encodeURIComponent(email)}`;
 
   // TODO (peterp, 2025-02-11): Fix this better.

--- a/experiments/billable/src/app/pages/auth/functions.ts
+++ b/experiments/billable/src/app/pages/auth/functions.ts
@@ -23,9 +23,9 @@ export async function generateAuthToken(email: string) {
   return authToken;
 }
 
-export async function emailLoginLink(email: string, opts: RouteOptions) {
+export async function emailLoginLink(email: string, opts?: RouteOptions) {
   const token = await generateAuthToken(email);
-  const { env } = opts;
+  const { env } = opts!;
   const loginUrl = `${env.APP_URL}${link("/user/auth")}?token=${token}&email=${encodeURIComponent(email)}`;
 
   // TODO (peterp, 2025-02-11): Fix this better.

--- a/experiments/billable/src/app/pages/invoice/DetailPage/InvoiceDetailPage.tsx
+++ b/experiments/billable/src/app/pages/invoice/DetailPage/InvoiceDetailPage.tsx
@@ -4,7 +4,7 @@ import { Layout } from "../../Layout";
 
 import { InvoiceForm } from "./InvoiceForm";
 import { db } from "src/db";
-import { RouteContext } from "@redwoodjs/sdk/router";
+import { RouteOptions } from "@redwoodjs/sdk/router";
 import {
   BreadcrumbLink,
   BreadcrumbList,
@@ -53,7 +53,7 @@ export async function getInvoice(id: string, userId: string) {
 export async function InvoiceDetailPage({
   params,
   ctx,
-}: RouteContext<{ id: string }>) {
+}: RouteOptions<{ id: string }>) {
   const invoice = await getInvoice(params.id, ctx.user.id);
 
   return (

--- a/experiments/billable/src/app/pages/invoice/DetailPage/InvoiceForm.tsx
+++ b/experiments/billable/src/app/pages/invoice/DetailPage/InvoiceForm.tsx
@@ -15,7 +15,7 @@ import { Textarea as OGTextarea } from "src/components/ui/textarea";
 import { PlusIcon, Trash2Icon } from "lucide-react";
 import { cn } from "src/components/cn";
 import { toast, Toaster } from "sonner";
-import { RouteContext } from "@redwoodjs/sdk/router";
+import { RouteOptions } from "@redwoodjs/sdk/router";
 import type { User } from "@prisma/client";
 
 function calculateSubtotal(items: InvoiceItem[]) {
@@ -36,7 +36,7 @@ function calculateTaxes(subtotal: number, taxes: InvoiceTaxes[]) {
 
 export function InvoiceForm(props: {
   invoice: Awaited<ReturnType<typeof getInvoice>>;
-  ctx: RouteContext;
+  ctx: RouteOptions;
 }) {
   const [invoice, setInvoice] = useState(props.invoice);
   const [items, setItems] = useState(props.invoice.items);

--- a/experiments/billable/src/app/pages/invoice/DetailPage/InvoiceForm.tsx
+++ b/experiments/billable/src/app/pages/invoice/DetailPage/InvoiceForm.tsx
@@ -16,7 +16,6 @@ import { PlusIcon, Trash2Icon } from "lucide-react";
 import { cn } from "src/components/cn";
 import { toast, Toaster } from "sonner";
 import { RouteOptions } from "@redwoodjs/sdk/router";
-import type { User } from "@prisma/client";
 
 function calculateSubtotal(items: InvoiceItem[]) {
   let sum = 0;
@@ -36,7 +35,7 @@ function calculateTaxes(subtotal: number, taxes: InvoiceTaxes[]) {
 
 export function InvoiceForm(props: {
   invoice: Awaited<ReturnType<typeof getInvoice>>;
-  ctx: RouteOptions;
+  ctx: RouteOptions["ctx"];
 }) {
   const [invoice, setInvoice] = useState(props.invoice);
   const [items, setItems] = useState(props.invoice.items);

--- a/experiments/billable/src/app/pages/invoice/ListPage/InvoiceListPage.tsx
+++ b/experiments/billable/src/app/pages/invoice/ListPage/InvoiceListPage.tsx
@@ -4,7 +4,7 @@ import { Layout } from "../../Layout";
 
 import { CreateInvoiceButton } from "./CreateInvoiceButton";
 import { db } from "src/db";
-import { RouteContext } from "@redwoodjs/sdk/router";
+import { RouteOptions } from "@redwoodjs/sdk/router";
 import { link } from "src/shared/links";
 
 import {
@@ -58,7 +58,7 @@ async function getInvoiceListSummary(userId: string) {
   });
 }
 
-export async function InvoiceListPage({ ctx }: RouteContext) {
+export async function InvoiceListPage({ ctx }: RouteOptions) {
   const invoices = await getInvoiceListSummary(ctx.user.id);
   return (
     <Layout ctx={ctx}>

--- a/experiments/cutable/src/app/pages/home/HomePage.tsx
+++ b/experiments/cutable/src/app/pages/home/HomePage.tsx
@@ -1,8 +1,8 @@
-import { RouteContext } from "@redwoodjs/sdk/router";
+import { RouteOptions } from "@redwoodjs/sdk/router";
 import { Layout } from "../Layout";
 import { CalculateSheets } from "./CalculateSheets";
 // import { Test } from "./Test"
-export default function HomePage({ ctx }: RouteContext) {
+export default function HomePage({ ctx }: RouteOptions) {
   return (
     <Layout ctx={ctx}>
       <CalculateSheets />

--- a/experiments/cutable/src/app/pages/project/DetailPage/CutlistDetailPage.tsx
+++ b/experiments/cutable/src/app/pages/project/DetailPage/CutlistDetailPage.tsx
@@ -1,5 +1,5 @@
 import { getProject, ProjectItem, updateProject } from "./ProjectDetailPage";
-import { RouteContext } from "@redwoodjs/sdk/router";
+import { RouteOptions } from "@redwoodjs/sdk/router";
 import { BreadcrumbLink } from "src/components/ui/breadcrumb";
 import { BreadcrumbSeparator } from "src/components/ui/breadcrumb";
 import { BreadcrumbPage } from "src/components/ui/breadcrumb";
@@ -12,7 +12,7 @@ import { findOptimalPacking, calculateFreeSpaces } from "./clientFunctions";
 export default async function CutlistDetailPage({
   params,
   ctx,
-}: RouteContext<{ id: string }>) {
+}: RouteOptions<{ id: string }>) {
   const project = await getProject(params.id, ctx.user.id);
   const cutlistItems = JSON.parse(
     project.cutlistItems as string,

--- a/experiments/cutable/src/app/pages/project/DetailPage/ProjectDetailPage.tsx
+++ b/experiments/cutable/src/app/pages/project/DetailPage/ProjectDetailPage.tsx
@@ -2,7 +2,7 @@
 
 import { Layout } from "../../Layout";
 import { ProjectForm } from "./ProjectForm";
-import { RouteContext } from "../../../../lib/router";
+import { RouteOptions } from "../../../../lib/router";
 import { db } from "../../../../db";
 import {
   BreadcrumbLink,
@@ -52,7 +52,7 @@ export async function updateProject(
 export default async function ProjectDetailPage({
   params,
   ctx,
-}: RouteContext<{ id: string }>) {
+}: RouteOptions<{ id: string }>) {
   const project = await getProject(params.id, ctx.user.id);
 
   return (

--- a/experiments/cutable/src/app/pages/project/ListPage/ProjectListPage.tsx
+++ b/experiments/cutable/src/app/pages/project/ListPage/ProjectListPage.tsx
@@ -4,7 +4,7 @@ import { Layout } from "../../Layout";
 
 import { CreateProjectButton } from "./CreateProjectButton";
 import { db } from "../../../../db";
-import { RouteContext } from "../../../../lib/router";
+import { RouteOptions } from "../../../../lib/router";
 import { link } from "src/shared/links";
 
 import {
@@ -61,7 +61,7 @@ async function getProjectListSummary(userId: string) {
   });
 }
 
-export default async function ProjectListPage({ ctx }: RouteContext) {
+export default async function ProjectListPage({ ctx }: RouteOptions) {
   const projects = await getProjectListSummary(ctx.user.id);
   return (
     <Layout ctx={ctx}>

--- a/experiments/cutl/lib/router.ts
+++ b/experiments/cutl/lib/router.ts
@@ -1,4 +1,4 @@
-export type RouteContext<TParams = Record<string, string>> = {
+export type RouteOptions<TParams = Record<string, string>> = {
   request: Request;
   params: TParams;
   env: Env;
@@ -6,4 +6,4 @@ export type RouteContext<TParams = Record<string, string>> = {
     id: string;
     // Add other user properties as needed
   };
-}; 
+};

--- a/experiments/cutl/src/app/pages/Home/HomePage.tsx
+++ b/experiments/cutl/src/app/pages/Home/HomePage.tsx
@@ -1,13 +1,12 @@
-import { RouteContext } from "../../../lib/router"
-import { Layout } from "../Layout"
-import {CalculateSheets} from "./CalculateSheets"
+import { RouteOptions } from "../../../lib/router";
+import { Layout } from "../Layout";
+import { CalculateSheets } from "./CalculateSheets";
 // import { Test } from "./Test"
-export default function HomePage({ ctx }: RouteContext) {
+export default function HomePage({ ctx }: RouteOptions) {
   return (
     <Layout ctx={ctx}>
       <CalculateSheets />
       {/* <Test /> */}
     </Layout>
-  )
+  );
 }
-

--- a/experiments/cutl/src/app/pages/auth/LoginPage.tsx
+++ b/experiments/cutl/src/app/pages/auth/LoginPage.tsx
@@ -5,7 +5,7 @@ import { Loader2 } from "lucide-react";
 import { useState, useTransition } from "react";
 import { emailLoginLink } from "./functions";
 import { Layout } from "../Layout";
-import { RouteContext } from "../../../lib/router";
+import { RouteOptions } from "../../../lib/router";
 import { Button } from "../../components/ui/button";
 import { Input } from "../../components/ui/input";
 import {
@@ -16,7 +16,7 @@ import {
 } from "../../components/ui/input-otp";
 import { link } from "../../shared/links";
 
-export function LoginPage({ ctx }: RouteContext) {
+export function LoginPage({ ctx }: RouteOptions) {
   const [email, setEmail] = useState("her.stander@gmail.com");
   const [isPending, startTransition] = useTransition();
   const [success, setSuccess] = useState(false);
@@ -46,7 +46,10 @@ export function LoginPage({ ctx }: RouteContext) {
           {success ? (
             <OTP
               onClick={(token) => {
-                const url = new URL(link("/auth/callback"), window.location.origin);
+                const url = new URL(
+                  link("/auth/callback"),
+                  window.location.origin,
+                );
                 url.searchParams.set("email", email);
                 url.searchParams.set("token", token);
                 window.location.href = url.toString();

--- a/experiments/cutl/src/app/pages/project/DetailPage/CutlistDetailPage.tsx
+++ b/experiments/cutl/src/app/pages/project/DetailPage/CutlistDetailPage.tsx
@@ -1,5 +1,5 @@
 import { getProject, ProjectItem, updateProject } from "./ProjectDetailPage";
-import { RouteContext } from "../../../../lib/router";
+import { RouteOptions } from "../../../../lib/router";
 import { BreadcrumbLink } from "src/components/ui/breadcrumb";
 import { BreadcrumbSeparator } from "src/components/ui/breadcrumb";
 import { BreadcrumbPage } from "src/components/ui/breadcrumb";
@@ -12,31 +12,43 @@ import { findOptimalPacking, calculateFreeSpaces } from "./clientFunctions";
 export default async function CutlistDetailPage({
   params,
   ctx,
-}: RouteContext<{ id: string }>) {
+}: RouteOptions<{ id: string }>) {
   const project = await getProject(params.id, ctx.user.id);
-  const cutlistItems = JSON.parse(project.cutlistItems as string) as ProjectItem[];
+  const cutlistItems = JSON.parse(
+    project.cutlistItems as string,
+  ) as ProjectItem[];
 
   const SHEET_WIDTH = project.boardWidth;
   const SHEET_HEIGHT = project.boardLength;
   const BLADE_WIDTH = project.bladeWidth;
 
-  const panels = cutlistItems.flatMap(item =>
+  const panels = cutlistItems.flatMap((item) =>
     Array(item.quantity).fill({
       width: item.width,
-      height: item.length
-    })
+      height: item.length,
+    }),
   );
 
-  let packer = await findOptimalPacking(panels, SHEET_WIDTH, SHEET_HEIGHT, BLADE_WIDTH);
+  let packer = await findOptimalPacking(
+    panels,
+    SHEET_WIDTH,
+    SHEET_HEIGHT,
+    BLADE_WIDTH,
+  );
   const boards = packer?.map((board: any) => {
     let usedRects = board.map((rect: any) => ({
       x: rect.x,
       y: rect.y,
       width: rect.width,
-      height: rect.height
+      height: rect.height,
     }));
 
-    let freeRects = calculateFreeSpaces(board, SHEET_WIDTH, SHEET_HEIGHT, BLADE_WIDTH); // Pass blade width
+    let freeRects = calculateFreeSpaces(
+      board,
+      SHEET_WIDTH,
+      SHEET_HEIGHT,
+      BLADE_WIDTH,
+    ); // Pass blade width
 
     return {
       width: board.width,
@@ -50,24 +62,23 @@ export default async function CutlistDetailPage({
     // update the project with the new needed and cost
     await updateProject(params.id, {
       boardsNeeded: boards.length,
-      total: boards.length * project.boardPrice
+      total: boards.length * project.boardPrice,
     });
   }
-
 
   const boardCount = packer?.length ?? 0;
   const totalCost = boardCount * project.boardPrice;
 
-
   // boards?
-
 
   return (
     <Layout ctx={ctx}>
       <BreadcrumbList>
-        <BreadcrumbLink href={link('/project/list')}>Projects</BreadcrumbLink>
+        <BreadcrumbLink href={link("/project/list")}>Projects</BreadcrumbLink>
         <BreadcrumbSeparator />
-        <BreadcrumbLink href={`/project/${params.id}`}>Edit Project</BreadcrumbLink>
+        <BreadcrumbLink href={`/project/${params.id}`}>
+          Edit Project
+        </BreadcrumbLink>
         <BreadcrumbSeparator />
         <BreadcrumbPage>Cutlist</BreadcrumbPage>
       </BreadcrumbList>
@@ -97,11 +108,14 @@ export default async function CutlistDetailPage({
           Cut Layout
         </h3>
         {boards ? (
-          <BoardRenderer boards={boards} boardWidth={project.boardWidth} boardHeight={project.boardLength} />
+          <BoardRenderer
+            boards={boards}
+            boardWidth={project.boardWidth}
+            boardHeight={project.boardLength}
+          />
         ) : (
           <p>Loading cutting layout...</p> // Placeholder while waiting for data
         )}
-
       </div>
     </Layout>
   );

--- a/experiments/cutl/src/app/pages/project/DetailPage/ProjectDetailPage.tsx
+++ b/experiments/cutl/src/app/pages/project/DetailPage/ProjectDetailPage.tsx
@@ -2,9 +2,14 @@
 
 import { Layout } from "../../Layout";
 import { ProjectForm } from "./ProjectForm";
-import { RouteContext } from "../../../../lib/router";
+import { RouteOptions } from "../../../../lib/router";
 import { db } from "../../../../db";
-import { BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator } from "src/components/ui/breadcrumb";
+import {
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "src/components/ui/breadcrumb";
 import { link } from "src/shared/links";
 
 export type ProjectItem = {
@@ -19,8 +24,7 @@ type Project = {
   total: number;
   boardsNeeded: number;
   createdAt: Date;
-}
-
+};
 
 export async function getProject(id: string, userId: string) {
   const project = await db.project.findFirstOrThrow({
@@ -29,38 +33,37 @@ export async function getProject(id: string, userId: string) {
       userId,
     },
   });
-  
+
   return {
     ...project,
   };
 }
 
-export async function updateProject(id: string, data: Partial<Omit<Project, 'userId' | 'cutlistItems'>>) {
+export async function updateProject(
+  id: string,
+  data: Partial<Omit<Project, "userId" | "cutlistItems">>,
+) {
   return await db.project.update({
     where: { id },
-    data
+    data,
   });
 }
 
 export default async function ProjectDetailPage({
   params,
   ctx,
-}: RouteContext<{ id: string }>) {
+}: RouteOptions<{ id: string }>) {
   const project = await getProject(params.id, ctx.user.id);
 
   return (
     <Layout ctx={ctx}>
       <BreadcrumbList>
-        <BreadcrumbLink href={link('/project/list')}>
-        Projects
-        </BreadcrumbLink>
+        <BreadcrumbLink href={link("/project/list")}>Projects</BreadcrumbLink>
         <BreadcrumbSeparator />
-        <BreadcrumbPage>
-        Edit Project
-        </BreadcrumbPage>
+        <BreadcrumbPage>Edit Project</BreadcrumbPage>
       </BreadcrumbList>
 
-        <ProjectForm project={project} />
+      <ProjectForm project={project} />
     </Layout>
   );
 }

--- a/experiments/cutl/src/app/pages/project/ListPage/ProjectListPage.tsx
+++ b/experiments/cutl/src/app/pages/project/ListPage/ProjectListPage.tsx
@@ -4,7 +4,7 @@ import { Layout } from "../../Layout";
 
 import { CreateProjectButton } from "./CreateProjectButton";
 import { db } from "../../../../db";
-import { RouteContext } from "../../../../lib/router";
+import { RouteOptions } from "../../../../lib/router";
 import { link } from "src/shared/links";
 
 import {
@@ -61,7 +61,7 @@ async function getProjectListSummary(userId: string) {
   });
 }
 
-export default async function ProjectListPage({ ctx }: RouteContext) {
+export default async function ProjectListPage({ ctx }: RouteOptions) {
   const projects = await getProjectListSummary(ctx.user.id);
   return (
     <Layout ctx={ctx}>

--- a/experiments/cutl/src/lib/router.ts
+++ b/experiments/cutl/src/lib/router.ts
@@ -8,10 +8,12 @@ export type RouteOptions<TParams = Record<string, string>> = {
 };
 
 type RouteMiddleware = (
-  ctx: RouteOptions,
+  opts: RouteOptions,
 ) => Response | Promise<Response> | void;
-type RouteFunction = (ctx: RouteOptions) => Response | Promise<Response>;
-type RouteComponent = (ctx: RouteOptions) => JSX.Element | Promise<JSX.Element>;
+type RouteFunction = (opts: RouteOptions) => Response | Promise<Response>;
+type RouteComponent = (
+  opts: RouteOptions,
+) => JSX.Element | Promise<JSX.Element>;
 
 type RouteHandler =
   | RouteFunction

--- a/experiments/realtime-poc/src/app/pages/auth/functions.ts
+++ b/experiments/realtime-poc/src/app/pages/auth/functions.ts
@@ -9,13 +9,13 @@ import {
 } from "@simplewebauthn/server";
 
 import { sessions } from "@/session/store";
-import { RouteContext } from "@redwoodjs/sdk/router";
+import { RouteOptions } from "@redwoodjs/sdk/router";
 import { db } from "@/db";
 import { verifyTurnstileToken } from "@redwoodjs/sdk/turnstile";
 
 export async function startPasskeyRegistration(
   username: string,
-  ctx?: RouteContext,
+  ctx?: RouteOptions,
 ) {
   const { headers, env } = ctx!;
 
@@ -40,7 +40,7 @@ export async function finishPasskeyRegistration(
   username: string,
   registration: RegistrationResponseJSON,
   turnstileToken: string,
-  ctx?: RouteContext,
+  ctx?: RouteOptions,
 ) {
   const { request, headers, env } = ctx!;
 
@@ -93,7 +93,7 @@ export async function finishPasskeyRegistration(
   return true;
 }
 
-export async function startPasskeyLogin(ctx?: RouteContext) {
+export async function startPasskeyLogin(ctx?: RouteOptions) {
   const { headers, env } = ctx!;
 
   const options = await generateAuthenticationOptions({
@@ -109,7 +109,7 @@ export async function startPasskeyLogin(ctx?: RouteContext) {
 
 export async function finishPasskeyLogin(
   login: AuthenticationResponseJSON,
-  ctx?: RouteContext,
+  ctx?: RouteOptions,
 ) {
   const { request, headers, env } = ctx!;
   const { origin } = new URL(request.url);

--- a/experiments/realtime-poc/src/app/pages/auth/functions.ts
+++ b/experiments/realtime-poc/src/app/pages/auth/functions.ts
@@ -9,15 +9,15 @@ import {
 } from "@simplewebauthn/server";
 
 import { sessions } from "@/session/store";
-import { RouteOptions } from "@redwoodjs/sdk/router";
+import { HandlerOptions } from "@redwoodjs/sdk/router";
 import { db } from "@/db";
 import { verifyTurnstileToken } from "@redwoodjs/sdk/turnstile";
 
 export async function startPasskeyRegistration(
   username: string,
-  ctx?: RouteOptions,
+  opts?: HandlerOptions,
 ) {
-  const { headers, env } = ctx!;
+  const { headers, env } = opts!;
 
   const options = await generateRegistrationOptions({
     rpName: env.APP_NAME,
@@ -40,9 +40,9 @@ export async function finishPasskeyRegistration(
   username: string,
   registration: RegistrationResponseJSON,
   turnstileToken: string,
-  ctx?: RouteOptions,
+  opts?: HandlerOptions,
 ) {
-  const { request, headers, env } = ctx!;
+  const { request, headers, env } = opts!;
 
   if (
     !(await verifyTurnstileToken({
@@ -93,8 +93,8 @@ export async function finishPasskeyRegistration(
   return true;
 }
 
-export async function startPasskeyLogin(ctx?: RouteOptions) {
-  const { headers, env } = ctx!;
+export async function startPasskeyLogin(opts?: HandlerOptions) {
+  const { headers, env } = opts!;
 
   const options = await generateAuthenticationOptions({
     rpID: env.RP_ID,
@@ -109,9 +109,9 @@ export async function startPasskeyLogin(ctx?: RouteOptions) {
 
 export async function finishPasskeyLogin(
   login: AuthenticationResponseJSON,
-  ctx?: RouteOptions,
+  opts?: HandlerOptions,
 ) {
-  const { request, headers, env } = ctx!;
+  const { request, headers, env } = opts!;
   const { origin } = new URL(request.url);
 
   const session = await sessions.load(request);

--- a/experiments/realtime-poc/src/app/pages/note/Note.tsx
+++ b/experiments/realtime-poc/src/app/pages/note/Note.tsx
@@ -2,9 +2,10 @@ import { Editor } from "./Editor";
 import { getContent } from "./functions";
 import { RouteOptions } from "@redwoodjs/sdk/router";
 
-const Note = async (ctx: RouteOptions) => {
-  const key = ctx.params.key;
-  const content = await getContent(key, ctx);
+const Note = async (opts: RouteOptions) => {
+  const { params } = opts;
+  const key = params.key;
+  const content = await getContent(key, opts);
   return <Editor props={{ initialContent: content, key }} />;
 };
 

--- a/experiments/realtime-poc/src/app/pages/note/Note.tsx
+++ b/experiments/realtime-poc/src/app/pages/note/Note.tsx
@@ -1,8 +1,8 @@
 import { Editor } from "./Editor";
 import { getContent } from "./functions";
-import { RouteContext } from "@redwoodjs/sdk/router";
+import { RouteOptions } from "@redwoodjs/sdk/router";
 
-const Note = async (ctx: RouteContext) => {
+const Note = async (ctx: RouteOptions) => {
   const key = ctx.params.key;
   const content = await getContent(key, ctx);
   return <Editor props={{ initialContent: content, key }} />;

--- a/experiments/realtime-poc/src/app/pages/note/functions.ts
+++ b/experiments/realtime-poc/src/app/pages/note/functions.ts
@@ -1,8 +1,8 @@
 "use server";
 
-import { RouteContext } from "@redwoodjs/sdk/router";
+import { RouteOptions } from "@redwoodjs/sdk/router";
 
-export const getContent = async (key: string, ctx?: RouteContext) => {
+export const getContent = async (key: string, ctx?: RouteOptions) => {
   const doId = ctx!.env.NOTE_DURABLE_OBJECT.idFromName(key);
   const noteDO = ctx!.env.NOTE_DURABLE_OBJECT.get(doId);
   return noteDO.getContent();
@@ -11,7 +11,7 @@ export const getContent = async (key: string, ctx?: RouteContext) => {
 export const updateContent = async (
   key: string,
   content: string,
-  ctx?: RouteContext,
+  ctx?: RouteOptions,
 ) => {
   const doId = ctx!.env.NOTE_DURABLE_OBJECT.idFromName(key);
   const noteDO = ctx!.env.NOTE_DURABLE_OBJECT.get(doId);

--- a/experiments/zoomshare/src/app/pages/auth/functions.ts
+++ b/experiments/zoomshare/src/app/pages/auth/functions.ts
@@ -10,12 +10,12 @@ import {
 } from "@simplewebauthn/server";
 
 import { sessions } from "@/session/store";
-import { RouteContext } from "@redwoodjs/sdk/router";
+import { RouteOptions } from "@redwoodjs/sdk/router";
 import { db } from "@/db";
 
 export async function startPasskeyRegistration(
   username: string,
-  ctx?: RouteContext,
+  ctx?: RouteOptions,
 ) {
   const { headers, env } = ctx!;
 
@@ -39,7 +39,7 @@ export async function startPasskeyRegistration(
 export async function finishPasskeyRegistration(
   username: string,
   registration: RegistrationResponseJSON,
-  ctx?: RouteContext,
+  ctx?: RouteOptions,
 ) {
   const { request, headers, env } = ctx!;
   const { origin } = new URL(request.url);
@@ -82,7 +82,7 @@ export async function finishPasskeyRegistration(
   return true;
 }
 
-export async function startPasskeyLogin(ctx?: RouteContext) {
+export async function startPasskeyLogin(ctx?: RouteOptions) {
   const { request, headers, env } = ctx!;
 
   const options = await generateAuthenticationOptions({
@@ -98,7 +98,7 @@ export async function startPasskeyLogin(ctx?: RouteContext) {
 
 export async function finishPasskeyLogin(
   login: AuthenticationResponseJSON,
-  ctx?: RouteContext,
+  ctx?: RouteOptions,
 ) {
   const { request, headers, env } = ctx!;
   const { origin } = new URL(request.url);

--- a/sdk/src/runtime/lib/router.ts
+++ b/sdk/src/runtime/lib/router.ts
@@ -41,11 +41,11 @@ export type RwContext<TContext> = {
   nonce: string;
   Layout: React.FC<LayoutProps<TContext>>;
   renderPage: RenderPage<TContext>;
-  handleAction: (ctx: RouteOptions<TContext>) => Promise<unknown>;
+  handleAction: (opts: RouteOptions<TContext>) => Promise<unknown>;
 };
 
 export type RouteMiddleware<TContext = any> = (
-  ctx: RouteOptions<TContext>,
+  opts: RouteOptions<TContext>,
 ) =>
   | Response
   | Promise<Response>
@@ -53,10 +53,10 @@ export type RouteMiddleware<TContext = any> = (
   | Promise<void>
   | Promise<Response | void>;
 type RouteFunction<TContext, TParams> = (
-  ctx: RouteOptions<TContext, TParams>,
+  opts: RouteOptions<TContext, TParams>,
 ) => Response | Promise<Response>;
 type RouteComponent<TContext, TParams> = (
-  ctx: RouteOptions<TContext, TParams>,
+  opts: RouteOptions<TContext, TParams>,
 ) => JSX.Element | Promise<JSX.Element>;
 
 type RouteHandler<TContext, TParams> =

--- a/sdk/src/runtime/lib/router.ts
+++ b/sdk/src/runtime/lib/router.ts
@@ -1,6 +1,6 @@
 import { isValidElementType } from "react-is";
 
-export type RouteContext<TContext = Record<string, any>, TParams = any> = {
+export type RouteOptions<TContext = Record<string, any>, TParams = any> = {
   request: Request;
   params: TParams;
   env: Env;
@@ -10,7 +10,7 @@ export type RouteContext<TContext = Record<string, any>, TParams = any> = {
 };
 
 export type PageProps<TContext> = Omit<
-  RouteContext<TContext>,
+  RouteOptions<TContext>,
   "request" | "headers" | "rw"
 > & { rw: { nonce: string } };
 
@@ -33,11 +33,11 @@ export type RwContext<TContext> = {
   nonce: string;
   Layout: React.FC<LayoutProps<TContext>>;
   renderPage: RenderPage<TContext>;
-  handleAction: (ctx: RouteContext<TContext>) => Promise<unknown>;
+  handleAction: (ctx: RouteOptions<TContext>) => Promise<unknown>;
 };
 
 export type RouteMiddleware<TContext = any> = (
-  ctx: RouteContext<TContext>,
+  ctx: RouteOptions<TContext>,
 ) =>
   | Response
   | Promise<Response>
@@ -45,10 +45,10 @@ export type RouteMiddleware<TContext = any> = (
   | Promise<void>
   | Promise<Response | void>;
 type RouteFunction<TContext, TParams> = (
-  ctx: RouteContext<TContext, TParams>,
+  ctx: RouteOptions<TContext, TParams>,
 ) => Response | Promise<Response>;
 type RouteComponent<TContext, TParams> = (
-  ctx: RouteContext<TContext, TParams>,
+  ctx: RouteOptions<TContext, TParams>,
 ) => JSX.Element | Promise<JSX.Element>;
 
 type RouteHandler<TContext, TParams> =
@@ -77,7 +77,7 @@ type RouteMatch<TContext = Record<string, any>, TParams = any> = {
 function matchPath(
   routePath: string,
   requestPath: string,
-): RouteContext["params"] | null {
+): RouteOptions["params"] | null {
   const pattern = routePath
     .replace(/:[a-zA-Z]+/g, "([^/]+)") // Convert :param to capture group
     .replace(/\*/g, "(.*)"); // Convert * to wildcard capture group
@@ -90,7 +90,7 @@ function matchPath(
   }
 
   // Extract named parameters and wildcards
-  const params: RouteContext["params"] = {};
+  const params: RouteOptions["params"] = {};
   const paramNames = [...routePath.matchAll(/:[a-zA-Z]+/g)].map((m) =>
     m[0].slice(1),
   );
@@ -153,7 +153,7 @@ export function defineRoutes<TContext = Record<string, any>>(
 
       // Find matching route
       let match: RouteMatch<TContext> | null = null;
-      const routeContext: RouteContext<TContext> = {
+      const RouteOptions: RouteOptions<TContext> = {
         request,
         params: {},
         ctx,
@@ -164,7 +164,7 @@ export function defineRoutes<TContext = Record<string, any>>(
 
       for (const route of flattenedRoutes) {
         if (typeof route === "function") {
-          const r = await route(routeContext);
+          const r = await route(RouteOptions);
 
           if (r instanceof Response) {
             return r;
@@ -186,12 +186,12 @@ export function defineRoutes<TContext = Record<string, any>>(
       }
 
       let { params, handler } = match;
-      routeContext.params = params;
+      RouteOptions.params = params;
 
       const handlers = Array.isArray(handler) ? handler : [handler];
       for (const h of handlers) {
         if (isRouteComponent(h)) {
-          const actionResult = await rw.handleAction(routeContext);
+          const actionResult = await rw.handleAction(RouteOptions);
           const props = {
             params,
             env,
@@ -205,7 +205,7 @@ export function defineRoutes<TContext = Record<string, any>>(
             Layout: rw.Layout,
           });
         } else {
-          const r = await (h(routeContext) as Promise<Response>);
+          const r = await (h(RouteOptions) as Promise<Response>);
           if (r instanceof Response) {
             return r;
           }

--- a/sdk/src/runtime/lib/router.ts
+++ b/sdk/src/runtime/lib/router.ts
@@ -1,5 +1,13 @@
 import { isValidElementType } from "react-is";
 
+export type HandlerOptions<TContext = Record<string, any>> = {
+  request: Request;
+  env: Env;
+  ctx: TContext;
+  headers: Headers;
+  rw: RwContext<TContext>;
+};
+
 export type RouteOptions<TContext = Record<string, any>, TParams = any> = {
   request: Request;
   params: TParams;
@@ -153,7 +161,7 @@ export function defineRoutes<TContext = Record<string, any>>(
 
       // Find matching route
       let match: RouteMatch<TContext> | null = null;
-      const RouteOptions: RouteOptions<TContext> = {
+      const routeOptions: RouteOptions<TContext> = {
         request,
         params: {},
         ctx,
@@ -164,7 +172,7 @@ export function defineRoutes<TContext = Record<string, any>>(
 
       for (const route of flattenedRoutes) {
         if (typeof route === "function") {
-          const r = await route(RouteOptions);
+          const r = await route(routeOptions);
 
           if (r instanceof Response) {
             return r;
@@ -186,12 +194,12 @@ export function defineRoutes<TContext = Record<string, any>>(
       }
 
       let { params, handler } = match;
-      RouteOptions.params = params;
+      routeOptions.params = params;
 
       const handlers = Array.isArray(handler) ? handler : [handler];
       for (const h of handlers) {
         if (isRouteComponent(h)) {
-          const actionResult = await rw.handleAction(RouteOptions);
+          const actionResult = await rw.handleAction(routeOptions);
           const props = {
             params,
             env,
@@ -205,7 +213,7 @@ export function defineRoutes<TContext = Record<string, any>>(
             Layout: rw.Layout,
           });
         } else {
-          const r = await (h(RouteOptions) as Promise<Response>);
+          const r = await (h(routeOptions) as Promise<Response>);
           if (r instanceof Response) {
             return r;
           }

--- a/sdk/src/runtime/register/worker.ts
+++ b/sdk/src/runtime/register/worker.ts
@@ -4,7 +4,7 @@ import {
   decodeReply,
 } from "react-server-dom-webpack/server.edge";
 import { getModuleExport } from "../imports/worker";
-import { RouteContext } from "../lib/router";
+import { RouteOptions } from "../lib/router";
 
 export function registerServerReference(
   action: Function,
@@ -33,7 +33,7 @@ export function registerClientReference<Target extends Record<string, any>>(
 
 export async function rscActionHandler<TContext>(
   req: Request,
-  ctx: RouteContext<TContext, Record<string, string>>,
+  ctx: RouteOptions<TContext, Record<string, string>>,
 ): Promise<unknown> {
   const url = new URL(req.url);
   const contentType = req.headers.get("content-type");

--- a/sdk/src/runtime/register/worker.ts
+++ b/sdk/src/runtime/register/worker.ts
@@ -4,7 +4,7 @@ import {
   decodeReply,
 } from "react-server-dom-webpack/server.edge";
 import { getModuleExport } from "../imports/worker";
-import { RouteOptions } from "../lib/router";
+import { HandlerOptions } from "../lib/router";
 
 export function registerServerReference(
   action: Function,
@@ -33,7 +33,7 @@ export function registerClientReference<Target extends Record<string, any>>(
 
 export async function rscActionHandler<TContext>(
   req: Request,
-  ctx: RouteOptions<TContext, Record<string, string>>,
+  opts: HandlerOptions<TContext>,
 ): Promise<unknown> {
   const url = new URL(req.url);
   const contentType = req.headers.get("content-type");
@@ -50,5 +50,5 @@ export async function rscActionHandler<TContext>(
     throw new Error(`Action ${actionId} is not a function`);
   }
 
-  return action(...args, ctx);
+  return action(...args, opts);
 }

--- a/sdk/src/runtime/worker.tsx
+++ b/sdk/src/runtime/worker.tsx
@@ -54,12 +54,12 @@ export const defineApp = <Context,>(routes: Route<Context>[]) => {
         const isRSCRequest = url.searchParams.has("__rsc");
 
         const handleAction = async (
-          ctx: RouteOptions<Context, Record<string, string>>,
+          opts: RouteOptions<Context, Record<string, string>>,
         ) => {
           const isRSCActionHandler = url.searchParams.has("__rsc_action_id");
 
           if (isRSCActionHandler) {
-            return await rscActionHandler(request, ctx); // maybe we should include params and ctx in the action handler?
+            return await rscActionHandler(request, opts); // maybe we should include params and ctx in the action handler?
           }
         };
 

--- a/sdk/src/runtime/worker.tsx
+++ b/sdk/src/runtime/worker.tsx
@@ -8,7 +8,7 @@ import { ErrorResponse } from "./error";
 
 import {
   Route,
-  RouteContext,
+  RouteOptions,
   defineRoutes,
   RenderPageParams,
   PageProps,
@@ -54,7 +54,7 @@ export const defineApp = <Context,>(routes: Route<Context>[]) => {
         const isRSCRequest = url.searchParams.has("__rsc");
 
         const handleAction = async (
-          ctx: RouteContext<Context, Record<string, string>>,
+          ctx: RouteOptions<Context, Record<string, string>>,
         ) => {
           const isRSCActionHandler = url.searchParams.has("__rsc_action_id");
 

--- a/starters/drizzle/src/app/pages/Home.tsx
+++ b/starters/drizzle/src/app/pages/Home.tsx
@@ -1,7 +1,7 @@
 import { users } from "../../db/schema";
-import { RouteContext } from "@redwoodjs/sdk/router";
+import { RouteOptions } from "@redwoodjs/sdk/router";
 
-export async function Home({ ctx }: RouteContext) {
+export async function Home({ ctx }: RouteOptions) {
   const allUsers = await ctx.db.select().from(users).all();
   return (
     <div>

--- a/starters/passkey-auth/src/app/pages/user/functions.ts
+++ b/starters/passkey-auth/src/app/pages/user/functions.ts
@@ -9,13 +9,13 @@ import {
 } from "@simplewebauthn/server";
 
 import { sessions } from "@/session/store";
-import { RouteContext } from "@redwoodjs/sdk/router";
+import { RouteOptions } from "@redwoodjs/sdk/router";
 import { db } from "@/db";
 import { verifyTurnstileToken } from "@redwoodjs/sdk/turnstile";
 
 export async function startPasskeyRegistration(
   username: string,
-  ctx?: RouteContext,
+  ctx?: RouteOptions,
 ) {
   const { headers, env } = ctx!;
 
@@ -40,7 +40,7 @@ export async function finishPasskeyRegistration(
   username: string,
   registration: RegistrationResponseJSON,
   turnstileToken: string,
-  ctx?: RouteContext,
+  ctx?: RouteOptions,
 ) {
   const { request, headers, env } = ctx!;
 
@@ -93,7 +93,7 @@ export async function finishPasskeyRegistration(
   return true;
 }
 
-export async function startPasskeyLogin(ctx?: RouteContext) {
+export async function startPasskeyLogin(ctx?: RouteOptions) {
   const { headers, env } = ctx!;
 
   const options = await generateAuthenticationOptions({
@@ -109,7 +109,7 @@ export async function startPasskeyLogin(ctx?: RouteContext) {
 
 export async function finishPasskeyLogin(
   login: AuthenticationResponseJSON,
-  ctx?: RouteContext,
+  ctx?: RouteOptions,
 ) {
   const { request, headers, env } = ctx!;
   const { origin } = new URL(request.url);

--- a/starters/passkey-auth/src/app/pages/user/functions.ts
+++ b/starters/passkey-auth/src/app/pages/user/functions.ts
@@ -9,15 +9,15 @@ import {
 } from "@simplewebauthn/server";
 
 import { sessions } from "@/session/store";
-import { RouteOptions } from "@redwoodjs/sdk/router";
+import { HandlerOptions } from "@redwoodjs/sdk/router";
 import { db } from "@/db";
 import { verifyTurnstileToken } from "@redwoodjs/sdk/turnstile";
 
 export async function startPasskeyRegistration(
   username: string,
-  ctx?: RouteOptions,
+  opts?: HandlerOptions,
 ) {
-  const { headers, env } = ctx!;
+  const { headers, env } = opts!;
 
   const options = await generateRegistrationOptions({
     rpName: env.APP_NAME,
@@ -40,9 +40,9 @@ export async function finishPasskeyRegistration(
   username: string,
   registration: RegistrationResponseJSON,
   turnstileToken: string,
-  ctx?: RouteOptions,
+  opts?: HandlerOptions,
 ) {
-  const { request, headers, env } = ctx!;
+  const { request, headers, env } = opts!;
 
   if (
     !(await verifyTurnstileToken({
@@ -93,8 +93,8 @@ export async function finishPasskeyRegistration(
   return true;
 }
 
-export async function startPasskeyLogin(ctx?: RouteOptions) {
-  const { headers, env } = ctx!;
+export async function startPasskeyLogin(opts?: HandlerOptions) {
+  const { headers, env } = opts!;
 
   const options = await generateAuthenticationOptions({
     rpID: env.RP_ID,
@@ -109,9 +109,9 @@ export async function startPasskeyLogin(ctx?: RouteOptions) {
 
 export async function finishPasskeyLogin(
   login: AuthenticationResponseJSON,
-  ctx?: RouteOptions,
+  opts?: HandlerOptions,
 ) {
-  const { request, headers, env } = ctx!;
+  const { request, headers, env } = opts!;
   const { origin } = new URL(request.url);
 
   const session = await sessions.load(request);

--- a/starters/sessions/src/app/pages/user/functions.ts
+++ b/starters/sessions/src/app/pages/user/functions.ts
@@ -1,9 +1,9 @@
 "use server";
 
 import { sessions } from "@/session/store";
-import { RouteContext } from "@redwoodjs/sdk/router";
+import { RouteOptions } from "@redwoodjs/sdk/router";
 
-export async function performLogin(ctx?: RouteContext) {
+export async function performLogin(ctx?: RouteOptions) {
   const { headers } = ctx!;
 
   // >>> Authentication logic for user goes here

--- a/starters/sessions/src/app/pages/user/functions.ts
+++ b/starters/sessions/src/app/pages/user/functions.ts
@@ -1,10 +1,10 @@
 "use server";
 
 import { sessions } from "@/session/store";
-import { RouteOptions } from "@redwoodjs/sdk/router";
+import { HandlerOptions } from "@redwoodjs/sdk/router";
 
-export async function performLogin(ctx?: RouteOptions) {
-  const { headers } = ctx!;
+export async function performLogin(opts?: HandlerOptions) {
+  const { headers } = opts!;
 
   // >>> Authentication logic for user goes here
   // >>> Replace this stub: e.g. get the user id from your database

--- a/starters/standard/src/app/pages/user/functions.ts
+++ b/starters/standard/src/app/pages/user/functions.ts
@@ -9,13 +9,13 @@ import {
 } from "@simplewebauthn/server";
 
 import { sessions } from "@/session/store";
-import { RouteContext } from "@redwoodjs/sdk/router";
+import { RouteOptions } from "@redwoodjs/sdk/router";
 import { db } from "@/db";
 import { verifyTurnstileToken } from "@redwoodjs/sdk/turnstile";
 
 export async function startPasskeyRegistration(
   username: string,
-  ctx?: RouteContext,
+  ctx?: RouteOptions,
 ) {
   const { headers, env } = ctx!;
 
@@ -40,7 +40,7 @@ export async function finishPasskeyRegistration(
   username: string,
   registration: RegistrationResponseJSON,
   turnstileToken: string,
-  ctx?: RouteContext,
+  ctx?: RouteOptions,
 ) {
   const { request, headers, env } = ctx!;
 
@@ -93,7 +93,7 @@ export async function finishPasskeyRegistration(
   return true;
 }
 
-export async function startPasskeyLogin(ctx?: RouteContext) {
+export async function startPasskeyLogin(ctx?: RouteOptions) {
   const { headers, env } = ctx!;
 
   const options = await generateAuthenticationOptions({
@@ -109,7 +109,7 @@ export async function startPasskeyLogin(ctx?: RouteContext) {
 
 export async function finishPasskeyLogin(
   login: AuthenticationResponseJSON,
-  ctx?: RouteContext,
+  ctx?: RouteOptions,
 ) {
   const { request, headers, env } = ctx!;
   const { origin } = new URL(request.url);

--- a/starters/standard/src/app/pages/user/functions.ts
+++ b/starters/standard/src/app/pages/user/functions.ts
@@ -9,15 +9,15 @@ import {
 } from "@simplewebauthn/server";
 
 import { sessions } from "@/session/store";
-import { RouteOptions } from "@redwoodjs/sdk/router";
+import { HandlerOptions } from "@redwoodjs/sdk/router";
 import { db } from "@/db";
 import { verifyTurnstileToken } from "@redwoodjs/sdk/turnstile";
 
 export async function startPasskeyRegistration(
   username: string,
-  ctx?: RouteOptions,
+  opts?: HandlerOptions,
 ) {
-  const { headers, env } = ctx!;
+  const { headers, env } = opts!;
 
   const options = await generateRegistrationOptions({
     rpName: env.APP_NAME,
@@ -40,9 +40,9 @@ export async function finishPasskeyRegistration(
   username: string,
   registration: RegistrationResponseJSON,
   turnstileToken: string,
-  ctx?: RouteOptions,
+  opts?: HandlerOptions,
 ) {
-  const { request, headers, env } = ctx!;
+  const { request, headers, env } = opts!;
 
   if (
     !(await verifyTurnstileToken({
@@ -93,8 +93,8 @@ export async function finishPasskeyRegistration(
   return true;
 }
 
-export async function startPasskeyLogin(ctx?: RouteOptions) {
-  const { headers, env } = ctx!;
+export async function startPasskeyLogin(opts?: HandlerOptions) {
+  const { headers, env } = opts!;
 
   const options = await generateAuthenticationOptions({
     rpID: env.RP_ID,
@@ -109,9 +109,9 @@ export async function startPasskeyLogin(ctx?: RouteOptions) {
 
 export async function finishPasskeyLogin(
   login: AuthenticationResponseJSON,
-  ctx?: RouteOptions,
+  opts?: HandlerOptions,
 ) {
-  const { request, headers, env } = ctx!;
+  const { request, headers, env } = opts!;
   const { origin } = new URL(request.url);
 
   const session = await sessions.load(request);


### PR DESCRIPTION
## Problem
Currently we call the properties we pass to routes `ctx: RouteContext`, but we also have a `ctx` key inside of it (for the user's own mutable context object). This means we have a `ctx.ctx` - this looks weird, and it is easy to mistake the one `ctx` for the other this way.

## Solution
Rename `ctx: RouteContext` to `opts: RouteOptions`:

```ts
const SomeComponent = (opts: RouteOptions) => {
  const { env, request, params } = opts
  ...
}
```


## ⚠️ Breaking Change
Any references to `RouteContext` in your app need to be renamed to RouteOptions`