### PR TITLE
fix: Check for sdk/auth import in deploy script

### DIFF
--- a/sdk/src/scripts/ensure-deploy-env.mts
+++ b/sdk/src/scripts/ensure-deploy-env.mts
@@ -53,7 +53,7 @@ const hasD1Database = async () => {
   return false;
 };
 
-const hasAuthSecret = async () => {
+const hasAuthUsage = async () => {
   const files = await glob("src/**/*.{ts,tsx}", { ignore: "node_modules/**" });
   for (const file of files) {
     const content = await readFile(file, "utf-8");
@@ -161,13 +161,12 @@ export const ensureDeployEnv = async () => {
   }
 
   // Check AUTH_SECRET_KEY setup
-  const needsAuthSecret = await hasAuthSecret();
-  if (!needsAuthSecret) {
+  if (!(await hasAuthUsage())) {
     console.log(
-      "Skipping AUTH_SECRET_KEY setup - no AUTH_SECRET_KEY usage detected in codebase"
+      "Skipping AUTH_SECRET_KEY setup - no auth usage detected in codebase"
     );
   } else {
-    console.log("Found AUTH_SECRET_KEY usage, checking secret setup...");
+    console.log("Found auth usage, checking secret setup...");
     try {
       // Get list of all secrets
       const secretsResult = await $`wrangler secret list --format=json`;

--- a/sdk/src/scripts/ensure-deploy-env.mts
+++ b/sdk/src/scripts/ensure-deploy-env.mts
@@ -57,7 +57,7 @@ const hasAuthSecret = async () => {
   const files = await glob("src/**/*.{ts,tsx}", { ignore: "node_modules/**" });
   for (const file of files) {
     const content = await readFile(file, "utf-8");
-    if (content.includes("AUTH_SECRET_KEY")) {
+    if (content.includes("@redwoodjs/sdk/auth")) {
       return true;
     }
   }


### PR DESCRIPTION
In #329, we're looking for an `AUTH_SECRET_KEY` when deciding whether to set it during deployment. Except we no longer require this var to be specified in user app (we look it up in the sdk itself). What we _should_ be looking for, is imports to `@redwoodjs/sdk/auth`. That's what we change in this PR.