### PR TITLE
fix: Move entry point <script> to <body> in starters

### DIFF
--- a/starters/minimal/src/app/Document.tsx
+++ b/starters/minimal/src/app/Document.tsx
@@ -6,10 +6,10 @@ export const Document: React.FC<{ children: React.ReactNode }> = ({
       <meta charSet="utf-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
       <title>@redwoodjs/starter-minimal</title>
-      <script src="/src/client.tsx"></script>
     </head>
     <body>
       <div id="root">{children}</div>
+      <script src="/src/client.tsx"></script>
     </body>
   </html>
 );

--- a/starters/standard/src/app/Document.tsx
+++ b/starters/standard/src/app/Document.tsx
@@ -6,10 +6,10 @@ export const Document: React.FC<{ children: React.ReactNode }> = ({
       <meta charSet="utf-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
       <title>@redwoodjs/starter-standard</title>
-      <script src="/src/client.tsx"></script>
     </head>
     <body>
       <div id="root">{children}</div>
+      <script src="/src/client.tsx"></script>
     </body>
   </html>
 );


### PR DESCRIPTION
Should have been done in #320, slipped my mind.

See #320 for context.