### PR TITLE
fix: Use ~6.5.0 for prisma in standard starter

### DIFF
--- a/starters/standard/package.json
+++ b/starters/standard/package.json
@@ -27,8 +27,8 @@
     "types": "tsc"
   },
   "dependencies": {
-    "@prisma/adapter-d1": "^6.4.1",
-    "@prisma/client": "^6.4.1",
+    "@prisma/adapter-d1": "~6.5.0",
+    "@prisma/client": "~6.5.0",
     "@redwoodjs/sdk": "0.0.57",
     "@simplewebauthn/browser": "^13.1.0",
     "@simplewebauthn/server": "^13.1.1",
@@ -40,7 +40,7 @@
     "@types/node": "^22.14.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
-    "prisma": "^6.4.1",
+    "prisma": "~6.5.0",
     "typescript": "^5.8.3",
     "vite": "^6.2.5",
     "wrangler": "^4.8.0"


### PR DESCRIPTION
From https://discord.com/channels/679514959968993311/1307974274145062912/1361451940449358054

> if you are having issues running release and getting a split error, make sure you are not running v6.6.0 of Prisma, there is an issue https://github.com/prisma/prisma/issues/26881 they are working on. Stick w/ v6.5.0 max