### PR TITLE
fix: Deploying client assets

### DIFF
--- a/sdk/src/vite/moveStaticAssetsPlugin.mts
+++ b/sdk/src/vite/moveStaticAssetsPlugin.mts
@@ -11,13 +11,10 @@ export const moveStaticAssetsPlugin = ({
   apply: "build",
 
   async closeBundle() {
-    if (this.environment.name === "client") {
-      await $sh({ cwd: rootDir })`mv dist/client/assets/* dist/client/ || true`;
-      await $sh({ cwd: rootDir })`rmdir dist/client/assets || true`;
-    }
-
     if (this.environment.name === "worker") {
-      await $sh({ cwd: rootDir })`mv dist/worker/assets/* dist/client/ || true`;
+      await $sh({
+        cwd: rootDir,
+      })`mv dist/worker/assets/* dist/client/assets || true`;
       await $sh({ cwd: rootDir })`rmdir dist/worker/assets || true`;
     }
   },


### PR DESCRIPTION
Ever since moving to CF's vite plugin, wrangler looks for `dist/client/assets` for assets (via the field in the wrangler json the plugin builds on `vite build`), rather than `./dist/client` as we had it previously configured.

We need to make sure the assets are situated there now.