### PR TITLE
fix: `export default` cases for "use client"

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,7 @@ importers:
     dependencies:
       '@redwoodjs/sdk':
         specifier: 0.0.34
-        version: 0.0.34(@types/node@22.13.11)(kysely@0.27.5)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1))(rollup@4.34.8)(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250320.0)
+        version: 0.0.34(@types/node@22.13.11)(kysely@0.27.5)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1))(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
       react:
         specifier: 19.0.0-rc-f2df5694-20240916
         version: 19.0.0-rc-f2df5694-20240916
@@ -82,7 +82,7 @@ importers:
         version: 1.1.1(@types/react@18.3.18)(react@19.0.0-rc-f2df5694-20240916)
       '@redwoodjs/sdk':
         specifier: 0.0.34
-        version: 0.0.34(@types/node@22.13.11)(kysely@0.27.5)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1))(rollup@4.34.8)(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250320.0)
+        version: 0.0.34(@types/node@22.13.11)(kysely@0.27.5)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1))(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
       '@types/lodash':
         specifier: ^4.17.13
         version: 4.17.14
@@ -191,7 +191,7 @@ importers:
         version: 3.2.0(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)
       '@redwoodjs/sdk':
         specifier: 0.0.34
-        version: 0.0.34(@types/node@22.13.11)(kysely@0.27.5)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1(esbuild@0.24.2)))(rollup@4.34.8)(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250320.0)
+        version: 0.0.34(@types/node@22.13.11)(kysely@0.27.5)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1(esbuild@0.24.2)))(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.5.2)
@@ -267,7 +267,7 @@ importers:
         version: 6.4.1(prisma@6.4.1(typescript@5.7.3))(typescript@5.7.3)
       '@redwoodjs/sdk':
         specifier: 0.0.34
-        version: 0.0.34(@types/node@22.13.11)(kysely@0.27.5)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1(esbuild@0.24.2)))(rollup@4.34.8)(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250320.0)
+        version: 0.0.34(@types/node@22.13.11)(kysely@0.27.5)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1(esbuild@0.24.2)))(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
       '@simplewebauthn/browser':
         specifier: ^13.1.0
         version: 13.1.0
@@ -316,7 +316,7 @@ importers:
     dependencies:
       '@redwoodjs/sdk':
         specifier: 0.0.34
-        version: 0.0.34(@types/node@22.13.11)(kysely@0.27.5)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1))(rollup@4.34.8)(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250320.0)
+        version: 0.0.34(@types/node@22.13.11)(kysely@0.27.5)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1))(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
       react:
         specifier: 19.0.0-rc-f2df5694-20240916
         version: 19.0.0-rc-f2df5694-20240916
@@ -353,7 +353,7 @@ importers:
         version: 6.4.1(prisma@6.4.1(typescript@5.7.3))(typescript@5.7.3)
       '@redwoodjs/sdk':
         specifier: 0.0.34
-        version: 0.0.34(@types/node@22.13.11)(kysely@0.27.5)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1))(rollup@4.34.8)(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250320.0)
+        version: 0.0.34(@types/node@22.13.11)(kysely@0.27.5)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1))(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
       '@simplewebauthn/browser':
         specifier: ^13.1.0
         version: 13.1.0
@@ -502,6 +502,9 @@ importers:
       toml:
         specifier: ^3.0.0
         version: 3.0.0
+      ts-morph:
+        specifier: ^25.0.1
+        version: 25.0.1
       tsx:
         specifier: ^4.19.2
         version: 4.19.2
@@ -553,7 +556,7 @@ importers:
     dependencies:
       '@redwoodjs/sdk':
         specifier: 0.0.34
-        version: 0.0.34(@types/node@22.13.11)(kysely@0.27.5)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1(esbuild@0.19.12)))(rollup@4.34.8)(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250320.0)
+        version: 0.0.34(@types/node@22.13.11)(kysely@0.27.5)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1(esbuild@0.19.12)))(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
       dotenv:
         specifier: ^16.4.7
         version: 16.4.7
@@ -596,7 +599,7 @@ importers:
     dependencies:
       '@redwoodjs/sdk':
         specifier: 0.0.34
-        version: 0.0.34(@types/node@22.13.11)(kysely@0.27.5)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1))(rollup@4.34.8)(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250320.0)
+        version: 0.0.34(@types/node@22.13.11)(kysely@0.27.5)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1))(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
       react:
         specifier: 19.0.0-rc-f2df5694-20240916
         version: 19.0.0-rc-f2df5694-20240916
@@ -633,7 +636,7 @@ importers:
         version: 6.4.1(prisma@6.4.1(typescript@5.7.3))(typescript@5.7.3)
       '@redwoodjs/sdk':
         specifier: 0.0.34
-        version: 0.0.34(@types/node@22.13.11)(kysely@0.27.5)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1))(rollup@4.34.8)(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250320.0)
+        version: 0.0.34(@types/node@22.13.11)(kysely@0.27.5)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1))(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
       '@simplewebauthn/browser':
         specifier: ^13.1.0
         version: 13.1.0
@@ -679,7 +682,7 @@ importers:
         version: 6.4.1(prisma@6.4.1(typescript@5.7.3))(typescript@5.7.3)
       '@redwoodjs/sdk':
         specifier: 0.0.34
-        version: 0.0.34(@types/node@22.13.11)(kysely@0.27.5)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1))(rollup@4.34.8)(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250320.0)
+        version: 0.0.34(@types/node@22.13.11)(kysely@0.27.5)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1))(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
       react:
         specifier: 19.0.0-rc-f2df5694-20240916
         version: 19.0.0-rc-f2df5694-20240916
@@ -713,7 +716,7 @@ importers:
     dependencies:
       '@redwoodjs/sdk':
         specifier: 0.0.34
-        version: 0.0.34(@types/node@22.13.11)(kysely@0.27.5)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1))(rollup@4.34.8)(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250320.0)
+        version: 0.0.34(@types/node@22.13.11)(kysely@0.27.5)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1))(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
       react:
         specifier: 19.0.0-rc-f2df5694-20240916
         version: 19.0.0-rc-f2df5694-20240916
@@ -750,7 +753,7 @@ importers:
         version: 6.4.1(prisma@6.4.1(typescript@5.7.3))(typescript@5.7.3)
       '@redwoodjs/sdk':
         specifier: 0.0.34
-        version: 0.0.34(@types/node@22.13.11)(kysely@0.27.5)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1))(rollup@4.34.8)(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250320.0)
+        version: 0.0.34(@types/node@22.13.11)(kysely@0.27.5)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1))(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
       '@simplewebauthn/browser':
         specifier: ^13.1.0
         version: 13.1.0
@@ -3105,6 +3108,9 @@ packages:
   '@swc/types@0.1.17':
     resolution: {integrity: sha512-V5gRru+aD8YVyCOMAjMpWR1Ui577DD5KSJsHP8RAxopAH22jFz6GZd/qxqjO6MJHQhcsjvjOFXyDhyLQUnMveQ==}
 
+  '@ts-morph/common@0.26.1':
+    resolution: {integrity: sha512-Sn28TGl/4cFpcM+jwsH1wLncYq3FtN/BIpem+HOygfBWPT5pAeS5dB4VFVzV8FbnOKHpDLZmvAl4AjPEev5idA==}
+
   '@types/acorn@4.0.6':
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
 
@@ -3740,6 +3746,9 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  code-block-writer@13.0.3:
+    resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
 
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
@@ -6137,6 +6146,9 @@ packages:
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  ts-morph@25.0.1:
+    resolution: {integrity: sha512-QJEiTdnz1YjrB3JFhd626gX4rKHDLSjSVMvGGG4v7ONc3RBwa0Eei98G9AT9uNFDMtV54JyuXsFeC+OH0n6bXQ==}
 
   tsconfck@3.1.4:
     resolution: {integrity: sha512-kdqWFGVJqe+KGYvlSO9NIaWn9jT1Ny4oKVzAJsKii5eoE9snzTJzL4+MMVOMn+fikWGFmKEylcXL710V/kIPJQ==}
@@ -8550,7 +8562,7 @@ snapshots:
       react-dom: 19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916)
       react-promise-suspense: 0.3.4
 
