### PR TITLE
Improve "migrate:new" usability.

### DIFF
--- a/sdk/src/scripts/migrate-new.mts
+++ b/sdk/src/scripts/migrate-new.mts
@@ -50,6 +50,8 @@ export const migrateNew = async (name: string, skipApply = false) => {
   if (!skipApply) {
     console.log("Applying migration in development...");
     await $`pnpm migrate:dev`;
+    console.log("Generating Prisma Client");
+    await $`pnpm prisma generate`;
   }
 };
 

--- a/sdk/src/scripts/migrate-new.mts
+++ b/sdk/src/scripts/migrate-new.mts
@@ -20,7 +20,7 @@ const getNextMigrationNumber = async (): Promise<string> => {
 export const migrateNew = async (name: string, skipApply = false) => {
   if (!name) {
     console.log("Usage: pnpm migrate:new <migration-name> [--no-apply]");
-    console.log('Example: pnpm migrate:new "Add user"');
+    console.log("Example: pnpm migrate:new add a user");
     process.exit(1);
   }
 
@@ -61,7 +61,7 @@ if (import.meta.url === new URL(process.argv[1], import.meta.url).href) {
   const nonFlags = args.filter((arg) => !arg.startsWith("--"));
 
   const skipApply = flags.has("--no-apply");
-  const [name] = nonFlags;
+  const name = nonFlags.join("_").toLocaleLowerCase();
 
   migrateNew(name, skipApply);
 }


### PR DESCRIPTION
- Change format for specifying name.
- Generate Prisma client if migration is applied.

Fixes #205 
