### PR TITLE
fix: react-dom/server.edge resolving in dev

### DIFF
--- a/sdk/src/vite/reactConditionsResolverPlugin.mts
+++ b/sdk/src/vite/reactConditionsResolverPlugin.mts
@@ -78,19 +78,17 @@ export const reactConditionsResolverPlugin = async ({
       const baseResolved = sdkRequire.resolve("react-dom");
       const packageDir = path.dirname(baseResolved);
 
-      // Resolve directly to the edge production file
-      const edgeProductionPath = path.join(
-        packageDir,
-        "cjs",
-        "react-dom-server.edge.production.js"
-      );
-      if (await pathExists(edgeProductionPath)) {
-        log(
-          "Using edge production server for %s: %s",
-          packageName,
-          edgeProductionPath
-        );
-        return edgeProductionPath;
+      // Determine which file to use based on mode
+      const edgeFileName =
+        mode === "development"
+          ? "react-dom-server.edge.development.js"
+          : "react-dom-server.edge.production.js";
+
+      const edgePath = path.join(packageDir, "cjs", edgeFileName);
+
+      if (await pathExists(edgePath)) {
+        log("Using edge %s server for %s: %s", mode, packageName, edgePath);
+        return edgePath;
       }
     }
 


### PR DESCRIPTION
#331 moves the react deps to the sdk, which required some custom resolving (see #331 description for more context on that). For `react-dom/server.edge`, we were only resolving correctly in production - in dev we were resolving to whatever `require('react-dom/server')` would resolve to, which differs to what the other react deps would be expecting in the context of edge+development.