### PR TITLE
feat: Preload entry point

### DIFF
--- a/starters/minimal/src/app/Document.tsx
+++ b/starters/minimal/src/app/Document.tsx
@@ -6,6 +6,7 @@ export const Document: React.FC<{ children: React.ReactNode }> = ({
       <meta charSet="utf-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
       <title>@redwoodjs/starter-minimal</title>
+      <link rel="preload" href="/src/client.tsx" as="script" />
     </head>
     <body>
       <div id="root">{children}</div>

--- a/starters/standard/src/app/Document.tsx
+++ b/starters/standard/src/app/Document.tsx
@@ -6,6 +6,7 @@ export const Document: React.FC<{ children: React.ReactNode }> = ({
       <meta charSet="utf-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
       <title>@redwoodjs/starter-standard</title>
+      <link rel="preload" href="/src/client.tsx" as="script" />
     </head>
     <body>
       <div id="root">{children}</div>


### PR DESCRIPTION
Slight improvement on #320 and #323 - now that we have the entry point script in the <body> in starters (see #320), ideally we can start downloading these scripts asap - especially considering we are rendering in streaming fashion.

This PR:
* Adds a preload link to the entry point scripts to the starters
* Changes our transform plugin that looks replaces script src with built asset path, to do the same for preload links for scripts