-  '@redwoodjs/sdk@0.0.34(@types/node@22.13.11)(kysely@0.27.5)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1(esbuild@0.19.12)))(rollup@4.34.8)(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250320.0)':
+  '@redwoodjs/sdk@0.0.34(@types/node@22.13.11)(kysely@0.27.5)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1(esbuild@0.19.12)))(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))':
     dependencies:
       '@cloudflare/vite-plugin': 0.1.15(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250320.0)(wrangler@4.4.0(@cloudflare/workers-types@4.20250321.0))
       '@cloudflare/workers-types': 4.20250321.0
@@ -8618,7 +8630,7 @@ snapshots:
       - utf-8-validate
       - workerd
 
-  '@redwoodjs/sdk@0.0.34(@types/node@22.13.11)(kysely@0.27.5)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1(esbuild@0.24.2)))(rollup@4.34.8)(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250320.0)':
+  '@redwoodjs/sdk@0.0.34(@types/node@22.13.11)(kysely@0.27.5)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1(esbuild@0.24.2)))(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))':
     dependencies:
       '@cloudflare/vite-plugin': 0.1.15(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250320.0)(wrangler@4.4.0(@cloudflare/workers-types@4.20250321.0))
       '@cloudflare/workers-types': 4.20250321.0
@@ -8686,7 +8698,7 @@ snapshots:
       - utf-8-validate
       - workerd
 
-  '@redwoodjs/sdk@0.0.34(@types/node@22.13.11)(kysely@0.27.5)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1))(rollup@4.34.8)(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250320.0)':
+  '@redwoodjs/sdk@0.0.34(@types/node@22.13.11)(kysely@0.27.5)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1))(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))':
     dependencies:
       '@cloudflare/vite-plugin': 0.1.15(vite@6.2.0(@types/node@22.13.11)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250320.0)(wrangler@4.4.0(@cloudflare/workers-types@4.20250321.0))
       '@cloudflare/workers-types': 4.20250321.0
@@ -8995,6 +9007,12 @@ snapshots:
   '@swc/types@0.1.17':
     dependencies:
       '@swc/counter': 0.1.3
+
+  '@ts-morph/common@0.26.1':
+    dependencies:
+      fast-glob: 3.3.3
+      minimatch: 9.0.5
+      path-browserify: 1.0.1
 
   '@types/acorn@4.0.6':
     dependencies:
@@ -9818,6 +9836,8 @@ snapshots:
   cli-boxes@3.0.0: {}
 
   clsx@2.1.1: {}
+
+  code-block-writer@13.0.3: {}
 
   collapse-white-space@2.1.0: {}
 
@@ -12886,6 +12906,11 @@ snapshots:
   trough@2.2.0: {}
 
   ts-interface-checker@0.1.13: {}
+
+  ts-morph@25.0.1:
+    dependencies:
+      '@ts-morph/common': 0.26.1
+      code-block-writer: 13.0.3
 
   tsconfck@3.1.4(typescript@5.7.3):
     optionalDependencies:

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -107,6 +107,7 @@
     "tailwindcss": "^3.4.16",
     "tmp-promise": "^3.0.3",
     "toml": "^3.0.0",
+    "ts-morph": "^25.0.1",
     "tsx": "^4.19.2",
     "typescript": "^5.6.3",
     "vite-plugin-commonjs": "^0.10.4",

--- a/sdk/src/vite/useClientPlugin.mts
+++ b/sdk/src/vite/useClientPlugin.mts
@@ -43,6 +43,13 @@ export async function transformUseClientCode(
     },
   });
   const sourceFile = project.createSourceFile("temp.tsx", code);
+
+  // Add import declaration properly through the AST
+  sourceFile.addImportDeclaration({
+    moduleSpecifier: "@redwoodjs/sdk/worker",
+    namedImports: [{ name: "registerClientReference" }],
+  });
+
   const components = new Map<string, ComponentInfo>();
   let anonymousDefaultCount = 0;
 
@@ -202,12 +209,6 @@ export async function transformUseClientCode(
         node.remove();
       }
     });
