### PR TITLE
feat: Use React canary release channel 

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,14 +53,14 @@ importers:
         specifier: ^11.0.4
         version: 11.0.4
       '@types/react':
-        specifier: ^18.3.12
-        version: 18.3.18
+        specifier: ^19.1.2
+        version: 19.1.2
       '@types/react-dom':
-        specifier: ^18.3.1
-        version: 18.3.5(@types/react@18.3.18)
+        specifier: ^19.1.2
+        version: 19.1.2(@types/react@19.1.2)
       '@types/react-is':
-        specifier: ^18.3.1
-        version: 18.3.1
+        specifier: ^19.0.0
+        version: 19.0.0
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.3.4(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
@@ -104,17 +104,17 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
       react:
-        specifier: 19.0.0-rc-f2df5694-20240916
-        version: 19.0.0-rc-f2df5694-20240916
+        specifier: canary
+        version: 19.2.0-canary-39cad7af-20250411
       react-dom:
-        specifier: 19.0.0-rc-f2df5694-20240916
-        version: 19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916)
+        specifier: canary
+        version: 19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411)
       react-is:
         specifier: ^19.0.0
         version: 19.0.0
       react-server-dom-webpack:
-        specifier: 19.0.0-rc-f2df5694-20240916
-        version: 19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1)
+        specifier: canary
+        version: 19.2.0-canary-39cad7af-20250411(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)(webpack@5.97.1)
       rsc-html-stream:
         specifier: ^0.0.3
         version: 0.0.3
@@ -172,26 +172,26 @@ importers:
     dependencies:
       '@redwoodjs/sdk':
         specifier: 0.0.60-test.0
-        version: 0.0.60-test.0(@types/node@22.14.0)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1))(rollup@4.34.8)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250408.0)
+        version: 0.0.60-test.0(@types/node@22.14.0)(react-server-dom-webpack@19.2.0-canary-39cad7af-20250411(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)(webpack@5.97.1))(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
       react:
-        specifier: 19.0.0-rc-f2df5694-20240916
-        version: 19.0.0-rc-f2df5694-20240916
+        specifier: canary
+        version: 19.2.0-canary-39cad7af-20250411
       react-dom:
-        specifier: 19.0.0-rc-f2df5694-20240916
-        version: 19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916)
+        specifier: canary
+        version: 19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411)
       react-server-dom-webpack:
-        specifier: 19.0.0-rc-f2df5694-20240916
-        version: 19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1)
+        specifier: canary
+        version: 19.2.0-canary-39cad7af-20250411(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)(webpack@5.97.1)
     devDependencies:
       '@types/node':
         specifier: ^22.14.0
         version: 22.14.0
       '@types/react':
-        specifier: ^18.3.12
-        version: 18.3.18
+        specifier: ^19.1.2
+        version: 19.1.2
       '@types/react-dom':
-        specifier: ^18.3.1
-        version: 18.3.5(@types/react@18.3.18)
+        specifier: ^19.1.2
+        version: 19.1.2(@types/react@19.1.2)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -212,7 +212,7 @@ importers:
         version: 6.5.0(prisma@6.5.0(typescript@5.8.3))(typescript@5.8.3)
       '@redwoodjs/sdk':
         specifier: 0.0.60-test.0
-        version: 0.0.60-test.0(@types/node@22.14.0)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1(esbuild@0.25.0)))(rollup@4.34.8)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250408.0)
+        version: 0.0.60-test.0(@types/node@22.14.0)(react-server-dom-webpack@19.2.0-canary-39cad7af-20250411(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)(webpack@5.97.1(esbuild@0.25.0)))(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
       '@simplewebauthn/browser':
         specifier: ^13.1.0
         version: 13.1.0
@@ -220,24 +220,24 @@ importers:
         specifier: ^13.1.1
         version: 13.1.1
       react:
-        specifier: 19.0.0-rc-f2df5694-20240916
-        version: 19.0.0-rc-f2df5694-20240916
+        specifier: canary
+        version: 19.2.0-canary-39cad7af-20250411
       react-dom:
-        specifier: 19.0.0-rc-f2df5694-20240916
-        version: 19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916)
+        specifier: canary
+        version: 19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411)
       react-server-dom-webpack:
-        specifier: 19.0.0-rc-f2df5694-20240916
-        version: 19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1(esbuild@0.25.0))
+        specifier: canary
+        version: 19.2.0-canary-39cad7af-20250411(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)(webpack@5.97.1(esbuild@0.25.0))
     devDependencies:
       '@types/node':
         specifier: ^22.14.0
         version: 22.14.0
       '@types/react':
-        specifier: ^18.3.12
-        version: 18.3.18
+        specifier: ^19.1.2
+        version: 19.1.2
       '@types/react-dom':
-        specifier: ^18.3.1
-        version: 18.3.5(@types/react@18.3.18)
+        specifier: ^19.1.2
+        version: 19.1.2(@types/react@19.1.2)
       prisma:
         specifier: ~6.5.0
         version: 6.5.0(typescript@5.8.3)
