### PR TITLE
fix: Avoid worker import in router

### DIFF
--- a/sdk/src/runtime/lib/router.ts
+++ b/sdk/src/runtime/lib/router.ts
@@ -1,9 +1,5 @@
 import { isValidElementType } from "react-is";
-import {
-  runWithRequestInfoOverrides,
-  RequestInfo,
-  getRequestInfo,
-} from "../requestInfo/worker";
+import type { RequestInfo } from "../requestInfo/types";
 
 export type DocumentProps = RequestInfo & {
   children: React.ReactNode;
@@ -96,15 +92,27 @@ export function defineRoutes(routes: Route[]): {
   handle: ({
     request,
     renderPage,
+    getRequestInfo,
+    runWithRequestInfoOverrides,
   }: {
     request: Request;
     renderPage: (requestInfo: RequestInfo, Page: React.FC) => Promise<Response>;
+    getRequestInfo: () => RequestInfo;
+    runWithRequestInfoOverrides: <Result>(
+      overrides: Partial<RequestInfo>,
+      fn: () => Promise<Result>,
+    ) => Promise<Result>;
   }) => Response | Promise<Response>;
 } {
   const flattenedRoutes = flattenRoutes(routes);
   return {
     routes: flattenedRoutes,
-    async handle({ request, renderPage }) {
+    async handle({
+      request,
+      renderPage,
+      getRequestInfo,
+      runWithRequestInfoOverrides,
+    }) {
       const url = new URL(request.url);
       let path = url.pathname;
 

--- a/sdk/src/runtime/requestInfo/types.ts
+++ b/sdk/src/runtime/requestInfo/types.ts
@@ -1,0 +1,12 @@
+import { RwContext } from "../lib/router";
+
+export interface DefaultAppContext {}
+
+export interface RequestInfo<Params = any, AppContext = DefaultAppContext> {
+  request: Request;
+  params: Params;
+  ctx: AppContext;
+  headers: Headers;
+  rw: RwContext;
+  cf: ExecutionContext;
+}

--- a/sdk/src/runtime/requestInfo/worker.ts
+++ b/sdk/src/runtime/requestInfo/worker.ts
@@ -1,16 +1,7 @@
 import { AsyncLocalStorage } from "async_hooks";
-import { RwContext } from "../lib/router";
+import { RequestInfo, DefaultAppContext } from "./types";
 
-export interface DefaultAppContext {}
-
-export interface RequestInfo<Params = any, AppContext = DefaultAppContext> {
-  request: Request;
-  params: Params;
-  ctx: AppContext;
-  headers: Headers;
-  rw: RwContext;
-  cf: ExecutionContext;
-}
+export type { RequestInfo };
 
 const requestInfoStore = new AsyncLocalStorage<Record<string, any>>();
 

--- a/sdk/src/runtime/worker.tsx
+++ b/sdk/src/runtime/worker.tsx
@@ -6,9 +6,10 @@ import { ssrWebpackRequire } from "./imports/worker";
 import { rscActionHandler } from "./register/worker";
 import { ErrorResponse } from "./error";
 import {
-  RequestInfo,
   getRequestInfo,
   runWithRequestInfo,
+  runWithRequestInfoOverrides,
+  type RequestInfo,
 } from "./requestInfo/worker";
 
 import { Route, defineRoutes } from "./lib/router";
@@ -149,6 +150,8 @@ export const defineApp = (routes: Route[]) => {
           router.handle({
             request,
             renderPage,
+            getRequestInfo,
+            runWithRequestInfoOverrides,
           }),
         );
 


### PR DESCRIPTION
## Problem
Now with #251, the sdk's router runtime code imports code in the module where `requestInfo` is defined, which in turn uses async_hooks (a node API, which CF also supports and polyfills). The problem comes in when client side code tries import `@redwoodjs/sdk/router` - when it needs to do to use `defineLinks()` (valid for that to be client side). As a result, the client side tries import async_hooks.

## Soution
Avoid imports requestInfo module in router