-
-  // Add import at the top
-  sourceFile.addImportDeclaration({
-    moduleSpecifier: "@redwoodjs/sdk/worker",
-    namedImports: [{ name: "registerClientReference" }],
-  });
 
   // Add client references and exports
   components.forEach(

--- a/sdk/src/vite/useClientPlugin.mts
+++ b/sdk/src/vite/useClientPlugin.mts
@@ -24,6 +24,12 @@ interface ComponentInfo {
   isAnonymousDefault?: boolean;
 }
 
+function isJsxFunction(text: string): boolean {
+  return (
+    text.includes("jsx(") || text.includes("jsxs(") || text.includes("jsxDEV(")
+  );
+}
+
 export async function transformUseClientCode(
   code: string,
   relativeId: string,
@@ -63,7 +69,7 @@ export async function transformUseClientCode(
       if (!name) return;
 
       // Only track if it's a component (has JSX return)
-      if (node.getText().includes("jsx(") || node.getText().includes("jsxs(")) {
+      if (isJsxFunction(node.getText())) {
         const ssrName = `${name}SSR`;
         const isInlineExport = node.hasModifier(SyntaxKind.ExportKeyword);
 
@@ -96,10 +102,7 @@ export async function transformUseClientCode(
         if (!arrowFunc) return;
 
         // Only track if it's a component (has JSX return)
-        if (
-          arrowFunc.getText().includes("jsx(") ||
-          arrowFunc.getText().includes("jsxs(")
-        ) {
+        if (isJsxFunction(arrowFunc.getText())) {
           const name = varDecl.getName();
           const isDefault = !!statement.getFirstAncestorByKind(
             SyntaxKind.ExportAssignment,

--- a/sdk/src/vite/useClientPlugin.mts
+++ b/sdk/src/vite/useClientPlugin.mts
@@ -204,10 +204,10 @@ export async function transformUseClientCode(
     });
 
   // Add import at the top
-  sourceFile.insertStatements(
-    0,
-    `import { registerClientReference } from "@redwoodjs/sdk/worker";\n`,
-  );
+  sourceFile.addImportDeclaration({
+    moduleSpecifier: "@redwoodjs/sdk/worker",
+    namedImports: [{ name: "registerClientReference" }],
+  });
 
   // Add client references and exports
   components.forEach(

--- a/sdk/src/vite/useClientPlugin.test.mts
+++ b/sdk/src/vite/useClientPlugin.test.mts
@@ -337,11 +337,11 @@ export default () => {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-      const DefaultComponent0SSR = () => {
+      const defaultSSR = () => {
         return jsx('div', { children: 'Hello' });
       }
-      const DefaultComponent0 = registerClientReference("/test/file.tsx", "default", DefaultComponent0SSR);
-      export { DefaultComponent0SSR as default, DefaultComponent0 };"
+      const DefaultComponent0 = registerClientReference("/test/file.tsx", "default", defaultSSR);
+      export { DefaultComponent0 as default, defaultSSR };"
     `);
   });
 
@@ -354,11 +354,11 @@ export default async () => {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-      const DefaultComponent0SSR = async () => {
+      const defaultSSR = async () => {
         return jsx('div', { children: 'Hello' });
       }
-      const DefaultComponent0 = registerClientReference("/test/file.tsx", "default", DefaultComponent0SSR);
-      export { DefaultComponent0SSR as default, DefaultComponent0 };"
+      const DefaultComponent0 = registerClientReference("/test/file.tsx", "default", defaultSSR);
+      export { DefaultComponent0 as default, defaultSSR };"
     `);
   });
 
@@ -372,11 +372,11 @@ export default function Component({ prop1, prop2 }) {
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
 
-      export default function ComponentSSR({ prop1, prop2 }) {
+      function defaultSSR({ prop1, prop2 }) {
         return jsx('div', { children: 'Hello' });
       }
-      const Component = registerClientReference("/test/file.tsx", "default", ComponentSSR);
-      export { ComponentSSR as default, Component };"
+      const Component = registerClientReference("/test/file.tsx", "default", defaultSSR);
+      export { Component as default, defaultSSR };"
     `);
   });
 
@@ -390,11 +390,11 @@ export default async function Component() {
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
 
-      export default async function ComponentSSR() {
+      async function defaultSSR() {
         return jsx('div', { children: 'Hello' });
       }
-      const Component = registerClientReference("/test/file.tsx", "default", ComponentSSR);
-      export { ComponentSSR as default, Component };"
+      const Component = registerClientReference("/test/file.tsx", "default", defaultSSR);
+      export { Component as default, defaultSSR };"
     `);
   });
 
@@ -598,19 +598,19 @@ export { Fourth as AnotherName }`),
         return jsx('div', { children: 'Fourth' });
       }
 
-      export default function MainSSR() {
+      function defaultSSR() {
         return jsx('div', { children: 'Main' });
       }
 
       export { SecondSSR, ThirdSSR }
       export { FourthSSR as AnotherName }
       const Third = registerClientReference("/test/file.tsx", "Third", ThirdSSR);
-      const Main = registerClientReference("/test/file.tsx", "default", MainSSR);
+      const Main = registerClientReference("/test/file.tsx", "default", defaultSSR);
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
       const Fourth = registerClientReference("/test/file.tsx", "Fourth", FourthSSR);
       export { ThirdSSR, Third };
-      export { MainSSR as default, Main };
+      export { Main as default, defaultSSR };
       export { FirstSSR, First };
       export { SecondSSR, Second };
       export { FourthSSR, Fourth };"

--- a/sdk/src/vite/useClientPlugin.test.mts
+++ b/sdk/src/vite/useClientPlugin.test.mts
@@ -331,9 +331,11 @@ export default () => {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-      export default () => {
+      export default DefaultComponent0SSR
+      const DefaultComponent0SSR = () => {
         return jsx('div', { children: 'Hello' });
-      }"
+      }
+      const DefaultComponent0 = registerClientReference("/test/file.tsx", "default", DefaultComponent0SSR);"
     `);
   });
 
@@ -346,9 +348,11 @@ export default async () => {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-      export default async () => {
+      export default DefaultComponent0SSR
+      const DefaultComponent0SSR = async () => {
         return jsx('div', { children: 'Hello' });
-      }"
+      }
+      const DefaultComponent0 = registerClientReference("/test/file.tsx", "default", DefaultComponent0SSR);"
     `);
   });
 

--- a/sdk/src/vite/useClientPlugin.test.mts
+++ b/sdk/src/vite/useClientPlugin.test.mts
@@ -619,7 +619,8 @@ export { Fourth as AnotherName }`),
 
   it("transforms function declaration that is exported default separately", async () => {
     expect(
-      await transform(`"use client"
+      await transform(`
+"use client"
 
 function Component({ prop1, prop2 }) {
   return jsx('div', { children: 'Hello' });
@@ -635,6 +636,176 @@ export default Component;`),
 
       const Component = registerClientReference("/test/file.tsx", "default", ComponentSSR);
       export { Component as default, ComponentSSR };"
+    `);
+  });
+
+  it("Works in dev", async () => {
+    expect(
+      await transform(`"use client"
+import { jsxDEV } from "react/jsx-dev-runtime";
+import { sendMessage } from "./functions";
+import { useState } from "react";
+import { consumeEventStream } from "@redwoodjs/sdk/client";
+
+export function Chat() {
+  const [message, setMessage] = useState("");
+  const [reply, setReply] = useState("");
+  const onClick = async () => {
+    setReply("");
+    (await sendMessage(message)).pipeTo(
+      consumeEventStream({
+        onChunk: (event) => {
+          setReply(
+            (prev) => prev + (event.data === "[DONE]" ? "" : JSON.parse(event.data).response)
+          );
+        }
+      })
+    );
+  };
+  return /* @__PURE__ */ jsxDEV("div", { children: [
+    /* @__PURE__ */ jsxDEV(
+      "input",
+      {
+        type: "text",
+        value: message,
+        placeholder: "Type a message...",
+        onChange: (e) => setMessage(e.target.value),
+        style: {
+          width: "80%",
+          padding: "10px",
+          marginRight: "8px",
+          borderRadius: "4px",
+          border: "1px solid #ccc"
+        }
+      },
+      void 0,
+      false,
+      {
+        fileName: "/Users/justin/rw/sdk/experiments/ai-stream/src/app/pages/Chat/Chat.tsx",
+        lineNumber: 28,
+        columnNumber: 7
+      },
+      this
+    ),
+    /* @__PURE__ */ jsxDEV(
+      "button",
+      {
+        onClick,
+        style: {
+          padding: "10px 20px",
+          borderRadius: "4px",
+          border: "none",
+          backgroundColor: "#007bff",
+          color: "white",
+          cursor: "pointer"
+        },
+        children: "Send"
+      },
+      void 0,
+      false,
+      {
+        fileName: "/Users/justin/rw/sdk/experiments/ai-stream/src/app/pages/Chat/Chat.tsx",
+        lineNumber: 41,
+        columnNumber: 7
+      },
+      this
+    ),
+    /* @__PURE__ */ jsxDEV("div", { children: reply }, void 0, false, {
+      fileName: "/Users/justin/rw/sdk/experiments/ai-stream/src/app/pages/Chat/Chat.tsx",
+      lineNumber: 54,
+      columnNumber: 7
+    }, this)
+  ] }, void 0, true, {
+    fileName: "/Users/justin/rw/sdk/experiments/ai-stream/src/app/pages/Chat/Chat.tsx",
+    lineNumber: 27,
+    columnNumber: 5
+  }, this);
+}
+`),
+    ).toMatchInlineSnapshot(`
+      "import { jsxDEV } from "react/jsx-dev-runtime";
+      import { sendMessage } from "./functions";
+      import { useState } from "react";
+      import { consumeEventStream } from "@redwoodjs/sdk/client";
+      import { registerClientReference } from "@redwoodjs/sdk/worker";
+
+      function ChatSSR() {
+        const [message, setMessage] = useState("");
+        const [reply, setReply] = useState("");
+        const onClick = async () => {
+          setReply("");
+          (await sendMessage(message)).pipeTo(
+            consumeEventStream({
+              onChunk: (event) => {
+                setReply(
+                  (prev) => prev + (event.data === "[DONE]" ? "" : JSON.parse(event.data).response)
+                );
+              }
+            })
+          );
+        };
+        return /* @__PURE__ */ jsxDEV("div", { children: [
+          /* @__PURE__ */ jsxDEV(
+            "input",
+            {
+              type: "text",
+              value: message,
+              placeholder: "Type a message...",
+              onChange: (e) => setMessage(e.target.value),
+              style: {
+                width: "80%",
+                padding: "10px",
+                marginRight: "8px",
+                borderRadius: "4px",
+                border: "1px solid #ccc"
+              }
+            },
+            void 0,
+            false,
+            {
+              fileName: "/Users/justin/rw/sdk/experiments/ai-stream/src/app/pages/Chat/Chat.tsx",
+              lineNumber: 28,
+              columnNumber: 7
+            },
+            this
+          ),
+          /* @__PURE__ */ jsxDEV(
+            "button",
+            {
+              onClick,
+              style: {
+                padding: "10px 20px",
+                borderRadius: "4px",
+                border: "none",
+                backgroundColor: "#007bff",
+                color: "white",
+                cursor: "pointer"
+              },
+              children: "Send"
+            },
+            void 0,
+            false,
+            {
+              fileName: "/Users/justin/rw/sdk/experiments/ai-stream/src/app/pages/Chat/Chat.tsx",
+              lineNumber: 41,
+              columnNumber: 7
+            },
+            this
+          ),
+          /* @__PURE__ */ jsxDEV("div", { children: reply }, void 0, false, {
+            fileName: "/Users/justin/rw/sdk/experiments/ai-stream/src/app/pages/Chat/Chat.tsx",
+            lineNumber: 54,
+            columnNumber: 7
+          }, this)
+        ] }, void 0, true, {
+          fileName: "/Users/justin/rw/sdk/experiments/ai-stream/src/app/pages/Chat/Chat.tsx",
+          lineNumber: 27,
+          columnNumber: 5
+        }, this);
+      }
+      const Chat = registerClientReference("/test/file.tsx", "Chat", ChatSSR);
+      export { ChatSSR, Chat };
+      "
     `);
   });
 });

--- a/sdk/src/vite/useClientPlugin.test.mts
+++ b/sdk/src/vite/useClientPlugin.test.mts
@@ -16,6 +16,7 @@ export const Component = () => {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
       const ComponentSSR = () => {
         return jsx('div', { children: 'Hello' });
       }
@@ -33,6 +34,7 @@ export const baz = 23
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
       export const foo = "bar"
       export const baz = 23
       }"
@@ -48,6 +50,7 @@ export const Component = async () => {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
       const ComponentSSR = async () => {
         return jsx('div', { children: 'Hello' });
       }
@@ -65,6 +68,7 @@ export function Component() {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
       function ComponentSSR() {
         return jsx('div', { children: 'Hello' });
       }
@@ -82,6 +86,7 @@ export async function Component() {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
       async function ComponentSSR() {
         return jsx('div', { children: 'Hello' });
       }
@@ -103,6 +108,7 @@ export const Second = () => {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
       const FirstSSR = () => {
         return jsx('div', { children: 'First' });
       }
@@ -130,6 +136,7 @@ export const Second = async () => {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
       const FirstSSR = async () => {
         return jsx('div', { children: 'First' });
       }
@@ -157,6 +164,7 @@ export function Second() {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
       function FirstSSR() {
         return jsx('div', { children: 'First' });
       }
@@ -184,6 +192,7 @@ export async function Second() {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
       async function FirstSSR() {
         return jsx('div', { children: 'First' });
       }
@@ -213,6 +222,7 @@ const Second = () => {
 export { First, Second }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
       const FirstSSR = () => {
         return jsx('div', { children: 'First' });
       }
@@ -244,6 +254,7 @@ const Second = async () => {
 export { First, Second }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
       const FirstSSR = async () => {
         return jsx('div', { children: 'First' });
       }
@@ -275,6 +286,7 @@ function Second() {
 export { First, Second }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
       function FirstSSR() {
         return jsx('div', { children: 'First' });
       }
@@ -306,6 +318,7 @@ async function Second() {
 export { First, Second }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
       async function FirstSSR() {
         return jsx('div', { children: 'First' });
       }
@@ -331,6 +344,7 @@ export default () => {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
       export default DefaultComponent0SSR
       const DefaultComponent0SSR = () => {
         return jsx('div', { children: 'Hello' });
@@ -348,6 +362,7 @@ export default async () => {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
       export default DefaultComponent0SSR
       const DefaultComponent0SSR = async () => {
         return jsx('div', { children: 'Hello' });
@@ -365,6 +380,7 @@ export default function Component({ prop1, prop2 }) {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
       export default function ComponentSSR({ prop1, prop2 }) {
         return jsx('div', { children: 'Hello' });
       }
@@ -382,6 +398,7 @@ export default async function Component() {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
       export default async function ComponentSSR() {
         return jsx('div', { children: 'Hello' });
       }
@@ -468,6 +485,7 @@ export function ComplexComponent({ initialCount = 0 }) {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
       function ComplexComponentSSR({ initialCount = 0 }) {
         const [count, setCount] = useState(initialCount);
         const [items, setItems] = useState([]);
@@ -573,6 +591,7 @@ export { Second, Third }
 export { Fourth as AnotherName }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
       const FirstSSR = () => {
         return jsx('div', { children: 'First' });
       }
@@ -619,6 +638,7 @@ function Component({ prop1, prop2 }) {
 export default Component;`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
       function ComponentSSR({ prop1, prop2 }) {
         return jsx('div', { children: 'Hello' });
       }

--- a/sdk/src/vite/useClientPlugin.test.mts
+++ b/sdk/src/vite/useClientPlugin.test.mts
@@ -683,4 +683,24 @@ export { Fourth as AnotherName }`),
       "
     `);
   });
+
+  it("transforms function declaration that is exported default separately", async () => {
+    expect(
+      await transform(`"use client"
+
+function Component({ prop1, prop2 }) {
+  return jsx('div', { children: 'Hello' });
+}
+
+export default Component;`),
+    ).toMatchInlineSnapshot(`
+      "
+      import { registerClientReference } from "@redwoodjs/sdk/worker";
+      function Component({ prop1, prop2 }) {
+        return jsx('div', { children: 'Hello' });
+      }
+
+      export default Component;"
+    `);
+  });
 });

--- a/sdk/src/vite/useClientPlugin.test.mts
+++ b/sdk/src/vite/useClientPlugin.test.mts
@@ -15,17 +15,33 @@ export const Component = () => {
   return jsx('div', { children: 'Hello' });
 }`),
     ).toMatchInlineSnapshot(`
-      "
-      import { registerClientReference } from "@redwoodjs/sdk/worker";
-      export const ComponentSSR = () => {
+      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
+
+
+      const Component = () => {
         return jsx('div', { children: 'Hello' });
       }
-
-      // >>> Client references
       const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
+      export { ComponentSSR, Component };"
+    `);
+  });
 
-      export { Component };
-      "
+  it("does nothing for irrelevant exports", async () => {
+    expect(
+      await transform(`"use client"
+
+export const foo = "bar"
+export const baz = 23
+}`),
+    ).toMatchInlineSnapshot(`
+      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
+
+
+      export const foo = "bar"
+      export const baz = 23
+      }"
     `);
   });
 
@@ -37,17 +53,15 @@ export const Component = async () => {
   return jsx('div', { children: 'Hello' });
 }`),
     ).toMatchInlineSnapshot(`
-      "
-      import { registerClientReference } from "@redwoodjs/sdk/worker";
-      export const ComponentSSR = async () => {
+      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
+
+
+      const Component = async () => {
         return jsx('div', { children: 'Hello' });
       }
-
-      // >>> Client references
       const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
-
-      export { Component };
-      "
+      export { ComponentSSR, Component };"
     `);
   });
 
@@ -59,17 +73,15 @@ export function Component() {
   return jsx('div', { children: 'Hello' });
 }`),
     ).toMatchInlineSnapshot(`
-      "
-      import { registerClientReference } from "@redwoodjs/sdk/worker";
-      export function ComponentSSR() {
+      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
+
+
+      function Component() {
         return jsx('div', { children: 'Hello' });
       }
-
-      // >>> Client references
       const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
-
-      export { Component };
-      "
+      export { ComponentSSR, Component };"
     `);
   });
 
@@ -81,17 +93,15 @@ export async function Component() {
   return jsx('div', { children: 'Hello' });
 }`),
     ).toMatchInlineSnapshot(`
-      "
-      import { registerClientReference } from "@redwoodjs/sdk/worker";
-      export async function ComponentSSR() {
+      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
+
+
+      function Component() {
         return jsx('div', { children: 'Hello' });
       }
-
-      // >>> Client references
       const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
-
-      export { Component };
-      "
+      export { ComponentSSR, Component };"
     `);
   });
 
@@ -107,22 +117,21 @@ export const Second = () => {
   return jsx('div', { children: 'Second' });
 }`),
     ).toMatchInlineSnapshot(`
-      "
-      import { registerClientReference } from "@redwoodjs/sdk/worker";
-      export const FirstSSR = () => {
+      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
+
+
+      const First = () => {
         return jsx('div', { children: 'First' });
       }
 
-      export const SecondSSR = () => {
+      expst Second = () => {
         return jsx('div', { children: 'Second' });
       }
-
-      // >>> Client references
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
+      export { FirstSSR, First };
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-
-      export { First, Second };
-      "
+      export { SecondSSR, Second };"
     `);
   });
 
@@ -138,22 +147,21 @@ export const Second = async () => {
   return jsx('div', { children: 'Second' });
 }`),
     ).toMatchInlineSnapshot(`
-      "
-      import { registerClientReference } from "@redwoodjs/sdk/worker";
-      export const FirstSSR = async () => {
+      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
+
+
+      const First = async () => {
         return jsx('div', { children: 'First' });
       }
 
-      export const SecondSSR = async () => {
+      expst Second = async () => {
         return jsx('div', { children: 'Second' });
       }
-
-      // >>> Client references
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
+      export { FirstSSR, First };
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-
-      export { First, Second };
-      "
+      export { SecondSSR, Second };"
     `);
   });
 
@@ -169,22 +177,21 @@ export function Second() {
   return jsx('div', { children: 'Second' });
 }`),
     ).toMatchInlineSnapshot(`
-      "
-      import { registerClientReference } from "@redwoodjs/sdk/worker";
-      export function FirstSSR() {
+      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
+
+
+      function First() {
         return jsx('div', { children: 'First' });
       }
 
-      export function SecondSSR() {
+      expction Second() {
         return jsx('div', { children: 'Second' });
       }
-
-      // >>> Client references
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
+      export { FirstSSR, First };
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-
-      export { First, Second };
-      "
+      export { SecondSSR, Second };"
     `);
   });
 
@@ -200,22 +207,21 @@ export async function Second() {
   return jsx('div', { children: 'Second' });
 }`),
     ).toMatchInlineSnapshot(`
-      "
-      import { registerClientReference } from "@redwoodjs/sdk/worker";
-      export async function FirstSSR() {
+      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
+
+
+      function First() {
         return jsx('div', { children: 'First' });
       }
 
-      export async function SecondSSR() {
+      expction Second() {
         return jsx('div', { children: 'Second' });
       }
-
-      // >>> Client references
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
+      export { FirstSSR, First };
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-
-      export { First, Second };
-      "
+      export { SecondSSR, Second };"
     `);
   });
 
@@ -233,26 +239,23 @@ const Second = () => {
 
 export { First, Second }`),
     ).toMatchInlineSnapshot(`
-      "
-      import { registerClientReference } from "@redwoodjs/sdk/worker";
-      const FirstSSR = () => {
+      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
+
+
+      const First = () => {
         return jsx('div', { children: 'First' });
       }
 
-      const SecondSSR = () => {
+      const Second = () => {
         return jsx('div', { children: 'Second' });
       }
 
-
-
-      // >>> Client references
+      export { First, Second }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
+      export { FirstSSR, First };
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-
-      export { FirstSSR, SecondSSR };
-
-      export { First, Second };
-      "
+      export { SecondSSR, Second };"
     `);
   });
 
@@ -270,26 +273,23 @@ const Second = async () => {
 
 export { First, Second }`),
     ).toMatchInlineSnapshot(`
-      "
-      import { registerClientReference } from "@redwoodjs/sdk/worker";
-      const FirstSSR = async () => {
+      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
+
+
+      const First = async () => {
         return jsx('div', { children: 'First' });
       }
 
-      const SecondSSR = async () => {
+      const Second = async () => {
         return jsx('div', { children: 'Second' });
       }
 
-
-
-      // >>> Client references
+      export { First, Second }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
+      export { FirstSSR, First };
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-
-      export { FirstSSR, SecondSSR };
-
-      export { First, Second };
-      "
+      export { SecondSSR, Second };"
     `);
   });
 
@@ -307,26 +307,23 @@ function Second() {
 
 export { First, Second }`),
     ).toMatchInlineSnapshot(`
-      "
-      import { registerClientReference } from "@redwoodjs/sdk/worker";
-      function FirstSSR() {
+      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
+
+
+      function First() {
         return jsx('div', { children: 'First' });
       }
 
-      function SecondSSR() {
+      function Second() {
         return jsx('div', { children: 'Second' });
       }
 
-
-
-      // >>> Client references
+      export { First, Second }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
+      export { FirstSSR, First };
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-
-      export { FirstSSR, SecondSSR };
-
-      export { First, Second };
-      "
+      export { SecondSSR, Second };"
     `);
   });
 
@@ -344,26 +341,23 @@ async function Second() {
 
 export { First, Second }`),
     ).toMatchInlineSnapshot(`
-      "
-      import { registerClientReference } from "@redwoodjs/sdk/worker";
-      async function FirstSSR() {
+      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
+
+
+      function First() {
         return jsx('div', { children: 'First' });
       }
 
-      async function SecondSSR() {
+      asyction Second() {
         return jsx('div', { children: 'Second' });
       }
 
-
-
-      // >>> Client references
+      export { First, Second }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
+      export { FirstSSR, First };
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-
-      export { FirstSSR, SecondSSR };
-
-      export { First, Second };
-      "
+      export { SecondSSR, Second };"
     `);
   });
 
@@ -375,16 +369,12 @@ export default () => {
   return jsx('div', { children: 'Hello' });
 }`),
     ).toMatchInlineSnapshot(`
-      "
-      import { registerClientReference } from "@redwoodjs/sdk/worker";
-      function AnonymousComponent0SSR()  {
-        return jsx('div', { children: 'Hello' })
+      "import { registerClientReference } from "@redwoodjs/sdk/worker";
 
-      // >>> Client references
-      const AnonymousComponent0 = registerClientReference("/test/file.tsx", "AnonymousComponent0", AnonymousComponent0SSR);
 
-      export { AnonymousComponent0SSR };
-      export { AnonymousComponent0 as default };;
+
+      export default () => {
+        return jsx('div', { children: 'Hello' });
       }"
     `);
   });
@@ -397,16 +387,12 @@ export default async () => {
   return jsx('div', { children: 'Hello' });
 }`),
     ).toMatchInlineSnapshot(`
-      "
-      import { registerClientReference } from "@redwoodjs/sdk/worker";
-      async function AnonymousComponent0SSR()  {
-        return jsx('div', { children: 'Hello' })
+      "import { registerClientReference } from "@redwoodjs/sdk/worker";
 
-      // >>> Client references
-      const AnonymousComponent0 = registerClientReference("/test/file.tsx", "AnonymousComponent0", AnonymousComponent0SSR);
 
-      export { AnonymousComponent0SSR };
-      export { AnonymousComponent0 as default };;
+
+      export default async () => {
+        return jsx('div', { children: 'Hello' });
       }"
     `);
   });
@@ -419,18 +405,15 @@ export default function Component({ prop1, prop2 }) {
   return jsx('div', { children: 'Hello' });
 }`),
     ).toMatchInlineSnapshot(`
-      "
-      import { registerClientReference } from "@redwoodjs/sdk/worker";
-      function ComponentSSR({ prop1, prop2 }){
+      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
+
+
+      function Component({ prop1, prop2 }) {
         return jsx('div', { children: 'Hello' });
       }
-
-      // >>> Client references
       const Component = registerClientReference("/test/file.tsx", "default", ComponentSSR);
-
-      export { ComponentSSR };
-      export { Component as default };
-      "
+      export default ComponentSSR;"
     `);
   });
 
@@ -442,18 +425,15 @@ export default async function Component() {
   return jsx('div', { children: 'Hello' });
 }`),
     ).toMatchInlineSnapshot(`
-      "
-      import { registerClientReference } from "@redwoodjs/sdk/worker";
-      async function ComponentSSR(){
+      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
+
+
+      function Component() {
         return jsx('div', { children: 'Hello' });
       }
-
-      // >>> Client references
       const Component = registerClientReference("/test/file.tsx", "default", ComponentSSR);
-
-      export { ComponentSSR };
-      export { Component as default };
-      "
+      export default ComponentSSR;"
     `);
   });
 
@@ -534,9 +514,11 @@ export function ComplexComponent({ initialCount = 0 }) {
   });
 }`),
     ).toMatchInlineSnapshot(`
-      "
-      import { registerClientReference } from "@redwoodjs/sdk/worker";
-      export function ComplexComponentSSR({ initialCount = 0 }) {
+      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
+
+
+      function ComplexComponent({ initialCount = 0 }) {
         const [count, setCount] = useState(initialCount);
         const [items, setItems] = useState([]);
         const doubledCount = useMemo(() => count * 2, [count]);
@@ -608,12 +590,8 @@ export function ComplexComponent({ initialCount = 0 }) {
           ]
         });
       }
-
-      // >>> Client references
       const ComplexComponent = registerClientReference("/test/file.tsx", "ComplexComponent", ComplexComponentSSR);
-
-      export { ComplexComponent };
-      "
+      export { ComplexComponentSSR, ComplexComponent };"
     `);
   });
 
@@ -644,43 +622,42 @@ export default function Main() {
 export { Second, Third }
 export { Fourth as AnotherName }`),
     ).toMatchInlineSnapshot(`
-      "
-      import { registerClientReference } from "@redwoodjs/sdk/worker";
-      export const FirstSSR = () => {
+      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
+
+
+      const First = () => {
         return jsx('div', { children: 'First' });
       }
 
-      const SecondSSR = () => {
+      const Second = () => {
         return jsx('div', { children: 'Second' });
       }
 
-      function ThirdSSR() {
+      function Third() {
         return jsx('div', { children: 'Third' });
       }
 
-      const FourthSSR = () => {
+      const Fourth = () => {
         return jsx('div', { children: 'Fourth' });
       }
 
-      function MainSSR(){
+      export defaun() {
         return jsx('div', { children: 'Main' });
       }
 
-
-
-
-      // >>> Client references
-      const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
-      const Main = registerClientReference("/test/file.tsx", "default", MainSSR);
-      const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
+      export { Second, Third }
+      export { Fourth as AnotherName }
       const Third = registerClientReference("/test/file.tsx", "Third", ThirdSSR);
-      const Fourth = registerClientReference("/test/file.tsx", "AnotherName", FourthSSR);
-
-      export { MainSSR, SecondSSR, ThirdSSR, FourthSSR };
-
-      export { First, Second, Third, Fourth as AnotherName };
-      export { Main as default };
-      "
+      export { ThirdSSR, Third };
+      const Main = registerClientReference("/test/file.tsx", "default", MainSSR);
+      export default MainSSR;
+      const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
+      export { FirstSSR, First };
+      const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
+      export { SecondSSR, Second };
+      const Fourth = registerClientReference("/test/file.tsx", "Fourth", FourthSSR);
+      export { FourthSSR, Fourth };"
     `);
   });
 
@@ -694,18 +671,17 @@ function Component({ prop1, prop2 }) {
 
 export default Component;`),
     ).toMatchInlineSnapshot(`
-      "
-      import { registerClientReference } from "@redwoodjs/sdk/worker";
+      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
+
+
       function Component({ prop1, prop2 }) {
         return jsx('div', { children: 'Hello' });
       }
 
-
-      // >>> Client references
-      const Component = registerClientReference("/test/file.tsx", "default", ComponentSSR);
-
-      export { ComponentSSR };
-      export { Component as default };"
+      export default Component;
+      const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
+      export { ComponentSSR, Component };"
     `);
   });
 });

--- a/sdk/src/vite/useClientPlugin.test.mts
+++ b/sdk/src/vite/useClientPlugin.test.mts
@@ -337,11 +337,11 @@ export default () => {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-      const defaultSSR = () => {
+      const DefaultComponent0SSR = () => {
         return jsx('div', { children: 'Hello' });
       }
-      const DefaultComponent0 = registerClientReference("/test/file.tsx", "default", defaultSSR);
-      export { DefaultComponent0 as default, defaultSSR };"
+      const DefaultComponent0 = registerClientReference("/test/file.tsx", "default", DefaultComponent0SSR);
+      export { DefaultComponent0 as default, DefaultComponent0SSR };"
     `);
   });
 
@@ -354,11 +354,11 @@ export default async () => {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-      const defaultSSR = async () => {
+      const DefaultComponent0SSR = async () => {
         return jsx('div', { children: 'Hello' });
       }
-      const DefaultComponent0 = registerClientReference("/test/file.tsx", "default", defaultSSR);
-      export { DefaultComponent0 as default, defaultSSR };"
+      const DefaultComponent0 = registerClientReference("/test/file.tsx", "default", DefaultComponent0SSR);
+      export { DefaultComponent0 as default, DefaultComponent0SSR };"
     `);
   });
 
