### PR TITLE
Update formatting for Deploy Docs

### DIFF
--- a/docs/src/content/docs/core/hosting.mdx
+++ b/docs/src/content/docs/core/hosting.mdx
@@ -27,12 +27,18 @@ Ship your webapp to Cloudflare with the following command:
 
 <Tabs syncKey="package-manager">
   <TabItem label="pnpm">
-    ```bash frame="none" showLineNumbers=false pnpm release ```
+    ```bash frame="none" showLineNumbers=false
+    pnpm release
+    ```
   </TabItem>
   <TabItem label="npm">
-    ```bash frame="none" showLineNumbers=false npm run release ```
+    ```bash frame="none" showLineNumbers=false
+    npm run release
+    ```
   </TabItem>
   <TabItem label="yarn">
-    ```bash frame="none" showLineNumbers=false yarn release ```
+    ```bash frame="none" showLineNumbers=false
+    yarn release
+    ```
   </TabItem>
 </Tabs>


### PR DESCRIPTION
Fixed formatting on the **Core > Deploy Docs**

## Before
![CleanShot 2025-04-10 at 16 16 34](https://github.com/user-attachments/assets/17e17e75-63c0-4a2c-b4fa-f704ab893937)

## After
![CleanShot 2025-04-11 at 16 21 24](https://github.com/user-attachments/assets/7c224b48-2f20-4a71-8b9a-fc3234bc0ace)
