### PR TITLE
(docs): updated code blocks for consistency

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,3 +30,29 @@ These are simple guidelines that help us keep the documentation consistent.
 1. Always refer to "RedwoodSDK" as "RedwoodSDK," not "Redwood," "RedwoodJS" or "Redwood SDK."
 2. Use "Request/Response" rather than "Request / Response" or "Request/ Response."
 3. Use "Route handler" rather than "Route function."
+
+## Code Syntax
+
+Prefer "bash showLineNumbers=false" when only showing code commands.
+
+Example: 
+
+```bash showLineNumbers=false
+npx degit redwoodjs/sdk/starters/standard <project-name>
+```
+
+Prefer "bash showLineNumbers=false withOutput" when showing both code commands along with the expected output. 
+
+Example
+
+```bash showLineNumbers=false withOutput
+> npx wrangler d1 create my-database
+
+✅ Successfully created DB 'my-database' in region WEUR
+Created your new D1 database.
+
+[[d1_databases]]
+binding = "DB"
+database_name = "my-database"
+database_id = "62x40823-4750-4973-b994-fb8fd55xxxx6"
+```

--- a/docs/src/content/docs/core/authentication.mdx
+++ b/docs/src/content/docs/core/authentication.mdx
@@ -31,7 +31,7 @@ If you haven't already, replace the `__change_me__` placeholders with a name for
 
 Then, create a new D1 database:
 
-```shell
+```bash showLineNumbers=false
 npx wrangler d1 create my-project-db
 ```
 
@@ -53,8 +53,8 @@ Copy the database ID provided and paste it into your project's `wrangler.jsonc` 
 
 For production, set your domain as the `RP_ID` via Cloudflare secrets:
 
-```shell
-wrangler secret put RP_ID
+```bash showLineNumbers=false
+npx wrangler secret put RP_ID
 ```
 
 When prompted, enter your production domain (e.g., `my-app.example.com`).
@@ -65,15 +65,15 @@ Note: The RP_ID must be a valid domain that matches your application's origin. F
 
 For production, generate a strong `SECRET_KEY` for signing session IDs. You can generate a secure random key using OpenSSL:
 
-```shell
+```bash showLineNumbers=false
 # Generate a 32-byte random key and encode it as base64
 openssl rand -base64 32
 ```
 
 Then set this key as a Cloudflare secret:
 
-```shell
-wrangler secret put SECRET_KEY
+```bash showLineNumbers=false
+npx wrangler secret put SECRET_KEY
 ```
 
 Never use the same secret key for development and production environments, and avoid committing your secret keys to version control.
@@ -95,8 +95,8 @@ const TURNSTILE_SITE_KEY = "<YOUR_SITE_KEY>";
 
 4. Set your **Turnstile Secret Key** via Cloudflare secrets for production:
 
-```shell
-wrangler secret put TURNSTILE_SECRET_KEY
+```bash showLineNumbers=false
+npx wrangler secret put TURNSTILE_SECRET_KEY
 ```
 
 ## How it all works

--- a/docs/src/content/docs/core/database.mdx
+++ b/docs/src/content/docs/core/database.mdx
@@ -18,8 +18,9 @@ You'll need to "bind" your database to your worker (`./src/worker.tsx`). "Bindin
 
 In order to bind a database to your worker you'll need to create a D1 database, and save it's configuration details in your `wrangler.jsonc` file.
 
-```bash
-npx wrangler d1 create my-database
+```bash showLineNumbers=false withOutput
+> npx wrangler d1 create my-database
+
 ✅ Successfully created DB 'my-database' in region WEUR
 Created your new D1 database.
 
@@ -46,7 +47,7 @@ npx degit redwoodjs/sdk/starters/prisma#main <project-name>
 
 Install the Prisma packages, as well as the adapter for D1, and create a `prisma` directory.
 
-```bash
+```bash showLineNumbers=false
 npm install @prisma/adapter-d1 @prisma/client prisma
 mkdir prisma
 touch prisma/schema.prisma

--- a/docs/src/content/docs/core/queues.mdx
+++ b/docs/src/content/docs/core/queues.mdx
@@ -17,7 +17,8 @@ To handle these you'll use **background tasks**. Background tasks are managed by
 ### Setup
 
 First thing you've got to do is create a queue and bind the queue producers and consumers to your worker.
-```bash frame="none" showLineNumbers=false
+
+```bash showLineNumbers=false
 npx wrangler queues create MY_QUEUE_NAME
 ```
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -12,7 +12,7 @@ RedwoodSDK is a composable framework for building server-side web apps on **Clou
 	<Card title="Quick start" icon="">
     	Create a new project by running the following command, replacing {"<project-name>"} with your project name
 
-    	```bash
+    	```bash frame="none"
     	npx degit redwoodjs/sdk/starters/standard <project-name>
     	```
 


### PR DESCRIPTION
1. Added README style notes for code blocks with commands. 
2. Updated code blocks with commands to be more consistent. 

### Readme update

I wasn't really happy with the way this turned out, but I added it anyway. When previewed, the code blocks render as markdown, when I was really trying to show them as text. But, if someone looks at them in an editor, then they will see it as intended. 

### Doc update examples

Added withOutput to commands showing output:

<img width="926" alt="image" src="https://github.com/user-attachments/assets/1e202e2e-5d7c-44d2-b9b9-c162d37f07e4" />

Removed numbers from command blocks:

<img width="934" alt="image" src="https://github.com/user-attachments/assets/1732df9d-7131-47ef-b6b6-3e22e1b279ca" />

Added 'terminal' styling where missing:
<img width="930" alt="image" src="https://github.com/user-attachments/assets/970293a0-bae7-4591-b90a-2a206f2f7d64" />

Note: with all three style updates, i did not introduce any new formatting options. These styles already existed, they were simply applied inconsistently. For instance, I got the style for the command with output from the storage setup page.