@@ -372,11 +372,11 @@ export default function Component({ prop1, prop2 }) {
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
 
-      function defaultSSR({ prop1, prop2 }) {
+      function ComponentSSR({ prop1, prop2 }) {
         return jsx('div', { children: 'Hello' });
       }
-      const Component = registerClientReference("/test/file.tsx", "default", defaultSSR);
-      export { Component as default, defaultSSR };"
+      const Component = registerClientReference("/test/file.tsx", "default", ComponentSSR);
+      export { Component as default, ComponentSSR };"
     `);
   });
 
@@ -390,11 +390,11 @@ export default async function Component() {
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
 
-      async function defaultSSR() {
+      async function ComponentSSR() {
         return jsx('div', { children: 'Hello' });
       }
-      const Component = registerClientReference("/test/file.tsx", "default", defaultSSR);
-      export { Component as default, defaultSSR };"
+      const Component = registerClientReference("/test/file.tsx", "default", ComponentSSR);
+      export { Component as default, ComponentSSR };"
     `);
   });
 
@@ -598,19 +598,19 @@ export { Fourth as AnotherName }`),
         return jsx('div', { children: 'Fourth' });
       }
 
-      function defaultSSR() {
+      function MainSSR() {
         return jsx('div', { children: 'Main' });
       }
 
       export { SecondSSR, ThirdSSR }
       export { FourthSSR as AnotherName }
       const Third = registerClientReference("/test/file.tsx", "Third", ThirdSSR);
-      const Main = registerClientReference("/test/file.tsx", "default", defaultSSR);
+      const Main = registerClientReference("/test/file.tsx", "default", MainSSR);
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
       const Fourth = registerClientReference("/test/file.tsx", "Fourth", FourthSSR);
       export { ThirdSSR, Third };
-      export { Main as default, defaultSSR };
+      export { Main as default, MainSSR };
       export { FirstSSR, First };
       export { SecondSSR, Second };
       export { FourthSSR, Fourth };"
@@ -633,9 +633,8 @@ export default Component;`),
         return jsx('div', { children: 'Hello' });
       }
 
