### PR TITLE
fix: Hanging postinstalls (some more)

### DIFF
--- a/sdk/src/scripts/patchInspectorPort.mts
+++ b/sdk/src/scripts/patchInspectorPort.mts
@@ -10,6 +10,8 @@ const debug = baseDebug("rwsdk:patch-net");
 
 const originalListen = net.Server.prototype.listen;
 
+const inspectorServers: net.Server[] = [];
+
 net.Server.prototype.listen = function (...args: any[]) {
   if (typeof args[0] === "object" && args[0]?.port === 9229) {
     debug("Overriding port 9229 with 0 in object options");
@@ -19,5 +21,13 @@ net.Server.prototype.listen = function (...args: any[]) {
     args[0] = 0;
   }
 
+  inspectorServers.push(this);
   return originalListen.apply(this, args as any);
+};
+
+export const closeAllInspectorServers = async () => {
+  for (const server of inspectorServers) {
+    await new Promise((resolve) => server.close(resolve));
+  }
+  inspectorServers.length = 0;
 };

--- a/sdk/src/scripts/worker-run.mts
+++ b/sdk/src/scripts/worker-run.mts
@@ -1,4 +1,4 @@
-import "./patchInspectorPort.mjs";
+import { closeAllInspectorServers } from "./patchInspectorPort.mjs";
 import { resolve } from "path";
 import { writeFile } from "fs/promises";
 import { unstable_readConfig } from "wrangler";
@@ -82,10 +82,19 @@ export const runWorkerScript = async (relativeScriptPath: string) => {
       debug("Server closed");
     }
   } finally {
+    debug("Closing inspector servers...");
+    await closeAllInspectorServers();
+    debug("Inspector servers closed");
     debug("Cleaning up temporary files...");
     await tmpWorkerPath.cleanup();
     debug("Temporary files cleaned up");
   }
+
+  // context(justinvdm, 31 Mar 2024): The process may still hang due to open WebSocket
+  // clients and a live workerd child process (spawned internally by Miniflare).
+  // These handles are not exposed for manual cleanup, but are safe to abandon in our
+  // postinstall/CLI context. We explicitly call process.exit(0) to ensure reliable termination.
+  process.exit(0);
 };
 
 if (import.meta.url === new URL(process.argv[1], import.meta.url).href) {


### PR DESCRIPTION
## **Context**

We run our seed scripts using Miniflare (via Cloudflare's Vite plugin) to simulate a deployed Worker environment. These scripts are used in pnpm seed as well as in postinstall hooks across our starters to ensure D1 databases are correctly migrated and seeded.

Miniflare launches an inspector on port 9229 and internally spawns a workerd child process. We previously patched net.Server.prototype.listen to rewrite attempts to bind to 9229 so they instead use an OS-assigned port (0), resolving port conflicts during concurrent script execution.

## **Problem**

Despite resolving port conflicts, the process would still sometimes hang after completing its work. By inspecting process._getActiveHandles(), we identified two remaining sources of lingering activity:

-  **Open WebSocket clients**, likely created by Miniflare or the Vite plugin

-  A **live workerd child process** spawned by Miniflare

These are not visible or controllable from the outside, and remain attached to the event loop even after our scripts complete. As a result, pnpm install and other workflows that depend on clean script exit would hang indefinitely.

## **Solution**

To guarantee clean shutdown, we now explicitly call process.exit(0) after performing cleanup. This is safe in our context because:

-  The script has completed all intended work

-  The remaining handles are internal and non-critical

-  The child process is not detached and will be reaped by the OS

-  We are running in a short-lived CLI/postinstall context where lingering background activity is irrelevant

We also added logic to track and close any net.Server instances created during execution (e.g. WebSocket or inspector servers), ensuring they don't prolong the event loop unnecessarily. With these changes, installs complete reliably without hangs, even under concurrent or long-lived dev server conditions.