### PR TITLE
fix: Set defaults for type params for router API methods

### DIFF
--- a/sdk/src/runtime/lib/router.ts
+++ b/sdk/src/runtime/lib/router.ts
@@ -228,7 +228,7 @@ export function defineRoutes<TContext = Record<string, any>>(
   };
 }
 
-export function route<TContext, TParams>(
+export function route<TContext = any, TParams = any>(
   path: string,
   handler: RouteHandler<TContext, TParams>,
 ): RouteDefinition<TContext, TParams> {
@@ -242,13 +242,13 @@ export function route<TContext, TParams>(
   };
 }
 
-export function index<TContext, TParams>(
+export function index<TContext = any, TParams = any>(
   handler: RouteHandler<TContext, TParams>,
 ): RouteDefinition<TContext, TParams> {
   return route("/", handler);
 }
 
-export function prefix<TContext, TParams>(
+export function prefix<TContext = any, TParams = any>(
   prefix: string,
   routes: ReturnType<typeof route<TContext, TParams>>[],
 ): RouteDefinition<TContext, TParams>[] {


### PR DESCRIPTION
## Problem
We use type params on our router API methods so that ts can infer the relevant types (e.g. context, params) for routes, based on their corresponding middleware or components.

It isn't always clear enough what types to infer though. For example, if routes arrays are defined without telling ts explicitly what the types are for the array. In the case below, when `authRoutes` is passed to `prefix()`, ts will take its type to be `RouteDefinition<unknown, unknown>[]`. `unknown` doesn't match to `Context`, causing type errors.

```ts
export const authRoutes = [route('/login', Login), route('/user/logout', () => {...}]

type Context = {...}

defineApp<Context>([
  prefix('/user', authRoutes)
])
```

## Solution
Default the values for type params to `any`. If ts is able to infer the types, they're sued instead of `any`, this is useful. If it isn't able to infer - we can't do much about this without explicit types (which we shouldn't require), so they now become` any` => at the very least valid usage won't fail typechecks