### PR TITLE
fix: A WebSocket 'attachment' cannot be larger than 2048 bytes

### DIFF
--- a/sdk/src/runtime/lib/realtime/durableObject.ts
+++ b/sdk/src/runtime/lib/realtime/durableObject.ts
@@ -231,4 +231,14 @@ export class RealtimeDurableObject extends DurableObject {
       }),
     );
   }
+
+  private async removeClientInfo(clientId: string): Promise<void> {
+    this.clientInfoCache.delete(clientId);
+    await this.storage.delete(`client:${clientId}`);
+  }
+
+  async webSocketClose(ws: WebSocket) {
+    const clientId = ws.deserializeAttachment() as string;
+    await this.removeClientInfo(clientId);
+  }
 }


### PR DESCRIPTION
## Problem
Our realtime durable object currently stores client info (the client's url, id, and cookie header for auth) as an attachment to the relevant socket using cloudflare's API for this: https://developers.cloudflare.com/durable-objects/best-practices/websockets/#serializeattachment

There is a limit of 2048 bytes for this attachment, so if the url and/or cookie header are large, the client info is easily larger than this limit and we end up with an error message.

## Solution
Store only the client id as an attachment, and use the durable object's storage API to persist the relevant client info for that client id (across evictions). We also keep an in-memory cache around to save us needing to go to storage unnecessarily.

## Steps to reproduce the issue
Include a long value in the url (e.g. `?<long_value>`) for the realtime POC: https://github.com/redwoodjs/example-realtime-notes