### PR TITLE
fix: RSC updates for fetch transport

### DIFF
--- a/sdk/src/runtime/client.tsx
+++ b/sdk/src/runtime/client.tsx
@@ -20,7 +20,7 @@ export type CreateCallServer = (
   context: TransportContext,
 ) => <Result>(id: null | string, args: null | unknown[]) => Promise<Result>;
 
-export const fetchTransport: Transport = ({ setRscPayload }) => {
+export const fetchTransport: Transport = (transportContext) => {
   const fetchCallServer = async <Result,>(
     id: null | string,
     args: null | unknown[],
@@ -44,7 +44,7 @@ export const fetchTransport: Transport = ({ setRscPayload }) => {
       { callServer: fetchCallServer },
     ) as Promise<ActionResponse<Result>>;
 
-    setRscPayload(streamData);
+    transportContext.setRscPayload(streamData);
     const result = await streamData;
     return (result as { actionResult: Result }).actionResult;
   };


### PR DESCRIPTION
When introducing the realtime API, I accidentally broke updates for our normal fetch-based client.

Underlying reason: the function for setting the rsc payload gets updated, but we only look at initial value rather than the current one.

Thank you for finding this @peterp!