### PR TITLE
fix: Client side loading after 0.0.59

### DIFF
--- a/sdk/src/vite/injectHmrPreambleJsxPlugin.mts
+++ b/sdk/src/vite/injectHmrPreambleJsxPlugin.mts
@@ -7,37 +7,22 @@ export const injectHmrPreambleJsxPlugin = (): Plugin => ({
   async transform(code: string, id: string) {
     const htmlHeadRE = /jsxDEV\("html",[^]*?jsxDEV\("head",[^]*?\[(.*?)\]/s;
 
-    const htmlMatch = code.match(htmlHeadRE);
+    const match = code.match(htmlHeadRE);
 
-    if (!htmlMatch) {
+    if (!match) {
       return;
     }
 
     const s = new MagicString(code);
-    const headContentStart = htmlMatch.index! + htmlMatch[0].lastIndexOf("[");
+    const headContentStart = match.index! + match[0].lastIndexOf("[");
 
-    const scriptRegex =
-      /jsxDEV\("script",\s*{\s*dangerouslySetInnerHTML:\s*{\s*__html:\s*['"](.+?)['"]\s*}\s*}\)/g;
-    const fileContent = s.toString();
-
-    let scriptMatch: RegExpExecArray | null;
-    while ((scriptMatch = scriptRegex.exec(fileContent)) !== null) {
-      const scriptContent = scriptMatch[1];
-      const matchIndex = scriptMatch.index;
-      const fullMatch = scriptMatch[0];
-
-      if (scriptContent.includes('import("./src/client.tsx")')) {
-        s.overwrite(
-          matchIndex + fullMatch.indexOf("__html: ") + 8,
-          matchIndex +
-            fullMatch.indexOf("__html: ") +
-            8 +
-            scriptContent.length +
-            2,
-          `'import("/__vite_preamble__").then(() => ${scriptContent})'`
-        );
-      }
-    }
+    s.appendLeft(
+      headContentStart + 1,
+      `jsxDEV("script", { 
+        type: "module",
+        src: "/__vite_preamble__",
+      }),`
+    );
 
     return {
       code: s.toString(),

--- a/sdk/src/vite/transformJsxScriptTagsPlugin.mts
+++ b/sdk/src/vite/transformJsxScriptTagsPlugin.mts
@@ -22,13 +22,13 @@ export const transformJsxScriptTagsPlugin = ({
 }: {
   manifestPath: string;
 }): Plugin => ({
-  name: "rw-sdk-transform-jsx-script-tags",
+  name: "rwsdk:transform-jsx-script-tags",
   apply: "build",
   async transform(code) {
-    // Simpler regex that just looks for the import statement inside script children
-    const scriptImportRE = /children:\s*'import\("([^"]+)"\)'/g;
+    const jsxScriptSrcRE =
+      /(jsx|jsxDEV)\("script",\s*{[^}]*src:\s*["']([^"']+)["'][^}]/g;
 
-    const matches = [...code.matchAll(scriptImportRE)];
+    const matches = [...code.matchAll(jsxScriptSrcRE)];
 
     if (!matches.length) {
       return;
@@ -38,10 +38,11 @@ export const transformJsxScriptTagsPlugin = ({
     const s = new MagicString(code);
 
     for (const match of matches) {
-      const src = match[1].slice("./".length); // Remove leading ./
+      const src = match[2].slice("/".length);
+
       if (manifest[src]) {
         const transformedSrc = manifest[src].file;
-        s.replaceAll(`import("${match[1]}")`, `import("/${transformedSrc}")`);
+        s.replaceAll(src, transformedSrc);
       }
     }
 

--- a/starters/minimal/src/app/Document.tsx
+++ b/starters/minimal/src/app/Document.tsx
@@ -9,7 +9,7 @@ export const Document: React.FC<DocumentProps> = ({
       <meta charSet="utf-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
       <title>@redwoodjs/starter-minimal</title>
-      <script nonce={nonce}>import("./src/client.tsx")</script>
+      <script type="module" src="/src/client.tsx"></script>
     </head>
     <body>
       <div id="root">{children}</div>

--- a/starters/standard/src/app/Document.tsx
+++ b/starters/standard/src/app/Document.tsx
@@ -9,7 +9,7 @@ export const Document: React.FC<DocumentProps> = ({
       <meta charSet="utf-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
       <title>@redwoodjs/starter-standard</title>
-      <script src="/src/client.tsx"></script>
+      <script type="module" src="/src/client.tsx"></script>
     </head>
     <body>
       <div id="root">{children}</div>

--- a/starters/standard/src/app/Document.tsx
+++ b/starters/standard/src/app/Document.tsx
@@ -9,7 +9,7 @@ export const Document: React.FC<DocumentProps> = ({
       <meta charSet="utf-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
       <title>@redwoodjs/starter-standard</title>
-      <script nonce={nonce}>import("./src/client.tsx")</script>
+      <script src="/src/client.tsx"></script>
     </head>
     <body>
       <div id="root">{children}</div>


### PR DESCRIPTION
0.0.58 and 0.0.59 introduces changes that broke client loading:
* 0.0.58: introduced a breaking change where scripts provided in a `Document` needed to be provided as inline scripts (though this was meant to be introduced as a backwards compatible change). This is because the plugin that injects the vite preamble was now incorrectly assuming scripts were always provided as inline scripts in the document.
* 0.0.59: after 0.0.58's change to using inline scripts, 0.0.59 fixed deploys to replace script imports with their built asset equivalents. In the process though, it ended up breaking how scripts are transformed in dev

This PR fixes both these issues by reverting the changes to the relevant vite plugins. It does mean we're no longer getting the fix that #316 intended to solve, but this will be done in a follow-up PR shortly (in a backwards compatible way ideally).