### PR TITLE
Remove aside re minimal starter

### DIFF
--- a/docs/src/content/docs/core/overview.mdx
+++ b/docs/src/content/docs/core/overview.mdx
@@ -6,12 +6,6 @@ tableOfContents: false
 
 import { Aside } from "@astrojs/starlight/components";
 
-<Aside type="caution">
-  The [Quick Start Guide](getting-started/quick-start) uses the **minimal
-  starter**, you should use the **standard starter** to get you set up and ready
-  for using Database, Queues, Sessions and Authentication.
-</Aside>
-
 Things you need to know in order to be effective with RedwoodSDK:
 
 1. [Request Handling, Routing & Responses](/core/routing)


### PR DESCRIPTION
We had an aside in the core docs overview mentioning that quick start using minimal starter but core uses standard. We're bcak to using standard starter in quick start so removing the aside.