### PR TITLE
fix: Default document should not have src/client.tsx script

### DIFF
--- a/sdk/src/runtime/worker.tsx
+++ b/sdk/src/runtime/worker.tsx
@@ -173,7 +173,6 @@ export const DefaultDocument: React.FC<{ children: React.ReactNode }> = ({
     <head>
       <meta charSet="utf-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
-      <script type="module" src="/src/client.tsx"></script>
     </head>
     <body>
       <div id="root">{children}</div>


### PR DESCRIPTION
We don't provide a default client.tsx so we shouldnt have the default document reference one.