@@ -1581,11 +1581,22 @@ packages:
     peerDependencies:
       '@types/react': ^18.0.0
 
+  '@types/react-dom@19.1.2':
+    resolution: {integrity: sha512-XGJkWF41Qq305SKWEILa1O8vzhb3aOo3ogBlSmiqNko/WmRb6QIaweuZCXjKygVDXpzXb5wyxKTSOsmkuqj+Qw==}
+    peerDependencies:
+      '@types/react': ^19.0.0
+
   '@types/react-is@18.3.1':
     resolution: {integrity: sha512-zts4lhQn5ia0cF/y2+3V6Riu0MAfez9/LJYavdM8TvcVl+S91A/7VWxyBT8hbRuWspmuCaiGI0F41OJYGrKhRA==}
 
+  '@types/react-is@19.0.0':
+    resolution: {integrity: sha512-71dSZeeJ0t3aoPyY9x6i+JNSvg5m9EF2i2OlSZI5QoJuI8Ocgor610i+4A10TQmURR+0vLwcVCEYFpXdzM1Biw==}
+
   '@types/react@18.3.18':
     resolution: {integrity: sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==}
+
+  '@types/react@19.1.2':
+    resolution: {integrity: sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==}
 
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
@@ -3228,6 +3239,11 @@ packages:
     peerDependencies:
       react: 19.0.0-rc-f2df5694-20240916
 
+  react-dom@19.2.0-canary-39cad7af-20250411:
+    resolution: {integrity: sha512-O9GNnsgW8BtodVQ8kQxUs3y6sy2LwzCLrVfMTgPWSCVmIMj7sb9Pgc9y4Tmzmzj/iaFeNNuZXbiLFsHvhslYww==}
+    peerDependencies:
+      react: 19.2.0-canary-39cad7af-20250411
+
   react-is@19.0.0:
     resolution: {integrity: sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g==}
 
@@ -3235,16 +3251,20 @@ packages:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
 
-  react-server-dom-webpack@19.0.0-rc-f2df5694-20240916:
-    resolution: {integrity: sha512-UhtCHuIp1iE6deBwin/iZJyv4tUqp8pbs2EsYe+cPf0yjwk/CcS98ZFHDNSMKaGNJLRcic25rzl8AlJrqcWkrA==}
+  react-server-dom-webpack@19.2.0-canary-39cad7af-20250411:
+    resolution: {integrity: sha512-B6TOkq4VA+p1rsPsElTCwLEwWe5T+eseoXVzYKR1COR2R2TNjO2bQb+52tr5ZJ76mXnZc18wpUdafp1+Zb6piw==}
     engines: {node: '>=0.10.0'}
     peerDependencies:
-      react: 19.0.0-rc-f2df5694-20240916
-      react-dom: 19.0.0-rc-f2df5694-20240916
+      react: 19.2.0-canary-39cad7af-20250411
+      react-dom: 19.2.0-canary-39cad7af-20250411
       webpack: ^5.59.0
 
   react@19.0.0-rc-f2df5694-20240916:
     resolution: {integrity: sha512-nGf0C1nmtK44uZVBGB1i320+oZpIL4YibvcDUpKQu/2wR/giIydwzVyx4mjsWRXbYDoyX240F04tHoYLTT2a2w==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.0-canary-39cad7af-20250411:
+    resolution: {integrity: sha512-F6Iiuc7rXFtMZpCYM7rjJUSc8ee2xJV2+1s47xYR29U7e3Z5ztSplpEy559zeTEol1nHIxNTRvyFwVjmyEXnUA==}
     engines: {node: '>=0.10.0'}
 
   readable-stream@3.6.2:
@@ -3375,6 +3395,9 @@ packages:
 
   scheduler@0.25.0-rc-f2df5694-20240916:
     resolution: {integrity: sha512-Gn75L9/3lldtLjFYgpsweYP3726xP/cgr23dsD6UZlLHc6RbkPbWiChQOfNuq21r8qManuD8p9hAHpXvtlvvbQ==}
+
+  scheduler@0.27.0-canary-39cad7af-20250411:
+    resolution: {integrity: sha512-u+r6WyKk4zmirtBMZP8QZx0sTptiRxMMbGjf/3nOunE0mNnmkGFDcsG2UVDuOb5CyxvfbxgWE6W5JIyzTN4FXQ==}
 
   schema-utils@3.3.0:
     resolution: {integrity: sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==}
@@ -4390,32 +4413,9 @@ snapshots:
     optionalDependencies:
       workerd: 1.20250405.0
 
-  '@cloudflare/unenv-preset@2.3.1(unenv@2.0.0-rc.15)(workerd@1.20250408.0)':
-    dependencies:
-      unenv: 2.0.0-rc.15
-    optionalDependencies:
-      workerd: 1.20250408.0
-
   '@cloudflare/vite-plugin@1.0.1(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250405.0)(wrangler@4.8.0(@cloudflare/workers-types@4.20250407.0))':
     dependencies:
       '@cloudflare/unenv-preset': 2.3.1(unenv@2.0.0-rc.15)(workerd@1.20250405.0)
-      '@hattip/adapter-node': 0.0.49
-      get-port: 7.1.0
-      miniflare: 4.20250405.0
-      picocolors: 1.1.1
-      tinyglobby: 0.2.12
-      unenv: 2.0.0-rc.15
-      vite: 6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
-      wrangler: 4.8.0(@cloudflare/workers-types@4.20250407.0)
-      ws: 8.18.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - workerd
-
-  '@cloudflare/vite-plugin@1.0.1(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250408.0)(wrangler@4.8.0(@cloudflare/workers-types@4.20250407.0))':
-    dependencies:
-      '@cloudflare/unenv-preset': 2.3.1(unenv@2.0.0-rc.15)(workerd@1.20250408.0)
       '@hattip/adapter-node': 0.0.49
       get-port: 7.1.0
       miniflare: 4.20250405.0
@@ -5062,9 +5062,9 @@ snapshots:
     dependencies:
       dotenv: 16.4.7
 
-  '@redwoodjs/sdk@0.0.60-test.0(@types/node@22.14.0)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1(esbuild@0.25.0)))(rollup@4.34.8)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250408.0)':
+  '@redwoodjs/sdk@0.0.60-test.0(@types/node@22.14.0)(react-server-dom-webpack@19.2.0-canary-39cad7af-20250411(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)(webpack@5.97.1(esbuild@0.25.0)))(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))':
     dependencies:
-      '@cloudflare/vite-plugin': 1.0.1(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250408.0)(wrangler@4.8.0(@cloudflare/workers-types@4.20250407.0))
+      '@cloudflare/vite-plugin': 1.0.1(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250405.0)(wrangler@4.8.0(@cloudflare/workers-types@4.20250407.0))
       '@cloudflare/workers-types': 4.20250407.0
       '@types/fnv-plus': 1.3.2
       '@types/fs-extra': 11.0.4
@@ -5088,7 +5088,7 @@ snapshots:
       react: 19.0.0-rc-f2df5694-20240916
       react-dom: 19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916)
       react-is: 19.0.0
