### PR TITLE
fix(docs): Update quick start guide to use minimal starter template

### DIFF
--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -25,7 +25,7 @@ In this quick start you'll go from zero to request/response in seconds and deplo
 Create a new project by running the following command, replacing `<project-name>` with your project name:
 
 ```bash showLineNumbers=false
-npx degit redwoodjs/sdk/starters/standard#main <project-name>
+npx degit redwoodjs/sdk/starters/minimal#main <project-name>
 ```
 
 ## Start developing


### PR DESCRIPTION
fixes #258 by replacing the standard starter with the minimal, so that  it doesn't fail when you run `pnpm dev`

