### PR TITLE
fix: Ensure early client hydration during RSC streaming by avoiding type="module" deferral

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,8 +162,8 @@ importers:
   starters/minimal:
     dependencies:
       '@redwoodjs/sdk':
-        specifier: 0.0.57-test.24
-        version: 0.0.57-test.24(@types/node@22.14.0)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1))(rollup@4.34.8)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250408.0)
+        specifier: 0.0.57-test.25
+        version: 0.0.57-test.25(@types/node@22.14.0)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1))(rollup@4.34.8)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250408.0)
       react:
         specifier: 19.0.0-rc-f2df5694-20240916
         version: 19.0.0-rc-f2df5694-20240916
@@ -202,8 +202,8 @@ importers:
         specifier: ~6.5.0
         version: 6.5.0(prisma@6.5.0(typescript@5.8.3))(typescript@5.8.3)
       '@redwoodjs/sdk':
-        specifier: 0.0.57-test.24
-        version: 0.0.57-test.24(@types/node@22.14.0)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1(esbuild@0.25.0)))(rollup@4.34.8)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250408.0)
+        specifier: 0.0.57-test.25
+        version: 0.0.57-test.25(@types/node@22.14.0)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1(esbuild@0.25.0)))(rollup@4.34.8)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250408.0)
       '@simplewebauthn/browser':
         specifier: ^13.1.0
         version: 13.1.0
@@ -1212,8 +1212,8 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@redwoodjs/sdk@0.0.57-test.24':
-    resolution: {integrity: sha512-79jJzqbifPgOPW3QiPmXbLq+VnEvYcVtaq4K/YUfTpDjU5/wO9Iq77M9uLcCc3Cxh+w3bk7+ItQ8rpxjISBQ3g==}
+  '@redwoodjs/sdk@0.0.57-test.25':
+    resolution: {integrity: sha512-udWh3s1i7WAvbAv9mpsek5jOpCfLtGu8mrngoWP29c8OE+yKMNVnXtLan6jFB98Fsxu7584f3ehb3edU4gGA3A==}
     hasBin: true
     peerDependencies:
       react-server-dom-webpack: 19.0.0-rc-f2df5694-20240916
@@ -4979,7 +4979,7 @@ snapshots:
     dependencies:
       dotenv: 16.4.7
 
-  '@redwoodjs/sdk@0.0.57-test.24(@types/node@22.14.0)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1(esbuild@0.25.0)))(rollup@4.34.8)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250408.0)':
+  '@redwoodjs/sdk@0.0.57-test.25(@types/node@22.14.0)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1(esbuild@0.25.0)))(rollup@4.34.8)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250408.0)':
     dependencies:
       '@cloudflare/vite-plugin': 1.0.1(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250408.0)(wrangler@4.8.0(@cloudflare/workers-types@4.20250407.0))
       '@cloudflare/workers-types': 4.20250407.0
@@ -5024,7 +5024,7 @@ snapshots:
       - utf-8-validate
       - workerd
 
-  '@redwoodjs/sdk@0.0.57-test.24(@types/node@22.14.0)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1))(rollup@4.34.8)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250408.0)':
+  '@redwoodjs/sdk@0.0.57-test.25(@types/node@22.14.0)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1))(rollup@4.34.8)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250408.0)':
     dependencies:
       '@cloudflare/vite-plugin': 1.0.1(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250408.0)(wrangler@4.8.0(@cloudflare/workers-types@4.20250407.0))
       '@cloudflare/workers-types': 4.20250407.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,8 +162,8 @@ importers:
   starters/minimal:
     dependencies:
       '@redwoodjs/sdk':
-        specifier: 0.0.57
-        version: 0.0.57(@types/node@22.14.0)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1))(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
+        specifier: 0.0.57-test.24
+        version: 0.0.57-test.24(@types/node@22.14.0)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1))(rollup@4.34.8)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250408.0)
       react:
         specifier: 19.0.0-rc-f2df5694-20240916
         version: 19.0.0-rc-f2df5694-20240916
@@ -202,8 +202,8 @@ importers:
         specifier: ~6.5.0
         version: 6.5.0(prisma@6.5.0(typescript@5.8.3))(typescript@5.8.3)
       '@redwoodjs/sdk':
