### PR TITLE
fix: DefaultAppContext in minimal starter

### DIFF
--- a/starters/minimal/types/rw.d.ts
+++ b/starters/minimal/types/rw.d.ts
@@ -1,10 +1,5 @@
-import { RequestContext } from "@redwoodjs/sdk/worker";
-import { Data, AppContext } from "@/worker";
+import { AppContext } from "../src/worker";
 
 declare module "@redwoodjs/sdk/worker" {
-  export const requestContext: RequestContext & {
-    data: Data;
-  };
-
-  export interface DefaultAppContext extends AppContext {}
+  interface DefaultAppContext extends AppContext {}
 }


### PR DESCRIPTION
It looks like I left the `rw.d.ts` in a broken state for minimal starter - updated minimal's `rw.d.ts` to match what we do for standard starter.