### PR TITLE
fix: Dropped source maps for use client when not worker environment

### DIFF
--- a/sdk/src/vite/useClientPlugin.mts
+++ b/sdk/src/vite/useClientPlugin.mts
@@ -34,9 +34,9 @@ export async function transformUseClientCode(
   code: string,
   relativeId: string,
   isWorkerEnvironment: boolean,
-): Promise<TransformResult> {
+): Promise<TransformResult | undefined> {
   if (!isWorkerEnvironment) {
-    return { code };
+    return;
   }
 
   const project = new Project({


### PR DESCRIPTION
We are accidentally now dropping source maps if we see `'use client'` but its not the worker environment.