-      export default ComponentSSR;
-      const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
-      export { ComponentSSR, Component };"
+      const Component = registerClientReference("/test/file.tsx", "default", ComponentSSR);
+      export { Component as default, ComponentSSR };"
     `);
   });
 });

--- a/sdk/src/vite/useClientPlugin.test.mts
+++ b/sdk/src/vite/useClientPlugin.test.mts
@@ -16,10 +16,7 @@ export const Component = () => {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
-
-
-      const Component = () => {
+      const ComponentSSR = () => {
         return jsx('div', { children: 'Hello' });
       }
       const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
@@ -36,9 +33,6 @@ export const baz = 23
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
-
-
       export const foo = "bar"
       export const baz = 23
       }"
@@ -54,10 +48,7 @@ export const Component = async () => {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
-
-
-      const Component = async () => {
+      const ComponentSSR = async () => {
         return jsx('div', { children: 'Hello' });
       }
       const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
@@ -74,10 +65,7 @@ export function Component() {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
-
-
-      function Component() {
+      function ComponentSSR() {
         return jsx('div', { children: 'Hello' });
       }
       const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
@@ -94,10 +82,7 @@ export async function Component() {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
-
-
-      function Component() {
+      async function ComponentSSR() {
         return jsx('div', { children: 'Hello' });
       }
       const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
@@ -118,14 +103,11 @@ export const Second = () => {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
-
-
-      const First = () => {
+      const FirstSSR = () => {
         return jsx('div', { children: 'First' });
       }
 
-      expst Second = () => {
+      const SecondSSR = () => {
         return jsx('div', { children: 'Second' });
       }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
@@ -148,14 +130,11 @@ export const Second = async () => {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
-
-
-      const First = async () => {
+      const FirstSSR = async () => {
         return jsx('div', { children: 'First' });
       }
 
-      expst Second = async () => {
+      const SecondSSR = async () => {
         return jsx('div', { children: 'Second' });
       }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
@@ -178,14 +157,11 @@ export function Second() {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
-
-
-      function First() {
+      function FirstSSR() {
         return jsx('div', { children: 'First' });
       }
 
-      expction Second() {
+      function SecondSSR() {
         return jsx('div', { children: 'Second' });
       }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
@@ -208,14 +184,11 @@ export async function Second() {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
-
-
-      function First() {
+      async function FirstSSR() {
         return jsx('div', { children: 'First' });
       }
 
-      expction Second() {
+      async function SecondSSR() {
         return jsx('div', { children: 'Second' });
       }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
@@ -240,18 +213,15 @@ const Second = () => {
 export { First, Second }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
-
-
-      const First = () => {
+      const FirstSSR = () => {
         return jsx('div', { children: 'First' });
       }
 
-      const Second = () => {
+      const SecondSSR = () => {
         return jsx('div', { children: 'Second' });
       }
 
-      export { First, Second }
+      export { FirstSSR, SecondSSR }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
       export { FirstSSR, First };
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
@@ -274,18 +244,15 @@ const Second = async () => {
 export { First, Second }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
-
-
-      const First = async () => {
+      const FirstSSR = async () => {
         return jsx('div', { children: 'First' });
       }
 
-      const Second = async () => {
+      const SecondSSR = async () => {
         return jsx('div', { children: 'Second' });
       }
 
-      export { First, Second }
+      export { FirstSSR, SecondSSR }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
       export { FirstSSR, First };
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
@@ -308,18 +275,15 @@ function Second() {
 export { First, Second }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
-
-
-      function First() {
+      function FirstSSR() {
         return jsx('div', { children: 'First' });
       }
 
-      function Second() {
+      function SecondSSR() {
         return jsx('div', { children: 'Second' });
       }
 
-      export { First, Second }
+      export { FirstSSR, SecondSSR }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
       export { FirstSSR, First };
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
@@ -342,18 +306,15 @@ async function Second() {
 export { First, Second }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
-
-
-      function First() {
+      async function FirstSSR() {
         return jsx('div', { children: 'First' });
       }
 
-      asyction Second() {
+      async function SecondSSR() {
         return jsx('div', { children: 'Second' });
       }
 
-      export { First, Second }
+      export { FirstSSR, SecondSSR }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
       export { FirstSSR, First };
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
@@ -370,9 +331,6 @@ export default () => {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
-
-
       export default () => {
         return jsx('div', { children: 'Hello' });
       }"
@@ -388,9 +346,6 @@ export default async () => {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
-
-
       export default async () => {
         return jsx('div', { children: 'Hello' });
       }"
@@ -406,10 +361,7 @@ export default function Component({ prop1, prop2 }) {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
-
-
-      function Component({ prop1, prop2 }) {
+      export default function ComponentSSR({ prop1, prop2 }) {
         return jsx('div', { children: 'Hello' });
       }
       const Component = registerClientReference("/test/file.tsx", "default", ComponentSSR);
@@ -426,10 +378,7 @@ export default async function Component() {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
-
-
-      function Component() {
+      export default async function ComponentSSR() {
         return jsx('div', { children: 'Hello' });
       }
       const Component = registerClientReference("/test/file.tsx", "default", ComponentSSR);
@@ -515,10 +464,7 @@ export function ComplexComponent({ initialCount = 0 }) {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
-
-
-      function ComplexComponent({ initialCount = 0 }) {
+      function ComplexComponentSSR({ initialCount = 0 }) {
         const [count, setCount] = useState(initialCount);
         const [items, setItems] = useState([]);
         const doubledCount = useMemo(() => count * 2, [count]);
@@ -623,31 +569,28 @@ export { Second, Third }
 export { Fourth as AnotherName }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
-
-
-      const First = () => {
+      const FirstSSR = () => {
         return jsx('div', { children: 'First' });
       }
 
-      const Second = () => {
+      const SecondSSR = () => {
         return jsx('div', { children: 'Second' });
       }
 
-      function Third() {
+      function ThirdSSR() {
         return jsx('div', { children: 'Third' });
       }
 
-      const Fourth = () => {
+      const FourthSSR = () => {
         return jsx('div', { children: 'Fourth' });
       }
 
-      export defaun() {
+      export default function MainSSR() {
         return jsx('div', { children: 'Main' });
       }
 
-      export { Second, Third }
-      export { Fourth as AnotherName }
+      export { SecondSSR, ThirdSSR }
+      export { FourthSSR as AnotherName }
       const Third = registerClientReference("/test/file.tsx", "Third", ThirdSSR);
       export { ThirdSSR, Third };
       const Main = registerClientReference("/test/file.tsx", "default", MainSSR);
@@ -672,14 +615,11 @@ function Component({ prop1, prop2 }) {
 export default Component;`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