-        specifier: 0.0.57
-        version: 0.0.57(@types/node@22.14.0)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1(esbuild@0.25.0)))(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
+        specifier: 0.0.57-test.24
+        version: 0.0.57-test.24(@types/node@22.14.0)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1(esbuild@0.25.0)))(rollup@4.34.8)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250408.0)
       '@simplewebauthn/browser':
         specifier: ^13.1.0
         version: 13.1.0
@@ -1212,8 +1212,8 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@redwoodjs/sdk@0.0.57':
-    resolution: {integrity: sha512-nRLtNsjKhK+4qH6D2/DGG+53TZAO6wRz+PNzavPurYNbqZthGN33jQTjlf29kCR8yKaR72Vc6HqHtMqdOIvbpw==}
+  '@redwoodjs/sdk@0.0.57-test.24':
+    resolution: {integrity: sha512-79jJzqbifPgOPW3QiPmXbLq+VnEvYcVtaq4K/YUfTpDjU5/wO9Iq77M9uLcCc3Cxh+w3bk7+ItQ8rpxjISBQ3g==}
     hasBin: true
     peerDependencies:
       react-server-dom-webpack: 19.0.0-rc-f2df5694-20240916
@@ -4316,9 +4316,32 @@ snapshots:
     optionalDependencies:
       workerd: 1.20250405.0
 
+  '@cloudflare/unenv-preset@2.3.1(unenv@2.0.0-rc.15)(workerd@1.20250408.0)':
+    dependencies:
+      unenv: 2.0.0-rc.15
+    optionalDependencies:
+      workerd: 1.20250408.0
+
   '@cloudflare/vite-plugin@1.0.1(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250405.0)(wrangler@4.8.0(@cloudflare/workers-types@4.20250407.0))':
     dependencies:
       '@cloudflare/unenv-preset': 2.3.1(unenv@2.0.0-rc.15)(workerd@1.20250405.0)
+      '@hattip/adapter-node': 0.0.49
+      get-port: 7.1.0
+      miniflare: 4.20250405.0
+      picocolors: 1.1.1
+      tinyglobby: 0.2.12
+      unenv: 2.0.0-rc.15
+      vite: 6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
+      wrangler: 4.8.0(@cloudflare/workers-types@4.20250407.0)
+      ws: 8.18.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - workerd
+
+  '@cloudflare/vite-plugin@1.0.1(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250408.0)(wrangler@4.8.0(@cloudflare/workers-types@4.20250407.0))':
+    dependencies:
+      '@cloudflare/unenv-preset': 2.3.1(unenv@2.0.0-rc.15)(workerd@1.20250408.0)
       '@hattip/adapter-node': 0.0.49
       get-port: 7.1.0
       miniflare: 4.20250405.0
@@ -4956,9 +4979,9 @@ snapshots:
     dependencies:
       dotenv: 16.4.7
 
-  '@redwoodjs/sdk@0.0.57(@types/node@22.14.0)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1(esbuild@0.25.0)))(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))':
+  '@redwoodjs/sdk@0.0.57-test.24(@types/node@22.14.0)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1(esbuild@0.25.0)))(rollup@4.34.8)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250408.0)':
     dependencies:
-      '@cloudflare/vite-plugin': 1.0.1(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250405.0)(wrangler@4.8.0(@cloudflare/workers-types@4.20250407.0))
+      '@cloudflare/vite-plugin': 1.0.1(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250408.0)(wrangler@4.8.0(@cloudflare/workers-types@4.20250407.0))
       '@cloudflare/workers-types': 4.20250407.0
       '@types/fnv-plus': 1.3.2
       '@types/fs-extra': 11.0.4
@@ -5001,9 +5024,9 @@ snapshots:
       - utf-8-validate
       - workerd
 
-  '@redwoodjs/sdk@0.0.57(@types/node@22.14.0)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1))(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))':
+  '@redwoodjs/sdk@0.0.57-test.24(@types/node@22.14.0)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1))(rollup@4.34.8)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250408.0)':
     dependencies:
