### PR TITLE
Ensure that "use client" is not accidentally transformed.

### DIFF
--- a/sdk/src/vite/useClientPlugin.mts
+++ b/sdk/src/vite/useClientPlugin.mts
@@ -33,7 +33,7 @@ function isJsxFunction(text: string): boolean {
 export async function transformUseClientCode(
   code: string,
   relativeId: string,
-  isWorkerEnvironment: boolean,
+  isWorkerEnvironment: boolean
 ): Promise<TransformResult | undefined> {
   if (!isWorkerEnvironment) {
     return;
@@ -97,7 +97,7 @@ export async function transformUseClientCode(
       const declarations = statement.getDeclarationList().getDeclarations();
       declarations.forEach((varDecl) => {
         const arrowFunc = varDecl.getFirstDescendantByKind(
-          SyntaxKind.ArrowFunction,
+          SyntaxKind.ArrowFunction
         );
         if (!arrowFunc) return;
 
@@ -105,10 +105,10 @@ export async function transformUseClientCode(
         if (isJsxFunction(arrowFunc.getText())) {
           const name = varDecl.getName();
           const isDefault = !!statement.getFirstAncestorByKind(
-            SyntaxKind.ExportAssignment,
+            SyntaxKind.ExportAssignment
           );
           const isInlineExport = statement.hasModifier(
-            SyntaxKind.ExportKeyword,
+            SyntaxKind.ExportKeyword
           );
 
           if (
@@ -168,7 +168,7 @@ export async function transformUseClientCode(
       const nodeText = node.getText();
       const newText = nodeText.replace(
         /^export\s+(default\s+)?(async\s+)?function/,
-        "$2function",
+        "$2function"
       );
       node.replaceWithText(newText);
     } else if (
@@ -188,7 +188,7 @@ export async function transformUseClientCode(
     .forEach((node) => {
       const namedExports = node.getNamedExports();
       const nonComponentExports = namedExports.filter(
-        (exp) => !components.has(exp.getName()),
+        (exp) => !components.has(exp.getName())
       );
 
       if (nonComponentExports.length === 0) {
@@ -216,7 +216,7 @@ export async function transformUseClientCode(
         // First add declarations
         sourceFile.addStatements(`const ${ssrName} = ${expression.getText()}`);
         sourceFile.addStatements(
-          `const ${anonName} = registerClientReference("${relativeId}", "default", ${ssrName});`,
+          `const ${anonName} = registerClientReference("${relativeId}", "default", ${ssrName});`
         );
 
         // Remove the original export default node
@@ -239,10 +239,12 @@ export async function transformUseClientCode(
     ({ ssrName, originalName, isDefault, isAnonymousDefault }) => {
       if (!isAnonymousDefault) {
         sourceFile.addStatements(
-          `const ${originalName} = registerClientReference("${relativeId}", "${isDefault ? "default" : originalName}", ${ssrName});`,
+          `const ${originalName} = registerClientReference("${relativeId}", "${
+            isDefault ? "default" : originalName
+          }", ${ssrName});`
         );
       }
-    },
+    }
   );
 
   // Then add all exports after declarations
@@ -250,7 +252,7 @@ export async function transformUseClientCode(
     if (isDefault) {
       // Export the registerClientReference version as default
       sourceFile.addStatements(
-        `export { ${originalName} as default, ${ssrName} };`,
+        `export { ${originalName} as default, ${ssrName} };`
       );
     } else {
       sourceFile.addStatements(`export { ${ssrName}, ${originalName} };`);
@@ -288,12 +290,19 @@ export const useClientPlugin = (): Plugin => ({
       return;
     }
 
-    if (code.includes('"use client"') || code.includes("'use client'")) {
-      const relativeId = `/${relative(this.environment.getTopLevelConfig().root, id)}`;
+    const cleanCode = code.trimStart();
+    if (
+      cleanCode.startsWith('"use client"') ||
+      cleanCode.startsWith("'use client'")
+    ) {
+      const relativeId = `/${relative(
+        this.environment.getTopLevelConfig().root,
+        id
+      )}`;
       return transformUseClientCode(
         code,
         relativeId,
-        this.environment.name === "worker",
+        this.environment.name === "worker"
       );
     }
   },

--- a/sdk/src/vite/useClientPlugin.test.mts
+++ b/sdk/src/vite/useClientPlugin.test.mts
@@ -13,7 +13,7 @@ describe("transformUseClientCode", () => {
 
 export const Component = () => {
   return jsx('div', { children: 'Hello' });
-}`),
+}`)
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
       const ComponentSSR = () => {
@@ -30,7 +30,7 @@ export const Component = () => {
 
 export const foo = "bar"
 export const baz = 23
-}`),
+}`)
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
       export const foo = "bar"
@@ -45,7 +45,7 @@ export const baz = 23
 
 export const Component = async () => {
   return jsx('div', { children: 'Hello' });
-}`),
+}`)
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
       const ComponentSSR = async () => {
@@ -62,7 +62,7 @@ export const Component = async () => {
 
 export function Component() {
   return jsx('div', { children: 'Hello' });
-}`),
+}`)
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
 
@@ -80,7 +80,7 @@ export function Component() {
 
 export async function Component() {
   return jsx('div', { children: 'Hello' });
-}`),
+}`)
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
 
@@ -102,7 +102,7 @@ export const First = () => {
 
 export const Second = () => {
   return jsx('div', { children: 'Second' });
-}`),
+}`)
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
       const FirstSSR = () => {
@@ -129,7 +129,7 @@ export const First = async () => {
 
 export const Second = async () => {
   return jsx('div', { children: 'Second' });
-}`),
+}`)
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
       const FirstSSR = async () => {
@@ -156,7 +156,7 @@ export function First() {
 
 export function Second() {
   return jsx('div', { children: 'Second' });
-}`),
+}`)
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
 
@@ -184,7 +184,7 @@ export async function First() {
 
 export async function Second() {
   return jsx('div', { children: 'Second' });
-}`),
+}`)
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
 
@@ -214,7 +214,7 @@ const Second = () => {
   return jsx('div', { children: 'Second' });
 }
 
-export { First, Second }`),
+export { First, Second }`)
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
       const FirstSSR = () => {
@@ -245,7 +245,7 @@ const Second = async () => {
   return jsx('div', { children: 'Second' });
 }
 
-export { First, Second }`),
+export { First, Second }`)
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
       const FirstSSR = async () => {
@@ -276,7 +276,7 @@ function Second() {
   return jsx('div', { children: 'Second' });
 }
 
-export { First, Second }`),
+export { First, Second }`)
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
 
@@ -308,7 +308,7 @@ async function Second() {
   return jsx('div', { children: 'Second' });
 }
 
-export { First, Second }`),
+export { First, Second }`)
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
 
@@ -334,7 +334,7 @@ export { First, Second }`),
 
 export default () => {
   return jsx('div', { children: 'Hello' });
-}`),
+}`)
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
       const DefaultComponent0SSR = () => {
@@ -351,7 +351,7 @@ export default () => {
 
 export default async () => {
   return jsx('div', { children: 'Hello' });
-}`),
+}`)
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
       const DefaultComponent0SSR = async () => {
@@ -368,7 +368,7 @@ export default async () => {
 
 export default function Component({ prop1, prop2 }) {
   return jsx('div', { children: 'Hello' });
-}`),
+}`)
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
 
@@ -386,7 +386,7 @@ export default function Component({ prop1, prop2 }) {
 
 export default async function Component() {
   return jsx('div', { children: 'Hello' });
-}`),
+}`)
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
 
@@ -473,7 +473,7 @@ export function ComplexComponent({ initialCount = 0 }) {
       })
     ]
   });
-}`),
+}`)
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
 
@@ -579,7 +579,7 @@ export default function Main() {
 }
 
 export { Second, Third }
-export { Fourth as AnotherName }`),
+export { Fourth as AnotherName }`)
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
       const FirstSSR = () => {
@@ -626,7 +626,7 @@ function Component({ prop1, prop2 }) {
   return jsx('div', { children: 'Hello' });
 }
 
-export default Component;`),
+export default Component;`)
     ).toMatchInlineSnapshot(`
       "import { registerClientReference } from "@redwoodjs/sdk/worker";
 
@@ -721,7 +721,7 @@ export function Chat() {
     columnNumber: 5
   }, this);
 }
-`),
+`)
     ).toMatchInlineSnapshot(`
       "import { jsxDEV } from "react/jsx-dev-runtime";
       import { sendMessage } from "./functions";
@@ -807,5 +807,11 @@ export function Chat() {
       export { ChatSSR, Chat };
       "
     `);
+  });
+
+  it("Does not transform when 'use client' is not directive", async () => {
+    expect(
+      await transform(`const message = "use client";`)
+    ).toMatchInlineSnapshot(``);
   });
 });

--- a/sdk/src/vite/useClientPlugin.test.mts
+++ b/sdk/src/vite/useClientPlugin.test.mts
@@ -810,8 +810,11 @@ export function Chat() {
   });
 
   it("Does not transform when 'use client' is not directive", async () => {
-    expect(
-      await transform(`const message = "use client";`)
-    ).toMatchInlineSnapshot(``);
+    expect(await transform(`const message = "use client";`))
+      .toMatchInlineSnapshot(`
+      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+
+      const message = "use client";"
+    `);
   });
 });


### PR DESCRIPTION
The only thing we have to keep in mind is that this has to be the top of the file, if they add a comment and then `"use client";` it'll break.
Closes #269 