### PR TITLE
README: Fixes readme link rendering in main title heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,20 +5,21 @@
       <img alt="RedwoodSDK logo" src="https://imagedelivery.net/EBSSfnGYYD9-tGTmYMjDgg/37162c6c-890c-48e3-790a-48b2b87fcd00/public" height="128">
     </picture>
   </a>
-  
-  <h1>RedwoodSDK | The React Framework for [Cloudflare](https://www.cloudflare.com/).</h1>
 
-  <a href="https://rwsdk.com"><img alt="Redwood Inc. logo" src="https://img.shields.io/badge/MADE%20BY%20Redwood%20Inc.-000000.svg?style=for-the-badge&logo=Redwood&labelColor=000"></a>
-  <a href="https://docs.rwsdk.com"><img alt="Documentation" src="https://img.shields.io/badge/Documentation-000000.svg?style=for-the-badge&logo=Redwood&labelColor=000"></a>
-  <a href="https://discord.gg/redwoodjs"><img alt="Join the community on Discord" src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&logo=Discord&labelColor=000000&logoWidth=20"></a>
-  <a href="https://github.com/redwoodjs/sdk/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/redwoodjs/sdk?style=for-the-badge&labelColor=000000"></a>
+  <h1>RedwoodSDK | The React Framework for <a href="https://www.cloudflare.com/">Cloudflare</a>.</h1>
+
+<a href="https://rwsdk.com"><img alt="Redwood Inc. logo" src="https://img.shields.io/badge/MADE%20BY%20Redwood%20Inc.-000000.svg?style=for-the-badge&logo=Redwood&labelColor=000"></a>
+<a href="https://docs.rwsdk.com"><img alt="Documentation" src="https://img.shields.io/badge/Documentation-000000.svg?style=for-the-badge&logo=Redwood&labelColor=000"></a>
+<a href="https://discord.gg/redwoodjs"><img alt="Join the community on Discord" src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&logo=Discord&labelColor=000000&logoWidth=20"></a>
+<a href="https://github.com/redwoodjs/sdk/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/redwoodjs/sdk?style=for-the-badge&labelColor=000000"></a>
+
 </div>
 
 # RedwoodSDK
 
 RedwoodSDK is a React Framework for [Cloudflare](https://www.cloudflare.com/).
 
-It begins as a Vite plugin that unlocks SSR, React Server Components, Server Functions, and realtime features.  Its standards-based router, with support for middleware and  interruptors, gives you fine-grained control over every request and  response.
+It begins as a Vite plugin that unlocks SSR, React Server Components, Server Functions, and realtime features. Its standards-based router, with support for middleware and interruptors, gives you fine-grained control over every request and response.
 
 → [Quick start](https://docs.rwsdk.com/getting-started/quick-start/)
 → [Docs](https://docs.rwsdk.com/)


### PR DESCRIPTION
<img width="929" alt="image" src="https://github.com/user-attachments/assets/8cd4a84f-8ffb-491b-8dce-708a8d04d8d2" />

The issue is that markdown syntax doesn't work inside HTML tags. When you have HTML tags like `h1`, the content inside them is treated as HTML, not markdown. So the markdown link syntax 

```
[Cloudflare](https://www.cloudflare.com/)
```
 won't be processed as a link.

Uses standard anchor.