### PR TITLE
feat: Pass CSP nonce to react SSR renderer

### DIFF
--- a/sdk/src/runtime/render/transformRscToHtmlStream.tsx
+++ b/sdk/src/runtime/render/transformRscToHtmlStream.tsx
@@ -6,9 +6,11 @@ import { renderToReadableStream } from "react-dom/server.edge";
 export const transformRscToHtmlStream = ({
   stream,
   Parent = ({ children }) => <>{children}</>,
+  nonce,
 }: {
   stream: ReadableStream;
   Parent: React.ComponentType<{ children: React.ReactNode }>;
+  nonce?: string;
 }) => {
   const thenable = createFromReadableStream(stream, {
     ssrManifest: {
@@ -22,5 +24,7 @@ export const transformRscToHtmlStream = ({
   );
   const el = <Component />;
 
-  return renderToReadableStream(el);
+  return renderToReadableStream(el, {
+    nonce,
+  });
 };

--- a/sdk/src/runtime/worker.tsx
+++ b/sdk/src/runtime/worker.tsx
@@ -131,6 +131,7 @@ export const defineApp = (routes: Route[]) => {
             Parent: ({ children }) => (
               <rw.Document {...requestInfo} children={children} />
             ),
+            nonce: rw.nonce,
           });
 
           const html = htmlStream.pipeThrough(


### PR DESCRIPTION
React's SSR renderer supports a nonce option, which is used for inline scripts added by react, e.g. for suspense boundaries (to "fill in" their results once suspense resolved). This PR passes the CSP nonce the sdk generates to react so that these inline scripts aren't blocked.