-      react-server-dom-webpack: 19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1(esbuild@0.25.0))
+      react-server-dom-webpack: 19.2.0-canary-39cad7af-20250411(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)(webpack@5.97.1(esbuild@0.25.0))
       rsc-html-stream: 0.0.3
       tmp-promise: 3.0.3
       ts-morph: 25.0.1
@@ -5110,9 +5110,9 @@ snapshots:
       - utf-8-validate
       - workerd
 
-  '@redwoodjs/sdk@0.0.60-test.0(@types/node@22.14.0)(react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1))(rollup@4.34.8)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250408.0)':
+  '@redwoodjs/sdk@0.0.60-test.0(@types/node@22.14.0)(react-server-dom-webpack@19.2.0-canary-39cad7af-20250411(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)(webpack@5.97.1))(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))':
     dependencies:
-      '@cloudflare/vite-plugin': 1.0.1(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250408.0)(wrangler@4.8.0(@cloudflare/workers-types@4.20250407.0))
+      '@cloudflare/vite-plugin': 1.0.1(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250405.0)(wrangler@4.8.0(@cloudflare/workers-types@4.20250407.0))
       '@cloudflare/workers-types': 4.20250407.0
       '@types/fnv-plus': 1.3.2
       '@types/fs-extra': 11.0.4
@@ -5136,7 +5136,7 @@ snapshots:
       react: 19.0.0-rc-f2df5694-20240916
       react-dom: 19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916)
       react-is: 19.0.0
-      react-server-dom-webpack: 19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1)
+      react-server-dom-webpack: 19.2.0-canary-39cad7af-20250411(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)(webpack@5.97.1)
       rsc-html-stream: 0.0.3
       tmp-promise: 3.0.3
       ts-morph: 25.0.1
@@ -5495,13 +5495,25 @@ snapshots:
     dependencies:
       '@types/react': 18.3.18
 
+  '@types/react-dom@19.1.2(@types/react@19.1.2)':
+    dependencies:
+      '@types/react': 19.1.2
+
   '@types/react-is@18.3.1':
     dependencies:
       '@types/react': 18.3.18
 
+  '@types/react-is@19.0.0':
+    dependencies:
+      '@types/react': 19.1.2
+
   '@types/react@18.3.18':
     dependencies:
       '@types/prop-types': 15.7.14
+      csstype: 3.1.3
+
+  '@types/react@19.1.2':
+    dependencies:
       csstype: 3.1.3
 
   '@types/sax@1.2.7':
@@ -5708,7 +5720,7 @@ snapshots:
 
   acorn-loose@8.4.0:
     dependencies:
-      acorn: 8.14.0
+      acorn: 8.14.1
 
   acorn-walk@8.3.2: {}
 
@@ -7712,29 +7724,36 @@ snapshots:
       react: 19.0.0-rc-f2df5694-20240916
       scheduler: 0.25.0-rc-f2df5694-20240916
 
