### PR TITLE
fix: HMR for realtime

### DIFF
--- a/sdk/src/runtime/client.tsx
+++ b/sdk/src/runtime/client.tsx
@@ -95,7 +95,7 @@ export const initClient = async ({
   if (import.meta.hot) {
     import.meta.hot.on("rsc:update", (e) => {
       console.log("[rw-sdk] hot update", e.file);
-      callServer(null, null);
+      callServer("__rsc_hot_update", [e.file]);
     });
   }
 };

--- a/sdk/src/runtime/register/worker.ts
+++ b/sdk/src/runtime/register/worker.ts
@@ -5,6 +5,7 @@ import {
 } from "react-server-dom-webpack/server.edge";
 import { getModuleExport } from "../imports/worker";
 import { HandlerOptions } from "../lib/router";
+import { IS_DEV } from "../constants";
 
 export function registerServerReference(
   action: Function,
@@ -45,7 +46,7 @@ export async function rscActionHandler<TAppContext>(
   const args = (await decodeReply(data, null)) as unknown[];
   const actionId = url.searchParams.get("__rsc_action_id");
 
-  if (actionId === "__rsc_hot_update") {
+  if (IS_DEV && actionId === "__rsc_hot_update") {
     return null;
   }
   const action = await getModuleExport(actionId!);

--- a/sdk/src/runtime/register/worker.ts
+++ b/sdk/src/runtime/register/worker.ts
@@ -44,6 +44,10 @@ export async function rscActionHandler<TAppContext>(
 
   const args = (await decodeReply(data, null)) as unknown[];
   const actionId = url.searchParams.get("__rsc_action_id");
+
+  if (actionId === "__rsc_hot_update") {
+    return null;
+  }
   const action = await getModuleExport(actionId!);
 
   if (typeof action !== "function") {


### PR DESCRIPTION
## Problem
We send an "empty" action request in order when we detect an HMR update is needed.

However, for realtime, we need to be able to forward the action request from the DO (which manages the websockets) to the worker. To this, we need a JSON serializable value for the action id and args.

## Solution
Send an internal action id (`__rsc_hot_update`) instead of an empty message, and special case this to do nothing when received server side (we only care about the new rsc result, not the action).