### PR TITLE
fix: Remove remaining pnpm script runs

### DIFF
--- a/sdk/src/scripts/migrate-new.mts
+++ b/sdk/src/scripts/migrate-new.mts
@@ -19,8 +19,8 @@ const getNextMigrationNumber = async (): Promise<string> => {
 
 export const migrateNew = async (name: string, skipApply = false) => {
   if (!name) {
-    console.log("Usage: pnpm migrate:new <migration-name> [--no-apply]");
-    console.log("Example: pnpm migrate:new add a user");
+    console.log("Usage: npm run migrate:new <migration-name> [--no-apply]");
+    console.log("Example: npm run migrate:new add a user");
     process.exit(1);
   }
 

--- a/sdk/src/scripts/worker-run.mts
+++ b/sdk/src/scripts/worker-run.mts
@@ -14,9 +14,9 @@ export const runWorkerScript = async (relativeScriptPath: string) => {
   if (!relativeScriptPath) {
     console.error("Error: Script path is required");
     console.log("\nUsage:");
-    console.log("  pnpm worker:run <script-path>");
+    console.log("  npm run worker:run <script-path>");
     console.log("\nExample:");
-    console.log("  pnpm worker:run src/scripts/seed.ts\n");
+    console.log("  npm run worker:run src/scripts/seed.ts\n");
     process.exit(1);
   }
 

--- a/sdk/src/vite/redwoodPlugin.mts
+++ b/sdk/src/vite/redwoodPlugin.mts
@@ -48,16 +48,16 @@ export const redwoodPlugin = async (
   );
 
   // context(justinvdm, 31 Mar 2025): We assume that if there is no .wrangler directory,
-  // then this is fresh install, and we run `pnpm dev:init` here.
+  // then this is fresh install, and we run `npm run dev:init` here.
   if (!(await pathExists(resolve(process.cwd(), ".wrangler")))) {
     console.log(
-      "🚀 Project has no .wrangler directory yet, assuming fresh install: running `pnpm dev:init`...",
+      "🚀 Project has no .wrangler directory yet, assuming fresh install: running `npm run dev:init`...",
     );
     await $({
       // context(justinvdm, 01 Apr 2025): We want to avoid interactive migration y/n prompt, so we ignore stdin
       // as a signal to operate in no-tty mode
       stdio: ["ignore", "inherit", "inherit"],
-    })`pnpm dev:init`;
+    })`npm run dev:init`;
   }
 
   const usesPrisma = await $({ reject: false })`pnpm prisma --version`;
@@ -93,14 +93,6 @@ export const redwoodPlugin = async (
     reactPlugin(),
     useServerPlugin(),
     useClientPlugin(),
-    asyncSetupPlugin({
-      async setup({ command }) {
-        if (command !== "build") {
-          console.log("Generating wrangler types...");
-          await $`pnpm wrangler types`;
-        }
-      },
-    }),
     injectHmrPreambleJsxPlugin(),
     useClientLookupPlugin({
       rootDir: projectRootDir,


### PR DESCRIPTION
In #255, we changed the sdk to not assume projects use pnpm. There were still some `pnpm` remnants around in the sdk, this PR removed those.

Fixes #296