+  react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411):
+    dependencies:
+      react: 19.2.0-canary-39cad7af-20250411
+      scheduler: 0.27.0-canary-39cad7af-20250411
+
   react-is@19.0.0: {}
 
   react-refresh@0.14.2: {}
 
-  react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1(esbuild@0.25.0)):
+  react-server-dom-webpack@19.2.0-canary-39cad7af-20250411(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)(webpack@5.97.1(esbuild@0.25.0)):
     dependencies:
       acorn-loose: 8.4.0
       neo-async: 2.6.2
-      react: 19.0.0-rc-f2df5694-20240916
-      react-dom: 19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916)
+      react: 19.2.0-canary-39cad7af-20250411
+      react-dom: 19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411)
       webpack: 5.97.1(esbuild@0.25.0)
       webpack-sources: 3.2.3
 
-  react-server-dom-webpack@19.0.0-rc-f2df5694-20240916(react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916))(react@19.0.0-rc-f2df5694-20240916)(webpack@5.97.1):
+  react-server-dom-webpack@19.2.0-canary-39cad7af-20250411(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)(webpack@5.97.1):
     dependencies:
       acorn-loose: 8.4.0
       neo-async: 2.6.2
-      react: 19.0.0-rc-f2df5694-20240916
-      react-dom: 19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916)
+      react: 19.2.0-canary-39cad7af-20250411
+      react-dom: 19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411)
       webpack: 5.97.1
       webpack-sources: 3.2.3
 
   react@19.0.0-rc-f2df5694-20240916: {}
+
+  react@19.2.0-canary-39cad7af-20250411: {}
 
   readable-stream@3.6.2:
     dependencies:
@@ -7970,6 +7989,8 @@ snapshots:
   sax@1.4.1: {}
 
   scheduler@0.25.0-rc-f2df5694-20240916: {}
+
+  scheduler@0.27.0-canary-39cad7af-20250411: {}
 
   schema-utils@3.3.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,8 +171,8 @@ importers:
   starters/minimal:
     dependencies:
       '@redwoodjs/sdk':
