### PR TITLE
feat: Include CF exec context in RouteOptions

### DIFF
--- a/docs/src/content/docs/core/routing.mdx
+++ b/docs/src/content/docs/core/routing.mdx
@@ -101,7 +101,7 @@ The request handler function takes in the following options:
 2. `params`: The matched parameters from the request URL.
 3. `env`: The Cloudflare environment.
 4. `ctx`: The context object (See [Middleware & Context](#middleware-context)).
-5. Cloudflare's [Execution Context API](https://developers.cloudflare.com/workers/runtime-apis/context/) methods, e.g. `waitUntil()`
+5. `cf:` Cloudflare's [Execution Context API](https://developers.cloudflare.com/workers/runtime-apis/context/) methods, e.g. `waitUntil()`
 
 Return values:
 - `Response`: A standard response object.

--- a/docs/src/content/docs/core/routing.mdx
+++ b/docs/src/content/docs/core/routing.mdx
@@ -101,6 +101,7 @@ The request handler function takes in the following options:
 2. `params`: The matched parameters from the request URL.
 3. `env`: The Cloudflare environment.
 4. `ctx`: The context object (See [Middleware & Context](#middleware-context)).
+5. Cloudflare's [Execution Context API](https://developers.cloudflare.com/workers/runtime-apis/context/) methods, e.g. `waitUntil()`
 
 Return values:
 - `Response`: A standard response object.

--- a/sdk/src/runtime/lib/router.ts
+++ b/sdk/src/runtime/lib/router.ts
@@ -1,4 +1,5 @@
 import { isValidElementType } from "react-is";
+import { ExecutionContext } from "@cloudflare/workers-types";
 
 export type HandlerOptions<TContext = Record<string, any>> = {
   request: Request;
@@ -8,7 +9,10 @@ export type HandlerOptions<TContext = Record<string, any>> = {
   rw: RwContext<TContext>;
 };
 
-export type RouteOptions<TContext = Record<string, any>, TParams = any> = {
+export type RouteOptions<
+  TContext = Record<string, any>,
+  TParams = any,
+> = ExecutionContext & {
   request: Request;
   params: TParams;
   env: Env;

--- a/sdk/src/runtime/worker.tsx
+++ b/sdk/src/runtime/worker.tsx
@@ -26,7 +26,11 @@ declare global {
 
 export const defineApp = <Context,>(routes: Route<Context>[]) => {
   return {
-    fetch: async (request: Request, env: Env, _ctx: ExecutionContext) => {
+    fetch: async (
+      request: Request,
+      env: Env,
+      execContext: ExecutionContext,
+    ) => {
       globalThis.__webpack_require__ = ssrWebpackRequire;
 
       const router = defineRoutes(routes);
@@ -127,6 +131,7 @@ export const defineApp = <Context,>(routes: Route<Context>[]) => {
         const userHeaders = new Headers();
 
         const response = await router.handle({
+          ...execContext,
           request,
           headers: userHeaders,
           ctx: {} as Context,

--- a/sdk/src/runtime/worker.tsx
+++ b/sdk/src/runtime/worker.tsx
@@ -26,11 +26,7 @@ declare global {
 
 export const defineApp = <Context,>(routes: Route<Context>[]) => {
   return {
-    fetch: async (
-      request: Request,
-      env: Env,
-      execContext: ExecutionContext,
-    ) => {
+    fetch: async (request: Request, env: Env, cf: ExecutionContext) => {
       globalThis.__webpack_require__ = ssrWebpackRequire;
 
       const router = defineRoutes(routes);
@@ -131,7 +127,7 @@ export const defineApp = <Context,>(routes: Route<Context>[]) => {
         const userHeaders = new Headers();
 
         const response = await router.handle({
-          ...execContext,
+          cf,
           request,
           headers: userHeaders,
           ctx: {} as Context,


### PR DESCRIPTION
In addition to `request` and `env`, CF also provide `ctx`: https://developers.cloudflare.com/workers/runtime-apis/context/

This PR adds the API methods in CF's `ctx` (the "execution context") to our `RouteOptions`:

```ts
const app = defineApp([
  ({ request, env, cf }) => {
    cf.waitUntil()
  }
])
```