### PR TITLE
fix: AppContext type augmentation

### DIFF
--- a/sdk/src/runtime/entries/worker.ts
+++ b/sdk/src/runtime/entries/worker.ts
@@ -8,4 +8,5 @@ export * from "../worker";
 export * from "../error";
 export * from "../script";
 export * from "../lib/utils";
+export * from "../requestInfo/types";
 export * from "../requestInfo/worker";

--- a/sdk/src/runtime/lib/router.ts
+++ b/sdk/src/runtime/lib/router.ts
@@ -1,5 +1,5 @@
 import { isValidElementType } from "react-is";
-import type { RequestInfo } from "../requestInfo/types";
+import { RequestInfo } from "../requestInfo/types";
 
 export type DocumentProps = RequestInfo & {
   children: React.ReactNode;

--- a/sdk/src/runtime/requestInfo/worker.ts
+++ b/sdk/src/runtime/requestInfo/worker.ts
@@ -1,8 +1,6 @@
 import { AsyncLocalStorage } from "async_hooks";
 import { RequestInfo, DefaultAppContext } from "./types";
 
-export type { RequestInfo };
-
 const requestInfoStore = new AsyncLocalStorage<Record<string, any>>();
 
 const requestInfoBase = {};

--- a/sdk/src/runtime/worker.tsx
+++ b/sdk/src/runtime/worker.tsx
@@ -9,8 +9,8 @@ import {
   getRequestInfo,
   runWithRequestInfo,
   runWithRequestInfoOverrides,
-  type RequestInfo,
 } from "./requestInfo/worker";
+import { RequestInfo } from "./requestInfo/types";
 
 import { Route, defineRoutes } from "./lib/router";
 import { generateNonce } from "./lib/utils";


### PR DESCRIPTION
Ever since #267, we've been exporting `RequestInfo` as a `type` rather than an `interface`, which breaks type augmentation of `DefaultAppContext` for it.