### PR TITLE
fix: typo

### DIFF
--- a/docs/src/content/docs/core/overview.mdx
+++ b/docs/src/content/docs/core/overview.mdx
@@ -3,7 +3,7 @@ title: Overview
 description: Things you need to know about RedwoodSDK
 ---
 
-RedwoodSDK is a full-stack web framework designed for web standards, TypeScript, Vite, and React Server Components. It give you the tools so that you can focus on the software that you want to build, rather than the infrastructure that you host it on.
+RedwoodSDK is a full-stack web framework designed for web standards, TypeScript, Vite, and React Server Components. It gives you the tools so that you can focus on the software that you want to build, rather than the infrastructure that you host it on.
 
 The documents below are what you need to understand to build a website with RedwoodSDK:
 


### PR DESCRIPTION
Added an s where needed. 

Although, a change to something like the following makes more sense to me:

> It gives you the tools to help you focus on the software you want to build rather than the infrastructure you host it on.
