### PR TITLE
fix: Realtime updates given in action responses

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -18,7 +18,8 @@
     "clean:vendor": "rm -rf ./vendor/dist",
     "format": "prettier --write ./src",
     "release": "./scripts/release.sh",
-    "test": "vitest"
+    "test": "vitest",
+    "debug:sync": "node ./dist/scripts/debug-sync.mjs"
   },
   "exports": {
     "./vite": {

--- a/sdk/src/runtime/lib/realtime/client.ts
+++ b/sdk/src/runtime/lib/realtime/client.ts
@@ -141,6 +141,9 @@ export const realtimeTransport =
           const rscPayload = createFromReadableStream(stream, {
             callServer: realtimeCallServer,
           });
+          transportContext.setRscPayload(
+            rscPayload as Promise<ActionResponse<unknown>>,
+          );
           resolve(rscPayload as Result);
         });
       } catch (e) {

--- a/sdk/src/runtime/lib/realtime/durableObject.ts
+++ b/sdk/src/runtime/lib/realtime/durableObject.ts
@@ -7,7 +7,6 @@ interface ClientInfo {
   clientId: string;
   cookieHeaders: string;
 }
-
 export class RealtimeDurableObject extends DurableObject {
   state: DurableObjectState;
   env: Env;
@@ -154,7 +153,9 @@ export class RealtimeDurableObject extends DurableObject {
       throw new Error(`Action failed: ${response.statusText}`);
     }
 
-    this.render({ exclude: [clientInfo.clientId] });
+    this.render({
+      exclude: [clientInfo.clientId],
+    });
 
     await this.streamResponse(response, ws, {
       chunk: MESSAGE_TYPE.ACTION_CHUNK,
@@ -163,12 +164,12 @@ export class RealtimeDurableObject extends DurableObject {
   }
 
   private async determineSockets({
-    include,
-    exclude,
+    include = [],
+    exclude = [],
   }: {
     include?: string[];
     exclude?: string[];
-  }): Promise<Array<{ socket: WebSocket; clientInfo: ClientInfo }>> {
+  } = {}): Promise<Array<{ socket: WebSocket; clientInfo: ClientInfo }>> {
     const sockets = Array.from(this.state.getWebSockets());
     const includeSet = include ? new Set(include) : null;
     const excludeSet = exclude ? new Set(exclude) : null;
@@ -198,7 +199,7 @@ export class RealtimeDurableObject extends DurableObject {
   }: {
     include?: string[];
     exclude?: string[];
-  }): Promise<void> {
+  } = {}): Promise<void> {
     const sockets = await this.determineSockets({ include, exclude });
     if (sockets.length === 0) return;
 

--- a/sdk/src/scripts/debug-sync.mts
+++ b/sdk/src/scripts/debug-sync.mts
@@ -1,0 +1,21 @@
+import { $ } from "../lib/$.mjs";
+
+export const debugSync = async () => {
+  const targetDir = process.argv[2];
+
+  if (!targetDir) {
+    console.error("❌ Please provide a target directory as an argument.");
+    process.exit(1);
+  }
+
+  const command = `pnpm tsc && rm -rf ${targetDir}/node_modules/@redwoodjs/sdk/dist && cp -r dist ${targetDir}/node_modules/@redwoodjs/sdk/`;
+
+  $({
+    stdio: "inherit",
+    shell: true,
+  })`npx chokidar-cli './src/**' -c "${command}"`;
+};
+
+if (import.meta.url === new URL(process.argv[1], import.meta.url).href) {
+  debugSync();
+}

--- a/sdk/src/scripts/debug-sync.mts
+++ b/sdk/src/scripts/debug-sync.mts
@@ -8,7 +8,7 @@ export const debugSync = async () => {
     process.exit(1);
   }
 
-  const command = `pnpm tsc && rm -rf ${targetDir}/node_modules/@redwoodjs/sdk/dist && cp -r dist ${targetDir}/node_modules/@redwoodjs/sdk/`;
+  const command = `echo syncing... && pnpm tsc && rm -rf ${targetDir}/node_modules/@redwoodjs/sdk/dist && cp -r dist ${targetDir}/node_modules/@redwoodjs/sdk/ && echo done`;
 
   $({
     stdio: "inherit",


### PR DESCRIPTION
In our realtime API, there are two cases where need to update the UI with a new RSC payload stream:
* 1. rsc update: a change issued by a different client (or by server) has  resulted in a new rsc payload
* 2. action result: a client called an action, so it gets a new rsc payload, including the UI update and action result

We were only setting a new payload stream in case 1 and not case 2.

Our note taking demo did not catch this, since the text was already being changed client side since it was a text box!