### PR TITLE
fix: Bring back .env symlinking+copying

### DIFF
--- a/sdk/src/vite/redwoodPlugin.mts
+++ b/sdk/src/vite/redwoodPlugin.mts
@@ -20,7 +20,6 @@ import { setupEnvFiles } from "./setupEnvFiles.mjs";
 import { invalidateCacheIfPrismaClientChanged } from "./invalidateCacheIfPrismaClientChanged.mjs";
 import { findWranglerConfig } from "../lib/findWranglerConfig.mjs";
 import { pathExists } from "fs-extra";
-import { stderr, stdout } from "node:process";
 
 export type RedwoodPluginOptions = {
   silent?: boolean;
@@ -48,6 +47,7 @@ export const redwoodPlugin = async (
     projectRootDir,
     options?.entry?.worker ?? "src/worker.tsx",
   );
+  await setupEnvFiles({ rootDir: projectRootDir });
 
   // context(justinvdm, 31 Mar 2025): We assume that if there is no .wrangler directory,
   // then this is fresh install, and we run `pnpm dev:init` here.


### PR DESCRIPTION
We used to automatically copy `.env.example` to `.env`, and symlink `.env` to `.dev.vars`.

And then I accidentally removed the line that does this: https://github.com/redwoodjs/sdk/pull/210

This PR brings it back.