-
-
-      function Component({ prop1, prop2 }) {
+      function ComponentSSR({ prop1, prop2 }) {
         return jsx('div', { children: 'Hello' });
       }
 
-      export default Component;
+      export default ComponentSSR;
       const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
       export { ComponentSSR, Component };"
     `);

--- a/sdk/src/vite/useClientPlugin.test.mts
+++ b/sdk/src/vite/useClientPlugin.test.mts
@@ -113,8 +113,8 @@ export const Second = () => {
         return jsx('div', { children: 'Second' });
       }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
-      export { FirstSSR, First };
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
+      export { FirstSSR, First };
       export { SecondSSR, Second };"
     `);
   });
@@ -140,8 +140,8 @@ export const Second = async () => {
         return jsx('div', { children: 'Second' });
       }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
-      export { FirstSSR, First };
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
+      export { FirstSSR, First };
       export { SecondSSR, Second };"
     `);
   });
@@ -168,8 +168,8 @@ export function Second() {
         return jsx('div', { children: 'Second' });
       }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
-      export { FirstSSR, First };
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
+      export { FirstSSR, First };
       export { SecondSSR, Second };"
     `);
   });
@@ -196,8 +196,8 @@ export async function Second() {
         return jsx('div', { children: 'Second' });
       }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
-      export { FirstSSR, First };
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
+      export { FirstSSR, First };
       export { SecondSSR, Second };"
     `);
   });
@@ -227,8 +227,8 @@ export { First, Second }`),
 
       export { FirstSSR, SecondSSR }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
