### PR TITLE
fix (docs): Update documentation to point to Standard instead of prisma

### DIFF
--- a/docs/src/content/docs/core/database.mdx
+++ b/docs/src/content/docs/core/database.mdx
@@ -33,11 +33,11 @@ We've run a command to create a database called `my-database`. Copy those values
 
 ## Usage with Prisma
 
-<Aside type="note" title="Prisma Starter">
-RedwoodSDK ships with a [Prisma starter project](https://github.com/redwoodjs/sdk/tree/main/starters/prisma), you can use it to get started with a database in seconds.
+<Aside type="note" title="Standard Starter">
+RedwoodSDK ships with a [Standard starter project](https://github.com/redwoodjs/sdk/tree/main/starters/standard), you can use it to get started with a database in seconds.
 
 ```bash frame="none"
-npx degit redwoodjs/sdk/starters/prisma#main <project-name>
+npx degit redwoodjs/sdk/starters/standard#main <project-name>
 ```
 
 </Aside>


### PR DESCRIPTION
fixes #260 by pointing to the standard starter instead of the (removed) prisma one
