### PR TITLE
fix: Bad check in determining which sockets to broadcast to

### DIFF
--- a/sdk/src/runtime/lib/realtime/durableObject.ts
+++ b/sdk/src/runtime/lib/realtime/durableObject.ts
@@ -171,8 +171,8 @@ export class RealtimeDurableObject extends DurableObject {
     exclude?: string[];
   } = {}): Promise<Array<{ socket: WebSocket; clientInfo: ClientInfo }>> {
     const sockets = Array.from(this.state.getWebSockets());
-    const includeSet = include ? new Set(include) : null;
-    const excludeSet = exclude ? new Set(exclude) : null;
+    const includeSet = include.length > 0 ? new Set(include) : null;
+    const excludeSet = exclude.length > 0 ? new Set(exclude) : null;
     const results: Array<{ socket: WebSocket; clientInfo: ClientInfo }> = [];
 
     for (const socket of sockets) {


### PR DESCRIPTION
We were checking the truthyness of an array rather than checking if its length was > 0, which ultimately caused us to not broadcast realtime updates to any clients.