### PR TITLE
chore: Renames JS->SDK

### DIFF
--- a/docs/src/content/docs/core/security.mdx
+++ b/docs/src/content/docs/core/security.mdx
@@ -51,7 +51,7 @@ headers.set(
 
 #### Using `nonce` for inline scripts
 
-Sometimes you need to include inline scripts in your application, but Content Security Policy (CSP) blocks them by default for security reasons. RedwoodJS automatically generates a fresh, cryptographically secure nonce value for each request You can access this nonce in document or page components rendered by the [router](./routing), using `rw.nonce`.
+Sometimes you need to include inline scripts in your application, but Content Security Policy (CSP) blocks them by default for security reasons. RedwoodSDK automatically generates a fresh, cryptographically secure nonce value for each request You can access this nonce in document or page components rendered by the [router](./routing), using `rw.nonce`.
 
 <Aside type="caution">
   Only use the nonce attribute for trusted inline scripts that you have full

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,3 +1,3 @@
 # Redwood SDK
 
-This is an early preview of the next epoch of RedwoodJS. Documentation is currently under development.
+This is an early preview of the next epoch of RedwoodSDK. Documentation is currently under development.

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -69,7 +69,7 @@
     "url": "https://github.com/redwoodjs/sdk",
     "directory": "sdk"
   },
-  "author": "RedwoodJS <peter@redwoodjs.com>",
+  "author": "RedwoodSDK <peter@redwoodjs.com>",
   "license": "MIT",
   "dependencies": {
     "@cloudflare/vite-plugin": "^0.1.15",

--- a/starters/minimal/README.md
+++ b/starters/minimal/README.md
@@ -1,6 +1,6 @@
 # Minimal Starter
 
-This starter gives you a bare-bones RedwoodJS project.
+This starter gives you a bare-bones RedwoodSDK project.
 
 Create your new project:
 
@@ -48,5 +48,5 @@ Within your project's `wrangler.jsonc` file, replace the placeholder values. For
 
 ## Further Reading
 
-- [RedwoodJS Documentation](https://redwoodjs.com)
+- [RedwoodSDK Documentation](https://docs.rwsdk.com/)
 - [Cloudflare Workers Documentation](https://developers.cloudflare.com/workers)

--- a/starters/passkey-auth/README.md
+++ b/starters/passkey-auth/README.md
@@ -1,6 +1,6 @@
 # Passkey Authentication Starter
 
-This starter provides a RedwoodJS-based passkey authentication implementation using WebAuthn. It allows password-less authentication leveraging built-in device authenticators and services such as Google Passkeys or 1Password.
+This starter provides a RedwoodSDK-based passkey authentication implementation using WebAuthn. It allows password-less authentication leveraging built-in device authenticators and services such as Google Passkeys or 1Password.
 
 ## Creating your project
 
@@ -115,6 +115,6 @@ Registration is protected using Cloudflare Turnstile to prevent automated bot re
 
 ## Further Reading
 
-- [RedwoodJS Documentation](https://redwoodjs.com)
+- [RedwoodSDK Documentation](https://docs.rwsdk.com/)
 - [Cloudflare Workers Secrets](https://developers.cloudflare.com/workers/runtime-apis/secrets/)
 - [Cloudflare Turnstile](https://developers.cloudflare.com/turnstile/)

--- a/starters/sessions/README.md
+++ b/starters/sessions/README.md
@@ -1,6 +1,6 @@
 # Sessions Starter
 
-This starter gives you a RedwoodJS project with built-in session management.
+This starter gives you a RedwoodSDK project with built-in session management.
 
 ## Creating your project
 
@@ -82,5 +82,5 @@ Never use the same secret key for development and production environments, and a
 
 ## Further Reading
 
-- [RedwoodJS Documentation](https://redwoodjs.com)
+- [RedwoodSDK Documentation](https://docs.rwsdk.com/)
 - [Cloudflare Workers Documentation](https://developers.cloudflare.com/workers)

--- a/starters/standard/README.md
+++ b/starters/standard/README.md
@@ -1,6 +1,6 @@
-# Standard RedwoodJS Starter
+# Standard RedwoodSDK Starter
 
-This starter provides a comprehensive RedwoodJS-based implementation that includes passkey authentication using WebAuthn, session management, database integration with Prisma, and file storage with Cloudflare R2. It serves as a fully integrated starting point for Redwood apps, consolidating various essential features into one package.
+This starter provides a comprehensive RedwoodSDK-based implementation that includes passkey authentication using WebAuthn, session management, database integration with Prisma, and file storage with Cloudflare R2. It serves as a fully integrated starting point for Redwood apps, consolidating various essential features into one package.
 
 ## Creating your project
 
@@ -113,6 +113,6 @@ Registration is protected using [Cloudflare Turnstile](https://www.cloudflare.co
 
 ## Further Reading
 
-- [RedwoodJS Documentation](https://redwoodjs.com)
+- [RedwoodSDK Documentation](https://docs.rwsdk.com/)
 - [Cloudflare Workers Secrets](https://developers.cloudflare.com/workers/runtime-apis/secrets/)
 - [Cloudflare Turnstile](https://developers.cloudflare.com/turnstile/)


### PR DESCRIPTION
There were a few places where we (I) said RedwoodJS when I meant RedwoodSDK