### PR TITLE
fix: Avoid warning when no prisma wasm found

### DIFF
--- a/sdk/src/vite/copyPrismaWasmPlugin.mts
+++ b/sdk/src/vite/copyPrismaWasmPlugin.mts
@@ -15,7 +15,7 @@ export const copyPrismaWasmPlugin = ({
   async writeBundle() {
     const wasmFilePath = resolve(
       rootDir,
-      "node_modules/.prisma/client/query_engine_bg.wasm",
+      "node_modules/.prisma/client/query_engine_bg.wasm"
     );
 
     const fileName = path.basename(wasmFilePath);
@@ -24,10 +24,8 @@ export const copyPrismaWasmPlugin = ({
     if (await pathExists(wasmFilePath)) {
       await copy(wasmFilePath, outputPath);
       console.log(
-        `✅ Copied ${fileName} from ${wasmFilePath} to ${outputPath}`,
+        `✅ Copied ${fileName} from ${wasmFilePath} to ${outputPath}`
       );
-    } else {
-      console.warn(`⚠️ WASM file not found at: ${wasmFilePath}`);
     }
   },
   renderChunk(code) {


### PR DESCRIPTION
We currently warn if prisma query engine wasm module (which we copy over manually for builds) isn't found. There are valid cases where it wouldn't exist though - when app has no db, or db client is not prisma. This PR just removes the warning.