### PR TITLE
✨ Added a preview banner

### DIFF
--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -1,7 +1,18 @@
-import { defineCollection } from 'astro:content';
+import { defineCollection, z } from 'astro:content';
 import { docsLoader } from '@astrojs/starlight/loaders';
 import { docsSchema } from '@astrojs/starlight/schema';
 
 export const collections = {
-	docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+  docs: defineCollection({
+    loader: docsLoader(),
+    schema: docsSchema({
+      extend: z.object({
+        banner: z.object({
+          content: z.string(),
+        }).default({
+          content: 'RedwoodSDK is in preview mode.',
+        })
+      }),
+    }),
+  }),
 };

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -13,7 +13,7 @@ li details ul li details summary {
 
 /* This is the caption that explains the code block, defined when you add "---" to the end of the code block.
 
-Example: 
+Example:
 ---
 This code sample does the following...
 ---
@@ -29,4 +29,9 @@ figcaption:not(.header) {
 
 .output {
   background-color: var(--ec-caption-bg) !important;
+}
+
+:root {
+  --sl-color-banner-bg: #ffae49;
+  --sl-color-banner-text: #000;
 }


### PR DESCRIPTION
Adds a preview banner that says "RedwoodSDK is in preview mode." at the top of every page of the documentation:

![CleanShot 2025-04-03 at 21 58 33@2x](https://github.com/user-attachments/assets/93450744-b61f-442c-99a4-2010f4010851)