-      '@cloudflare/vite-plugin': 1.0.1(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250405.0)(wrangler@4.8.0(@cloudflare/workers-types@4.20250407.0))
+      '@cloudflare/vite-plugin': 1.0.1(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250408.0)(wrangler@4.8.0(@cloudflare/workers-types@4.20250407.0))
       '@cloudflare/workers-types': 4.20250407.0
       '@types/fnv-plus': 1.3.2
       '@types/fs-extra': 11.0.4

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redwoodjs/sdk",
-  "version": "0.0.57-test.24",
+  "version": "0.0.57-test.25",
   "description": "Build fast, server-driven webapps on Cloudflare with SSR, RSC, and realtime",
   "type": "module",
   "bin": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redwoodjs/sdk",
-  "version": "0.0.57",
+  "version": "0.0.57-test.23",
   "description": "Build fast, server-driven webapps on Cloudflare with SSR, RSC, and realtime",
   "type": "module",
   "bin": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redwoodjs/sdk",
-  "version": "0.0.57-test.23",
+  "version": "0.0.57-test.24",
   "description": "Build fast, server-driven webapps on Cloudflare with SSR, RSC, and realtime",
   "type": "module",
   "bin": {

--- a/sdk/src/runtime/lib/router.ts
+++ b/sdk/src/runtime/lib/router.ts
@@ -11,7 +11,7 @@ export type RwContext = {
 };
 
 export type RouteMiddleware = (
-  requestInfo: RequestInfo,
+  requestInfo: RequestInfo
 ) =>
   | Response
   | Promise<Response>
@@ -22,7 +22,7 @@ export type RouteMiddleware = (
 type RouteFunction = (requestInfo: RequestInfo) => Response | Promise<Response>;
 
 type RouteComponent = (
-  requestInfo: RequestInfo,
+  requestInfo: RequestInfo
 ) => JSX.Element | Promise<JSX.Element>;
 
 type RouteHandler =
@@ -44,7 +44,7 @@ type RouteMatch = {
 
 function matchPath(
   routePath: string,
-  requestPath: string,
+  requestPath: string
 ): RequestInfo["params"] | null {
   const pattern = routePath
     .replace(/:[a-zA-Z0-9]+/g, "([^/]+)") // Convert :param to capture group
@@ -60,7 +60,7 @@ function matchPath(
   // Extract named parameters and wildcards
   const params: RequestInfo["params"] = {};
   const paramNames = [...routePath.matchAll(/:[a-zA-Z0-9]+/g)].map((m) =>
-    m[0].slice(1),
+    m[0].slice(1)
   );
   const wildcardCount = (routePath.match(/\*/g) || []).length;
 
@@ -100,7 +100,7 @@ export function defineRoutes(routes: Route[]): {
     getRequestInfo: () => RequestInfo;
     runWithRequestInfoOverrides: <Result>(
       overrides: Partial<RequestInfo>,
-      fn: () => Promise<Result>,
+      fn: () => Promise<Result>
     ) => Promise<Result>;
   }) => Response | Promise<Response>;
 } {
@@ -188,7 +188,7 @@ export function index(handler: RouteHandler): RouteDefinition {
 
 export function prefix(
   prefix: string,
-  routes: ReturnType<typeof route>[],
+  routes: ReturnType<typeof route>[]
 ): RouteDefinition[] {
   return routes.map((r) => {
     return {
@@ -199,8 +199,8 @@ export function prefix(
 }
 
 export function render(
-  Document: React.FC<{ children: React.ReactNode }>,
-  routes: Route[],
+  Document: React.FC<DocumentProps>,
+  routes: Route[]
 ): Route[] {
   const documentMiddleware: RouteMiddleware = ({ rw }) => {
     rw.Document = Document;

--- a/sdk/src/vite/injectHmrPreambleJsxPlugin.mts
+++ b/sdk/src/vite/injectHmrPreambleJsxPlugin.mts
@@ -7,22 +7,37 @@ export const injectHmrPreambleJsxPlugin = (): Plugin => ({
   async transform(code: string, id: string) {
     const htmlHeadRE = /jsxDEV\("html",[^]*?jsxDEV\("head",[^]*?\[(.*?)\]/s;
 
-    const match = code.match(htmlHeadRE);
+    const htmlMatch = code.match(htmlHeadRE);
 
-    if (!match) {
+    if (!htmlMatch) {
       return;
     }
 
     const s = new MagicString(code);
-    const headContentStart = match.index! + match[0].lastIndexOf("[");
+    const headContentStart = htmlMatch.index! + htmlMatch[0].lastIndexOf("[");
 
-    s.appendLeft(
-      headContentStart + 1,
-      `jsxDEV("script", { 
-        type: "module",
-        src: "/__vite_preamble__",
-      }),`,
-    );
+    const scriptRegex =
+      /jsxDEV\("script",\s*{\s*dangerouslySetInnerHTML:\s*{\s*__html:\s*['"](.+?)['"]\s*}\s*}\)/g;
+    const fileContent = s.toString();
+
+    let scriptMatch: RegExpExecArray | null;
+    while ((scriptMatch = scriptRegex.exec(fileContent)) !== null) {
+      const scriptContent = scriptMatch[1];
+      const matchIndex = scriptMatch.index;
+      const fullMatch = scriptMatch[0];
+
+      if (scriptContent.includes('import("./src/client.tsx")')) {
+        s.overwrite(
+          matchIndex + fullMatch.indexOf("__html: ") + 8,
+          matchIndex +
+            fullMatch.indexOf("__html: ") +
+            8 +
+            scriptContent.length +
+            2,
+          `'import("/__vite_preamble__").then(() => ${scriptContent})'`
+        );
+      }
+    }
 
     return {
       code: s.toString(),

--- a/starters/minimal/package.json
+++ b/starters/minimal/package.json
@@ -23,7 +23,7 @@
     "types": "tsc"
   },
   "dependencies": {
-    "@redwoodjs/sdk": "0.0.57-test.24",
+    "@redwoodjs/sdk": "0.0.57-test.25",
     "react": "19.0.0-rc-f2df5694-20240916",
     "react-dom": "19.0.0-rc-f2df5694-20240916",
     "react-server-dom-webpack": "19.0.0-rc-f2df5694-20240916"

--- a/starters/minimal/package.json
+++ b/starters/minimal/package.json
@@ -23,7 +23,7 @@
     "types": "tsc"
   },
   "dependencies": {
-    "@redwoodjs/sdk": "0.0.57",
+    "@redwoodjs/sdk": "0.0.57-test.24",
     "react": "19.0.0-rc-f2df5694-20240916",
     "react-dom": "19.0.0-rc-f2df5694-20240916",
     "react-server-dom-webpack": "19.0.0-rc-f2df5694-20240916"

--- a/starters/minimal/src/app/Document.tsx
+++ b/starters/minimal/src/app/Document.tsx
@@ -1,12 +1,15 @@
-export const Document: React.FC<{ children: React.ReactNode }> = ({
+import { DocumentProps } from "@redwoodjs/sdk/router";
+
+export const Document: React.FC<DocumentProps> = ({
   children,
+  rw: { nonce },
 }) => (
   <html lang="en">
     <head>
       <meta charSet="utf-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
       <title>@redwoodjs/starter-minimal</title>
-      <script type="module" src="/src/client.tsx"></script>
+      <script nonce={nonce}>import("./src/client.tsx")</script>
     </head>
     <body>
       <div id="root">{children}</div>

--- a/starters/standard/package.json
+++ b/starters/standard/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@prisma/adapter-d1": "~6.5.0",
     "@prisma/client": "~6.5.0",
-    "@redwoodjs/sdk": "0.0.57",
+    "@redwoodjs/sdk": "0.0.57-test.24",
     "@simplewebauthn/browser": "^13.1.0",
     "@simplewebauthn/server": "^13.1.1",
     "react": "19.0.0-rc-f2df5694-20240916",

--- a/starters/standard/package.json
+++ b/starters/standard/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@prisma/adapter-d1": "~6.5.0",
     "@prisma/client": "~6.5.0",
-    "@redwoodjs/sdk": "0.0.57-test.24",
+    "@redwoodjs/sdk": "0.0.57-test.25",
     "@simplewebauthn/browser": "^13.1.0",
     "@simplewebauthn/server": "^13.1.1",
     "react": "19.0.0-rc-f2df5694-20240916",

--- a/starters/standard/src/app/Document.tsx
+++ b/starters/standard/src/app/Document.tsx
@@ -1,27 +1,17 @@
-<<<<<<< Updated upstream
-import { TurnstileScript } from "@redwoodjs/sdk/turnstile";
-
-export const Document: React.FC<{ children: React.ReactNode }> = ({
-  children,
-=======
 import { DocumentProps } from "@redwoodjs/sdk/router";
+import { TurnstileScript } from "@redwoodjs/sdk/turnstile";
 
 export const Document: React.FC<DocumentProps> = ({
   children,
   rw: { nonce },
->>>>>>> Stashed changes
 }) => (
   <html lang="en">
     <head>
       <meta charSet="utf-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
       <title>@redwoodjs/starter-standard</title>
-<<<<<<< Updated upstream
       <TurnstileScript />
-      <script type="module" src="/src/client.tsx"></script>
-=======
       <script nonce={nonce}>import("./src/client.tsx")</script>
->>>>>>> Stashed changes
     </head>
     <body>
       <div id="root">{children}</div>

--- a/starters/standard/src/app/Document.tsx
+++ b/starters/standard/src/app/Document.tsx
@@ -1,15 +1,27 @@
+<<<<<<< Updated upstream
 import { TurnstileScript } from "@redwoodjs/sdk/turnstile";
 
 export const Document: React.FC<{ children: React.ReactNode }> = ({
   children,
+=======
+import { DocumentProps } from "@redwoodjs/sdk/router";
+
+export const Document: React.FC<DocumentProps> = ({
+  children,
+  rw: { nonce },
+>>>>>>> Stashed changes
 }) => (
   <html lang="en">
     <head>
       <meta charSet="utf-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
       <title>@redwoodjs/starter-standard</title>
+<<<<<<< Updated upstream
       <TurnstileScript />
       <script type="module" src="/src/client.tsx"></script>
+=======
+      <script nonce={nonce}>import("./src/client.tsx")</script>
+>>>>>>> Stashed changes
     </head>
     <body>
       <div id="root">{children}</div>


### PR DESCRIPTION
### **🧠 Context**

While testing client interactivity during RSC streaming, we encountered a delay in hydration with the following layout:

```
export function Home({ ctx }: RequestInfo) {
  return (
    <div>
      <Counter />
      <Suspense fallback={<Loading />}>
        <Todos />
      </Suspense>
    </div>
  );
}
```

In this setup:

-   <Counter /> is a client component rendered before the Suspense boundary

-   <Todos /> is rendered within the boundary

-   The HTML shell is flushed early and includes a <script type="module" src="/src/client.tsx"> intended to hydrate the app

* * * * *

### **🐞 Problem**

Despite being flushed early, the module script does not execute until after the full document has streamed --- including Suspense resolution and the $RC(...) patch. As a result, hydration is delayed and interactivity for components like <Counter /> is postponed.

This occurs because <script type="module"> is deferred by spec, and in streamed RSC environments, modern browsers wait for more of the document before executing it --- even when the markup is complete and well-formed.

* * * * *

### **✅ Solution**

We replaced the module script with a plain inline script that immediately calls import():

```
<script>
  import("/src/client.tsx");
</script>
```

This executes immediately when parsed and ensures that hydration begins as soon as the shell is received --- before Suspense resolves.

* * * * *

### **🔧 Changes**

-   Updated all starter Document components to include the above inline <script> instead of a deferred module script.

-   Updated the Vite preamble injection plugin to handle this new pattern:

    -   When client.tsx is imported dynamically via import(...), the plugin transforms the code to load the preamble first, then chain the actual import.

-   Updated the plugin that parses JSX <script> tags to support builds:

    -   It previously replaced any <script src="..."> tags that pointed to files found in the client manifest, ensuring that source file paths are replaced with their built, hashed equivalents.

    -   It now also handles **inline <script> blocks containing import(...) calls**: if the import target matches an entry in the client manifest, the plugin rewrites the import to point to the built file path.

    -   This is scoped to inline scripts in JSX only --- ordinary JavaScript is already handled by Vite.