### PR TITLE
fix: Separate webauthn vars for auth secret key vars in deployment script

### DIFF
--- a/starters/standard/src/session/store.ts
+++ b/starters/standard/src/session/store.ts
@@ -4,7 +4,6 @@ export let sessions: ReturnType<typeof createSessionStore>;
 
 const createSessionStore = (env: Env) =>
   defineDurableSession({
-    secretKey: env.AUTH_SECRET_KEY,
     sessionDurableObject: env.SESSION_DURABLE_OBJECT,
   });
 


### PR DESCRIPTION
In our deployment script, we check if the codebase has webauthn references, and only then set the relevant vars. At the moment this also includes `AUTH_SECRET_KEY` - but this is problematic since an application might have no webauthn but still reference `AUTH_SECRET_KEY`.

This PR fixes this by checking and handling for AUTH_SECRET_KEY separately in the deployment script.