-      export { FirstSSR, First };
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
+      export { FirstSSR, First };
       export { SecondSSR, Second };"
     `);
   });
@@ -258,8 +258,8 @@ export { First, Second }`),
 
       export { FirstSSR, SecondSSR }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
-      export { FirstSSR, First };
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
+      export { FirstSSR, First };
       export { SecondSSR, Second };"
     `);
   });
@@ -290,8 +290,8 @@ export { First, Second }`),
 
       export { FirstSSR, SecondSSR }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
-      export { FirstSSR, First };
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
+      export { FirstSSR, First };
       export { SecondSSR, Second };"
     `);
   });
@@ -322,8 +322,8 @@ export { First, Second }`),
 
       export { FirstSSR, SecondSSR }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
-      export { FirstSSR, First };
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
+      export { FirstSSR, First };
       export { SecondSSR, Second };"
     `);
   });
@@ -337,11 +337,11 @@ export default () => {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-      export default DefaultComponent0SSR
       const DefaultComponent0SSR = () => {
         return jsx('div', { children: 'Hello' });
       }
-      const DefaultComponent0 = registerClientReference("/test/file.tsx", "default", DefaultComponent0SSR);"
+      const DefaultComponent0 = registerClientReference("/test/file.tsx", "default", DefaultComponent0SSR);
+      export { DefaultComponent0SSR as default, DefaultComponent0 };"
     `);
   });
 