-        specifier: 0.0.60-test.0
-        version: 0.0.60-test.0(@types/node@22.14.0)(react-server-dom-webpack@19.2.0-canary-39cad7af-20250411(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)(webpack@5.97.1))(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
+        specifier: workspace:*
+        version: link:../../sdk
       react:
         specifier: canary
         version: 19.2.0-canary-39cad7af-20250411
@@ -211,8 +211,8 @@ importers:
         specifier: ~6.5.0
         version: 6.5.0(prisma@6.5.0(typescript@5.8.3))(typescript@5.8.3)
       '@redwoodjs/sdk':
-        specifier: 0.0.60-test.0
-        version: 0.0.60-test.0(@types/node@22.14.0)(react-server-dom-webpack@19.2.0-canary-39cad7af-20250411(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)(webpack@5.97.1(esbuild@0.25.0)))(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
+        specifier: workspace:*
+        version: link:../../sdk
       '@simplewebauthn/browser':
         specifier: ^13.1.0
         version: 13.1.0
@@ -1225,13 +1225,6 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@redwoodjs/sdk@0.0.60-test.0':
-    resolution: {integrity: sha512-1onIXe4yp8voVmBxzgw9pBWapbtRM3FeD11L1vAOjA62fP63Wr3fDY34+AVc9WiWZvASPTKZDaRKx9X6M+eiBg==}
-    hasBin: true
-    peerDependencies:
-      react-server-dom-webpack: 19.0.0-rc-f2df5694-20240916
-      vite: ^6.2.5
-
   '@rollup/plugin-virtual@3.0.2':
     resolution: {integrity: sha512-10monEYsBp3scM4/ND4LNH5Rxvh3e/cVeL3jWTgZ2SrQ+BmUoQcopVQvnaMcOnykb1VkxUFuDAN+0FnpTFRy2A==}
     engines: {node: '>=14.0.0'}
@@ -1573,27 +1566,13 @@ packages:
   '@types/node@22.14.0':
     resolution: {integrity: sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==}
 
-  '@types/prop-types@15.7.14':
-    resolution: {integrity: sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==}
-
-  '@types/react-dom@18.3.5':
-    resolution: {integrity: sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==}
-    peerDependencies:
-      '@types/react': ^18.0.0
-
   '@types/react-dom@19.1.2':
     resolution: {integrity: sha512-XGJkWF41Qq305SKWEILa1O8vzhb3aOo3ogBlSmiqNko/WmRb6QIaweuZCXjKygVDXpzXb5wyxKTSOsmkuqj+Qw==}
     peerDependencies:
       '@types/react': ^19.0.0
 
-  '@types/react-is@18.3.1':
-    resolution: {integrity: sha512-zts4lhQn5ia0cF/y2+3V6Riu0MAfez9/LJYavdM8TvcVl+S91A/7VWxyBT8hbRuWspmuCaiGI0F41OJYGrKhRA==}
-
   '@types/react-is@19.0.0':
     resolution: {integrity: sha512-71dSZeeJ0t3aoPyY9x6i+JNSvg5m9EF2i2OlSZI5QoJuI8Ocgor610i+4A10TQmURR+0vLwcVCEYFpXdzM1Biw==}
-
-  '@types/react@18.3.18':
-    resolution: {integrity: sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==}
 
   '@types/react@19.1.2':
     resolution: {integrity: sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==}
@@ -3234,11 +3213,6 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
-  react-dom@19.0.0-rc-f2df5694-20240916:
-    resolution: {integrity: sha512-z5bmlgbhXEUNO902dKEuy61Lk/6E06ESsufiIdykddfyhggoRd/0GSZiUH12bGnwmzMnojICk2yI3yNpPIwpCw==}
-    peerDependencies:
-      react: 19.0.0-rc-f2df5694-20240916
-
   react-dom@19.2.0-canary-39cad7af-20250411:
     resolution: {integrity: sha512-O9GNnsgW8BtodVQ8kQxUs3y6sy2LwzCLrVfMTgPWSCVmIMj7sb9Pgc9y4Tmzmzj/iaFeNNuZXbiLFsHvhslYww==}
     peerDependencies:
@@ -3258,10 +3232,6 @@ packages:
       react: 19.2.0-canary-39cad7af-20250411
       react-dom: 19.2.0-canary-39cad7af-20250411
       webpack: ^5.59.0
-
-  react@19.0.0-rc-f2df5694-20240916:
-    resolution: {integrity: sha512-nGf0C1nmtK44uZVBGB1i320+oZpIL4YibvcDUpKQu/2wR/giIydwzVyx4mjsWRXbYDoyX240F04tHoYLTT2a2w==}
-    engines: {node: '>=0.10.0'}
 
   react@19.2.0-canary-39cad7af-20250411:
     resolution: {integrity: sha512-F6Iiuc7rXFtMZpCYM7rjJUSc8ee2xJV2+1s47xYR29U7e3Z5ztSplpEy559zeTEol1nHIxNTRvyFwVjmyEXnUA==}
@@ -3392,9 +3362,6 @@ packages:
 
   sax@1.4.1:
     resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
-
-  scheduler@0.25.0-rc-f2df5694-20240916:
-    resolution: {integrity: sha512-Gn75L9/3lldtLjFYgpsweYP3726xP/cgr23dsD6UZlLHc6RbkPbWiChQOfNuq21r8qManuD8p9hAHpXvtlvvbQ==}
 
   scheduler@0.27.0-canary-39cad7af-20250411:
     resolution: {integrity: sha512-u+r6WyKk4zmirtBMZP8QZx0sTptiRxMMbGjf/3nOunE0mNnmkGFDcsG2UVDuOb5CyxvfbxgWE6W5JIyzTN4FXQ==}
@@ -5062,102 +5029,6 @@ snapshots:
     dependencies:
       dotenv: 16.4.7
 
-  '@redwoodjs/sdk@0.0.60-test.0(@types/node@22.14.0)(react-server-dom-webpack@19.2.0-canary-39cad7af-20250411(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)(webpack@5.97.1(esbuild@0.25.0)))(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))':
-    dependencies:
-      '@cloudflare/vite-plugin': 1.0.1(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250405.0)(wrangler@4.8.0(@cloudflare/workers-types@4.20250407.0))
-      '@cloudflare/workers-types': 4.20250407.0
-      '@types/fnv-plus': 1.3.2
-      '@types/fs-extra': 11.0.4
-      '@types/react': 18.3.18
-      '@types/react-dom': 18.3.5(@types/react@18.3.18)
-      '@types/react-is': 18.3.1
-      '@vitejs/plugin-react': 4.3.4(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
-      debug: 4.4.0
-      es-module-lexer: 1.6.0
-      eventsource-parser: 3.0.0
-      execa: 9.5.2
-      fnv-plus: 1.3.1
-      fs-extra: 11.3.0
-      glob: 11.0.1
-      import-meta-resolve: 4.1.0
-      jsonc-parser: 3.3.1
-      lodash: 4.17.21
-      magic-string: 0.30.17
-      miniflare: 4.20250405.0
-      picocolors: 1.1.1
-      react: 19.0.0-rc-f2df5694-20240916
-      react-dom: 19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916)
-      react-is: 19.0.0
-      react-server-dom-webpack: 19.2.0-canary-39cad7af-20250411(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)(webpack@5.97.1(esbuild@0.25.0))
-      rsc-html-stream: 0.0.3
-      tmp-promise: 3.0.3
-      ts-morph: 25.0.1
-      unique-names-generator: 4.7.1
-      vite: 6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
-      vite-plugin-commonjs: 0.10.4
-      vite-plugin-dts: 4.5.0(@types/node@22.14.0)(rollup@4.34.8)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
-      vite-plugin-top-level-await: 1.4.4(rollup@4.34.8)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
-      vite-plugin-wasm: 3.4.1(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
-      vite-tsconfig-paths: 5.1.4(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
-      wrangler: 4.8.0(@cloudflare/workers-types@4.20250407.0)
-    transitivePeerDependencies:
-      - '@swc/helpers'
-      - '@types/node'
-      - bufferutil
-      - rollup
-      - supports-color
-      - typescript
-      - utf-8-validate
-      - workerd
-
-  '@redwoodjs/sdk@0.0.60-test.0(@types/node@22.14.0)(react-server-dom-webpack@19.2.0-canary-39cad7af-20250411(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)(webpack@5.97.1))(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))':
-    dependencies:
-      '@cloudflare/vite-plugin': 1.0.1(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250405.0)(wrangler@4.8.0(@cloudflare/workers-types@4.20250407.0))
-      '@cloudflare/workers-types': 4.20250407.0
-      '@types/fnv-plus': 1.3.2
-      '@types/fs-extra': 11.0.4
-      '@types/react': 18.3.18
-      '@types/react-dom': 18.3.5(@types/react@18.3.18)
-      '@types/react-is': 18.3.1
-      '@vitejs/plugin-react': 4.3.4(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
-      debug: 4.4.0
-      es-module-lexer: 1.6.0
-      eventsource-parser: 3.0.0
-      execa: 9.5.2
-      fnv-plus: 1.3.1
-      fs-extra: 11.3.0
-      glob: 11.0.1
-      import-meta-resolve: 4.1.0
-      jsonc-parser: 3.3.1
-      lodash: 4.17.21
-      magic-string: 0.30.17
-      miniflare: 4.20250405.0
-      picocolors: 1.1.1
-      react: 19.0.0-rc-f2df5694-20240916
-      react-dom: 19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916)
-      react-is: 19.0.0
-      react-server-dom-webpack: 19.2.0-canary-39cad7af-20250411(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)(webpack@5.97.1)
-      rsc-html-stream: 0.0.3
-      tmp-promise: 3.0.3
-      ts-morph: 25.0.1
-      unique-names-generator: 4.7.1
-      vite: 6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
-      vite-plugin-commonjs: 0.10.4
-      vite-plugin-dts: 4.5.0(@types/node@22.14.0)(rollup@4.34.8)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
-      vite-plugin-top-level-await: 1.4.4(rollup@4.34.8)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
-      vite-plugin-wasm: 3.4.1(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
-      vite-tsconfig-paths: 5.1.4(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
-      wrangler: 4.8.0(@cloudflare/workers-types@4.20250407.0)
-    transitivePeerDependencies:
-      - '@swc/helpers'
-      - '@types/node'
-      - bufferutil
-      - rollup
-      - supports-color
-      - typescript
-      - utf-8-validate
-      - workerd
-
   '@rollup/plugin-virtual@3.0.2(rollup@4.34.8)':
     optionalDependencies:
       rollup: 4.34.8
@@ -5489,28 +5360,13 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/prop-types@15.7.14': {}
-
-  '@types/react-dom@18.3.5(@types/react@18.3.18)':
-    dependencies:
-      '@types/react': 18.3.18
-
   '@types/react-dom@19.1.2(@types/react@19.1.2)':
     dependencies:
       '@types/react': 19.1.2
 
-  '@types/react-is@18.3.1':
-    dependencies:
-      '@types/react': 18.3.18
-
   '@types/react-is@19.0.0':
     dependencies:
       '@types/react': 19.1.2
-
-  '@types/react@18.3.18':
-    dependencies:
-      '@types/prop-types': 15.7.14
-      csstype: 3.1.3
 
   '@types/react@19.1.2':
     dependencies:
@@ -7719,11 +7575,6 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-dom@19.0.0-rc-f2df5694-20240916(react@19.0.0-rc-f2df5694-20240916):
-    dependencies:
-      react: 19.0.0-rc-f2df5694-20240916
-      scheduler: 0.25.0-rc-f2df5694-20240916
-
   react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411):
     dependencies:
       react: 19.2.0-canary-39cad7af-20250411
@@ -7750,8 +7601,6 @@ snapshots:
       react-dom: 19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411)
       webpack: 5.97.1
       webpack-sources: 3.2.3
-
-  react@19.0.0-rc-f2df5694-20240916: {}
 
   react@19.2.0-canary-39cad7af-20250411: {}
 
@@ -7987,8 +7836,6 @@ snapshots:
   safe-buffer@5.2.1: {}
 
   sax@1.4.1: {}
-
-  scheduler@0.25.0-rc-f2df5694-20240916: {}
 
   scheduler@0.27.0-canary-39cad7af-20250411: {}
 

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -95,13 +95,15 @@
   "author": "RedwoodSDK <peter@redwoodjs.com>",
   "license": "MIT",
   "dependencies": {
+    "react": "canary",
+    "react-dom": "canary",
     "@cloudflare/vite-plugin": "^1.0.1",
     "@cloudflare/workers-types": "^4.20250407.0",
     "@types/fnv-plus": "^1.3.2",
     "@types/fs-extra": "^11.0.4",
-    "@types/react": "^18.3.12",
-    "@types/react-dom": "^18.3.1",
-    "@types/react-is": "^18.3.1",
+    "@types/react": "^19.1.2",
+    "@types/react-dom": "^19.1.2",
+    "@types/react-is": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.4",
     "debug": "^4.4.0",
     "es-module-lexer": "^1.5.4",
@@ -116,8 +118,6 @@
     "magic-string": "^0.30.17",
     "miniflare": "^4.20250405.0",
     "picocolors": "^1.1.1",
-    "react": "19.0.0-rc-f2df5694-20240916",
-    "react-dom": "19.0.0-rc-f2df5694-20240916",
     "react-is": "^19.0.0",
     "rsc-html-stream": "^0.0.3",
     "tmp-promise": "^3.0.3",
@@ -131,7 +131,7 @@
     "wrangler": "^4.8.0"
   },
   "peerDependencies": {
-    "react-server-dom-webpack": "19.0.0-rc-f2df5694-20240916",
+    "react-server-dom-webpack": "canary",
     "vite": "^6.2.5"
   },
   "packageManager": "pnpm@9.14.4+sha512.c8180b3fbe4e4bca02c94234717896b5529740a6cbadf19fa78254270403ea2f27d4e1d46a08a0f56c89b63dc8ebfd3ee53326da720273794e6200fcf0d184ab",

--- a/sdk/src/runtime/lib/router.ts
+++ b/sdk/src/runtime/lib/router.ts
@@ -1,3 +1,4 @@
+import type React from "react";
 import { isValidElementType } from "react-is";
 import { RequestInfo } from "../requestInfo/types";
 
@@ -23,7 +24,7 @@ type RouteFunction = (requestInfo: RequestInfo) => Response | Promise<Response>;
 
 type RouteComponent = (
   requestInfo: RequestInfo
-) => JSX.Element | Promise<JSX.Element>;
+) => React.JSX.Element | Promise<React.JSX.Element>;
 
 type RouteHandler =
   | RouteFunction

--- a/sdk/src/runtime/render/transformRscToHtmlStream.tsx
+++ b/sdk/src/runtime/render/transformRscToHtmlStream.tsx
@@ -13,7 +13,7 @@ export const transformRscToHtmlStream = ({
   nonce?: string;
 }) => {
   const thenable = createFromReadableStream(stream, {
-    ssrManifest: {
+    serverConsumerManifest: {
       moduleMap: createModuleMap(),
       moduleLoading: null,
     },

--- a/sdk/types/react.d.ts
+++ b/sdk/types/react.d.ts
@@ -48,7 +48,7 @@ declare module "react-server-dom-webpack/server.edge" {
   export function renderToReadableStream(
     model: ReactClientValue,
     webpackMap: ClientManifest,
-    options?: Options,
+    options?: Options
   ): ReadableStream;
 
   /**
@@ -64,7 +64,7 @@ declare module "react-server-dom-webpack/server.edge" {
   export function registerClientReference<T>(
     proxyImplementation: T,
     id: string,
-    exportName: string,
+    exportName: string
   ): T;
 }
 
@@ -94,7 +94,7 @@ declare module "react-server-dom-webpack/client" {
     // `Response` is a Web Response:
     // https://developer.mozilla.org/en-US/docs/Web/API/Response
     promiseForResponse: Promise<Response>,
-    options?: Options<A, T>,
+    options?: Options<A, T>
   ): Thenable<T>;
 
   /**
@@ -108,7 +108,7 @@ declare module "react-server-dom-webpack/client" {
    */
   export function encodeReply(
     // https://github.com/facebook/react/blob/dfaed5582550f11b27aae967a8e7084202dd2d90/packages/react-client/src/ReactFlightReplyClient.js#L65
-    value: ReactServerValue,
+    value: ReactServerValue
   ): Promise<string | URLSearchParams | FormData>;
 }
 
@@ -121,36 +121,36 @@ declare module "react-server-dom-webpack/server.edge" {
     bundlerConfig: import("./react").BundlerConfig,
     opitons?: {
       onError: import("react-dom/server").RenderToReadableStreamOptions["onError"];
-    },
+    }
   ): ReadableStream<Uint8Array>;
 
   export function registerClientReference<T>(
     ref: T,
     id: string,
-    name: string,
+    name: string
   ): T;
 
   export function registerServerReference<T>(
     ref: T,
     id: string,
-    name: string,
+    name: string
   ): T;
 
   export function decodeReply(
     body: string | FormData,
-    bundlerConfig: import("./react").BundlerConfig,
+    bundlerConfig: import("./react").BundlerConfig
     // TODO: temporaryReferences
   ): Promise<unknown[]>;
 
   export function decodeAction(
     body: FormData,
-    bundlerConfig: import("./react").BundlerConfig,
+    bundlerConfig: import("./react").BundlerConfig
   ): Promise<() => Promise<unknown>>;
 
   export function decodeFormState(
     actionResult: unknown,
     body: FormData,
-    serverManifest?: unknown,
+    serverManifest?: unknown
   ): Promise<unknown>;
 }
 
@@ -176,7 +176,7 @@ declare module "react-server-dom-webpack/server" {
    */
   export function decodeReply<T>(
     body: string | FormData,
-    webpackMap?: ServerManifest,
+    webpackMap?: ServerManifest
   ): Promise<T>;
 
   /**
@@ -190,7 +190,7 @@ declare module "react-server-dom-webpack/server" {
    */
   export function decodeReplyFromBusboy<T>(
     busboyStream: Busboy,
-    webpackMap?: ServerManifest,
+    webpackMap?: ServerManifest
   ): Promise<T>;
 
   type PipeableStream = {
@@ -211,7 +211,7 @@ declare module "react-server-dom-webpack/server" {
    */
   export function renderToPipeableStream(
     model: ReactClientValue,
-    webpackMap: ClientManifest,
+    webpackMap: ClientManifest
   ): PipeableStream;
 }
 
@@ -223,21 +223,21 @@ declare module "react-server-dom-webpack/client.browser" {
   export function createServerReference(
     id: string,
     callServer: CallServerCallback,
-    encodeFormAction?: unknown,
+    encodeFormAction?: unknown
   ): Function;
 
   export function createFromReadableStream<T>(
     stream: ReadableStream<Uint8Array>,
     options?: {
       callServer?: CallServerCallback;
-    },
+    }
   ): Promise<T>;
 
   export function createFromFetch<T>(
     promiseForResponse: Promise<Response>,
     options?: {
       callServer?: import("./react").CallServerCallback;
-    },
+    }
   ): Promise<T>;
 
   export function encodeReply(v: unknown[]): Promise<string | FormData>;
@@ -257,15 +257,15 @@ declare module "react-server-dom-webpack/client.edge" {
   export function createFromReadableStream<T>(
     stream: ReadableStream,
     options: {
-      ssrManifest: {
+      serverConsumerManifest: {
         moduleMap: ClientManifest;
         moduleLoading: null;
       };
-    },
+    }
   ): Thenable<T>;
 
   export function createServerReference<A, T>(
     id: string,
-    callServer: (id: string, args: A) => Promise<T>,
+    callServer: (id: string, args: A) => Promise<T>
   );
 }

--- a/starters/minimal/package.json
+++ b/starters/minimal/package.json
@@ -24,14 +24,14 @@
   },
   "dependencies": {
     "@redwoodjs/sdk": "0.0.60-test.0",
-    "react": "19.0.0-rc-f2df5694-20240916",
-    "react-dom": "19.0.0-rc-f2df5694-20240916",
-    "react-server-dom-webpack": "19.0.0-rc-f2df5694-20240916"
+    "react": "canary",
+    "react-dom": "canary",
+    "react-server-dom-webpack": "canary"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",
-    "@types/react": "^18.3.12",
-    "@types/react-dom": "^18.3.1",
+    "@types/react": "^19.1.2",
+    "@types/react-dom": "^19.1.2",
     "typescript": "^5.8.3",
     "vite": "^6.2.5",
     "wrangler": "^4.8.0"

--- a/starters/minimal/package.json
+++ b/starters/minimal/package.json
@@ -23,7 +23,7 @@
     "types": "tsc"
   },
   "dependencies": {
-    "@redwoodjs/sdk": "0.0.60-test.0",
+    "@redwoodjs/sdk": "workspace:*",
     "react": "canary",
     "react-dom": "canary",
     "react-server-dom-webpack": "canary"

--- a/starters/standard/package.json
+++ b/starters/standard/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@prisma/adapter-d1": "~6.5.0",
     "@prisma/client": "~6.5.0",
-    "@redwoodjs/sdk": "0.0.60-test.0",
+    "@redwoodjs/sdk": "workspace:*",
     "@simplewebauthn/browser": "^13.1.0",
     "@simplewebauthn/server": "^13.1.1",
     "react": "canary",

--- a/starters/standard/package.json
+++ b/starters/standard/package.json
@@ -32,14 +32,14 @@
     "@redwoodjs/sdk": "0.0.60-test.0",
     "@simplewebauthn/browser": "^13.1.0",
     "@simplewebauthn/server": "^13.1.1",
-    "react": "19.0.0-rc-f2df5694-20240916",
-    "react-dom": "19.0.0-rc-f2df5694-20240916",
-    "react-server-dom-webpack": "19.0.0-rc-f2df5694-20240916"
+    "react": "canary",
+    "react-dom": "canary",
+    "react-server-dom-webpack": "canary"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",
-    "@types/react": "^18.3.12",
-    "@types/react-dom": "^18.3.1",
+    "@types/react": "^19.1.2",
+    "@types/react-dom": "^19.1.2",
     "prisma": "~6.5.0",
     "typescript": "^5.8.3",
     "vite": "^6.2.5",


### PR DESCRIPTION
The recommendation here https://react.dev/reference/rsc/server-components, is that frameworks (like us!) should use canary channel. This PR updates our react deps accordingly.

Also updates react typedefs. This fixes an issue we saw with types for async components: https://discord.com/channels/679514959968993311/1361606082102951946/1361804456701722795