### PR TITLE
fix: Rerun wrangler types on pnpm dev

### DIFF
--- a/sdk/src/vite/redwoodPlugin.mts
+++ b/sdk/src/vite/redwoodPlugin.mts
@@ -48,6 +48,8 @@ export const redwoodPlugin = async (
     options?.entry?.worker ?? "src/worker.tsx",
   );
   await setupEnvFiles({ rootDir: projectRootDir });
+
+  console.log("Generating wrangler types...");
   await $({ reject: false })`npx wrangler types`;
 
   // context(justinvdm, 31 Mar 2025): We assume that if there is no .wrangler directory,

--- a/sdk/src/vite/redwoodPlugin.mts
+++ b/sdk/src/vite/redwoodPlugin.mts
@@ -48,6 +48,7 @@ export const redwoodPlugin = async (
     options?.entry?.worker ?? "src/worker.tsx",
   );
   await setupEnvFiles({ rootDir: projectRootDir });
+  await $({ reject: false })`npx wrangler types`;
 
   // context(justinvdm, 31 Mar 2025): We assume that if there is no .wrangler directory,
   // then this is fresh install, and we run `pnpm dev:init` here.


### PR DESCRIPTION
Users needing to run `pnpm wrangler types` is an extra step they need to think about that they arguably shouldn't need to. This PR makes it so that `pnpm wrangler types` is done as a step on `pnpm dev` inside the redwood plugin.