@@ -354,11 +354,11 @@ export default async () => {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-      export default DefaultComponent0SSR
       const DefaultComponent0SSR = async () => {
         return jsx('div', { children: 'Hello' });
       }
-      const DefaultComponent0 = registerClientReference("/test/file.tsx", "default", DefaultComponent0SSR);"
+      const DefaultComponent0 = registerClientReference("/test/file.tsx", "default", DefaultComponent0SSR);
+      export { DefaultComponent0SSR as default, DefaultComponent0 };"
     `);
   });
 
@@ -376,7 +376,7 @@ export default function Component({ prop1, prop2 }) {
         return jsx('div', { children: 'Hello' });
       }
       const Component = registerClientReference("/test/file.tsx", "default", ComponentSSR);
-      export default ComponentSSR;"
+      export { ComponentSSR as default, Component };"
     `);
   });
 
@@ -394,7 +394,7 @@ export default async function Component() {
         return jsx('div', { children: 'Hello' });
       }
       const Component = registerClientReference("/test/file.tsx", "default", ComponentSSR);
-      export default ComponentSSR;"
+      export { ComponentSSR as default, Component };"
     `);
   });
 
@@ -605,14 +605,14 @@ export { Fourth as AnotherName }`),
       export { SecondSSR, ThirdSSR }
       export { FourthSSR as AnotherName }
       const Third = registerClientReference("/test/file.tsx", "Third", ThirdSSR);
-      export { ThirdSSR, Third };
       const Main = registerClientReference("/test/file.tsx", "default", MainSSR);
-      export default MainSSR;
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
-      export { FirstSSR, First };
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-      export { SecondSSR, Second };
       const Fourth = registerClientReference("/test/file.tsx", "Fourth", FourthSSR);
+      export { ThirdSSR, Third };
+      export { MainSSR as default, Main };
+      export { FirstSSR, First };
+      export { SecondSSR, Second };
       export { FourthSSR, Fourth };"
     `);
   });

--- a/sdk/src/vite/useClientPlugin.test.mts
+++ b/sdk/src/vite/useClientPlugin.test.mts
@@ -16,7 +16,6 @@ export const Component = () => {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
       const ComponentSSR = () => {
         return jsx('div', { children: 'Hello' });
       }
@@ -34,7 +33,6 @@ export const baz = 23
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
       export const foo = "bar"
       export const baz = 23
       }"
@@ -50,7 +48,6 @@ export const Component = async () => {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
       const ComponentSSR = async () => {
         return jsx('div', { children: 'Hello' });
       }
@@ -108,7 +105,6 @@ export const Second = () => {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
       const FirstSSR = () => {
         return jsx('div', { children: 'First' });
       }
@@ -136,7 +132,6 @@ export const Second = async () => {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
       const FirstSSR = async () => {
         return jsx('div', { children: 'First' });
       }
@@ -222,7 +217,6 @@ const Second = () => {
 export { First, Second }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
       const FirstSSR = () => {
         return jsx('div', { children: 'First' });
       }
@@ -254,7 +248,6 @@ const Second = async () => {
 export { First, Second }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
       const FirstSSR = async () => {
         return jsx('div', { children: 'First' });
       }
@@ -344,7 +337,6 @@ export default () => {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
       export default DefaultComponent0SSR
       const DefaultComponent0SSR = () => {
         return jsx('div', { children: 'Hello' });
@@ -362,7 +354,6 @@ export default async () => {
 }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
       export default DefaultComponent0SSR
       const DefaultComponent0SSR = async () => {
         return jsx('div', { children: 'Hello' });
@@ -591,7 +582,6 @@ export { Second, Third }
 export { Fourth as AnotherName }`),
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
       const FirstSSR = () => {
         return jsx('div', { children: 'First' });
       }

--- a/sdk/src/vite/useClientPlugin.test.mts
+++ b/sdk/src/vite/useClientPlugin.test.mts
@@ -700,7 +700,12 @@ export default Component;`),
         return jsx('div', { children: 'Hello' });
       }
 
-      export default Component;"
+
+      // >>> Client references
+      const Component = registerClientReference("/test/file.tsx", "default", ComponentSSR);
+
+      export { ComponentSSR };
+      export { Component as default };"
     `);
   });
 });


### PR DESCRIPTION
## Context
For `"use client"`, the sdk works for inlined `export` (e.g. `export const function Component() {}` and grouped exports `export { Component }`, but does not work for `export default cases`. This PR gets it working with the export default cases.

## Implementation
Up until now, we've been using regexes as a way to do the necessary transformations for `use client`. This was fine in the beginning, but in order to cater for all the different kinds of export cases (grouped exports, inlined exports, grouped default exports, inlined default exports, and for each of those for arrows, functions, and for each of those sometimes anoynmous, sometimes not), it has grown in complexity to the extent that regexes are no longer a reliable way of extracting the necessary information and transforming the code, and its just getting out of hand.

We now use `ts-morph` (a thin wrapper around ts's compiler API) to parse and transform the ast for use client cases.