### PR TITLE
fix: React dep resolution should respect import conditions correctly

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,9 @@ importers:
       debug:
         specifier: ^4.4.0
         version: 4.4.0
+      enhanced-resolve:
+        specifier: ^5.18.1
+        version: 5.18.1
       es-module-lexer:
         specifier: ^1.5.4
         version: 1.6.0
@@ -172,7 +175,7 @@ importers:
     dependencies:
       '@redwoodjs/sdk':
         specifier: 0.0.65
-        version: 0.0.65(@types/node@22.14.0)(rollup@4.34.8)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250408.0)
+        version: 0.0.65(@types/node@22.14.0)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(webpack@5.97.1)
     devDependencies:
       '@types/node':
         specifier: ^22.14.0
@@ -203,7 +206,7 @@ importers:
         version: 6.5.0(prisma@6.5.0(typescript@5.8.3))(typescript@5.8.3)
       '@redwoodjs/sdk':
         specifier: 0.0.65
-        version: 0.0.65(@types/node@22.14.0)(rollup@4.34.8)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250408.0)
+        version: 0.0.65(@types/node@22.14.0)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))
       '@simplewebauthn/browser':
         specifier: ^13.1.0
         version: 13.1.0
@@ -4368,32 +4371,9 @@ snapshots:
     optionalDependencies:
       workerd: 1.20250405.0
 
-  '@cloudflare/unenv-preset@2.3.1(unenv@2.0.0-rc.15)(workerd@1.20250408.0)':
-    dependencies:
-      unenv: 2.0.0-rc.15
-    optionalDependencies:
-      workerd: 1.20250408.0
-
   '@cloudflare/vite-plugin@1.0.1(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250405.0)(wrangler@4.8.0(@cloudflare/workers-types@4.20250407.0))':
     dependencies:
       '@cloudflare/unenv-preset': 2.3.1(unenv@2.0.0-rc.15)(workerd@1.20250405.0)
-      '@hattip/adapter-node': 0.0.49
-      get-port: 7.1.0
-      miniflare: 4.20250405.0
-      picocolors: 1.1.1
-      tinyglobby: 0.2.12
-      unenv: 2.0.0-rc.15
-      vite: 6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
-      wrangler: 4.8.0(@cloudflare/workers-types@4.20250407.0)
-      ws: 8.18.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - workerd
-
-  '@cloudflare/vite-plugin@1.0.1(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250408.0)(wrangler@4.8.0(@cloudflare/workers-types@4.20250407.0))':
-    dependencies:
-      '@cloudflare/unenv-preset': 2.3.1(unenv@2.0.0-rc.15)(workerd@1.20250408.0)
       '@hattip/adapter-node': 0.0.49
       get-port: 7.1.0
       miniflare: 4.20250405.0
@@ -5040,9 +5020,9 @@ snapshots:
     dependencies:
       dotenv: 16.4.7
 
-  '@redwoodjs/sdk@0.0.65(@types/node@22.14.0)(rollup@4.34.8)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250408.0)':
+  '@redwoodjs/sdk@0.0.65(@types/node@22.14.0)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))':
     dependencies:
-      '@cloudflare/vite-plugin': 1.0.1(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250408.0)(wrangler@4.8.0(@cloudflare/workers-types@4.20250407.0))
+      '@cloudflare/vite-plugin': 1.0.1(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250405.0)(wrangler@4.8.0(@cloudflare/workers-types@4.20250407.0))
       '@cloudflare/workers-types': 4.20250407.0
       '@types/fnv-plus': 1.3.2
       '@types/fs-extra': 11.0.4
@@ -5089,9 +5069,9 @@ snapshots:
       - webpack
       - workerd
 
-  '@redwoodjs/sdk@0.0.65(@types/node@22.14.0)(rollup@4.34.8)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250408.0)':
+  '@redwoodjs/sdk@0.0.65(@types/node@22.14.0)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(webpack@5.97.1)':
     dependencies:
-      '@cloudflare/vite-plugin': 1.0.1(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250408.0)(wrangler@4.8.0(@cloudflare/workers-types@4.20250407.0))
+      '@cloudflare/vite-plugin': 1.0.1(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250405.0)(wrangler@4.8.0(@cloudflare/workers-types@4.20250407.0))
       '@cloudflare/workers-types': 4.20250407.0
       '@types/fnv-plus': 1.3.2
       '@types/fs-extra': 11.0.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,8 +174,8 @@ importers:
   starters/minimal:
     dependencies:
       '@redwoodjs/sdk':
-        specifier: 0.0.65
-        version: 0.0.65(@types/node@22.14.0)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(webpack@5.97.1)
+        specifier: 0.0.65-test.0
+        version: 0.0.65-test.0(@types/node@22.14.0)(rollup@4.34.8)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250408.0)
     devDependencies:
       '@types/node':
         specifier: ^22.14.0
@@ -205,8 +205,8 @@ importers:
         specifier: ~6.5.0
         version: 6.5.0(prisma@6.5.0(typescript@5.8.3))(typescript@5.8.3)
       '@redwoodjs/sdk':
-        specifier: 0.0.65
-        version: 0.0.65(@types/node@22.14.0)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))
+        specifier: 0.0.65-test.0
+        version: 0.0.65-test.0(@types/node@22.14.0)(rollup@4.34.8)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250408.0)
       '@simplewebauthn/browser':
         specifier: ^13.1.0
         version: 13.1.0
@@ -1210,8 +1210,8 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@redwoodjs/sdk@0.0.65':
-    resolution: {integrity: sha512-lOJ93PM5hk1/3bpt4tkFh4d9AC2ZN6mX/JqNJkqUk6yxd/mqYGY6QB20G6rQNsrGM+tAgvFOZkH9sVReXOkjtw==}
+  '@redwoodjs/sdk@0.0.65-test.0':
+    resolution: {integrity: sha512-kXpWjUfdawVc8g7FwqJnqjq7o+XScww5B2RK3EoKTQy5QVSGewvrK+B1rgAnZnjHopXh5g+d+o4bx9VuW1KMFA==}
     hasBin: true
     peerDependencies:
       vite: ^6.2.5
@@ -4371,9 +4371,32 @@ snapshots:
     optionalDependencies:
       workerd: 1.20250405.0
 
+  '@cloudflare/unenv-preset@2.3.1(unenv@2.0.0-rc.15)(workerd@1.20250408.0)':
+    dependencies:
+      unenv: 2.0.0-rc.15
+    optionalDependencies:
+      workerd: 1.20250408.0
+
   '@cloudflare/vite-plugin@1.0.1(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250405.0)(wrangler@4.8.0(@cloudflare/workers-types@4.20250407.0))':
     dependencies:
       '@cloudflare/unenv-preset': 2.3.1(unenv@2.0.0-rc.15)(workerd@1.20250405.0)
+      '@hattip/adapter-node': 0.0.49
+      get-port: 7.1.0
+      miniflare: 4.20250405.0
+      picocolors: 1.1.1
+      tinyglobby: 0.2.12
+      unenv: 2.0.0-rc.15
+      vite: 6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
+      wrangler: 4.8.0(@cloudflare/workers-types@4.20250407.0)
+      ws: 8.18.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - workerd
+
+  '@cloudflare/vite-plugin@1.0.1(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250408.0)(wrangler@4.8.0(@cloudflare/workers-types@4.20250407.0))':
+    dependencies:
+      '@cloudflare/unenv-preset': 2.3.1(unenv@2.0.0-rc.15)(workerd@1.20250408.0)
       '@hattip/adapter-node': 0.0.49
       get-port: 7.1.0
       miniflare: 4.20250405.0
@@ -5020,9 +5043,9 @@ snapshots:
     dependencies:
       dotenv: 16.4.7
 
-  '@redwoodjs/sdk@0.0.65(@types/node@22.14.0)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))':
+  '@redwoodjs/sdk@0.0.65-test.0(@types/node@22.14.0)(rollup@4.34.8)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250408.0)':
     dependencies:
-      '@cloudflare/vite-plugin': 1.0.1(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250405.0)(wrangler@4.8.0(@cloudflare/workers-types@4.20250407.0))
+      '@cloudflare/vite-plugin': 1.0.1(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250408.0)(wrangler@4.8.0(@cloudflare/workers-types@4.20250407.0))
       '@cloudflare/workers-types': 4.20250407.0
       '@types/fnv-plus': 1.3.2
       '@types/fs-extra': 11.0.4
@@ -5031,6 +5054,7 @@ snapshots:
       '@types/react-is': 19.0.0
       '@vitejs/plugin-react': 4.3.4(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
       debug: 4.4.0
+      enhanced-resolve: 5.18.1
       es-module-lexer: 1.6.0
       eventsource-parser: 3.0.0
       execa: 9.5.2
@@ -5069,9 +5093,9 @@ snapshots:
       - webpack
       - workerd
 
-  '@redwoodjs/sdk@0.0.65(@types/node@22.14.0)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(webpack@5.97.1)':
+  '@redwoodjs/sdk@0.0.65-test.0(@types/node@22.14.0)(rollup@4.34.8)(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250408.0)':
     dependencies:
-      '@cloudflare/vite-plugin': 1.0.1(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250405.0)(wrangler@4.8.0(@cloudflare/workers-types@4.20250407.0))
+      '@cloudflare/vite-plugin': 1.0.1(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(workerd@1.20250408.0)(wrangler@4.8.0(@cloudflare/workers-types@4.20250407.0))
       '@cloudflare/workers-types': 4.20250407.0
       '@types/fnv-plus': 1.3.2
       '@types/fs-extra': 11.0.4
@@ -5080,6 +5104,7 @@ snapshots:
       '@types/react-is': 19.0.0
       '@vitejs/plugin-react': 4.3.4(vite@6.2.5(@types/node@22.14.0)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
       debug: 4.4.0
+      enhanced-resolve: 5.18.1
       es-module-lexer: 1.6.0
       eventsource-parser: 3.0.0
       execa: 9.5.2

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redwoodjs/sdk",
-  "version": "0.0.65",
+  "version": "0.0.65-test.0",
   "description": "Build fast, server-driven webapps on Cloudflare with SSR, RSC, and realtime",
   "type": "module",
   "bin": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -104,6 +104,7 @@
     "@types/react-is": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.4",
     "debug": "^4.4.0",
+    "enhanced-resolve": "^5.18.1",
     "es-module-lexer": "^1.5.4",
     "eventsource-parser": "^3.0.0",
     "execa": "^9.5.2",

--- a/sdk/src/vite/configPlugin.mts
+++ b/sdk/src/vite/configPlugin.mts
@@ -59,13 +59,6 @@ export const configPlugin = ({
             esbuildOptions: {
               plugins: [ignoreVirtualModules],
             },
-            include: [
-              "react",
-              "react-dom/client",
-              "react/jsx-runtime",
-              "react/jsx-dev-runtime",
-              "react-server-dom-webpack/client.browser",
-            ],
           },
         },
         worker: {

--- a/sdk/src/vite/reactConditionsResolverPlugin.mts
+++ b/sdk/src/vite/reactConditionsResolverPlugin.mts
@@ -1,11 +1,12 @@
 import { resolve } from "path";
 import path from "path";
 import { Plugin, EnvironmentOptions } from "vite";
-import { createRequire } from "node:module";
+import { ROOT_DIR } from "../lib/constants.mjs";
 import debug from "debug";
 import { pathExists } from "fs-extra";
+import enhancedResolve from "enhanced-resolve";
 import { VENDOR_DIST_DIR } from "../lib/constants.mjs";
-
+import { createRequire } from "node:module";
 const log = debug("rwsdk:vite:react-conditions");
 
 // Define package sets for each environment
@@ -63,36 +64,28 @@ export const reactConditionsResolverPlugin = async ({
     command
   );
 
-  // Create a require function to resolve node modules from the SDK
-  const sdkRequire = createRequire(
-    resolve(projectRootDir, "node_modules/@redwoodjs/sdk")
-  );
-
-  // Path to custom React builds in the vendor directory
   const vendorDir = VENDOR_DIST_DIR;
+  const sdkRequire = createRequire(ROOT_DIR);
 
-  // Helper to resolve packages with mode in mind
-  const resolveWithMode = async (packageName: string, environment: string) => {
-    // Special handling for react-dom server packages
-    if (packageName.startsWith("react-dom/server")) {
-      const baseResolved = sdkRequire.resolve("react-dom");
-      const packageDir = path.dirname(baseResolved);
+  // Create resolver functions for each environment condition set
+  const workerResolver = enhancedResolve.create.sync({
+    conditionNames: ["react-server", "workerd", "worker", "edge", "default"],
+  });
 
-      // Determine which file to use based on mode
-      const edgeFileName =
-        mode === "development"
-          ? "react-dom-server.edge.development.js"
-          : "react-dom-server.edge.production.js";
+  const clientResolver = enhancedResolve.create.sync({
+    conditionNames: ["browser", "default"],
+  });
 
-      const edgePath = path.join(packageDir, "cjs", edgeFileName);
+  const skipReactServerResolver = enhancedResolve.create.sync({
+    conditionNames: ["workerd", "worker", "edge", "default"],
+  });
 
-      if (await pathExists(edgePath)) {
-        log("Using edge %s server for %s: %s", mode, packageName, edgePath);
-        return edgePath;
-      }
-    }
-
-    // For custom React builds, use our own bundled versions
+  // Helper to resolve packages with conditions
+  const resolveWithConditions = async (
+    packageName: string,
+    environment: string
+  ) => {
+    // Custom handling for react package - check for our custom builds first
     if (packageName === "react") {
       const modePath = resolve(vendorDir, `react.${mode}.js`);
       if (await pathExists(modePath)) {
@@ -101,78 +94,43 @@ export const reactConditionsResolverPlugin = async ({
       }
     }
 
-    // Environment conditions
-    const env = environment || "worker";
-    const conditions: string[] = [];
-
-    if (env === "worker") {
-      conditions.push("workerd", "edge", "worker");
-    } else {
-      conditions.push("browser");
-    }
-
-    // React-server condition - apply selectively
-    if (!SKIP_REACT_SERVER.includes(packageName)) {
-      conditions.push("react-server");
-    }
-
+    // Try enhanced-resolve resolution
     try {
-      const baseResolved = sdkRequire.resolve(packageName);
-      const packageDir = path.dirname(baseResolved);
-      const baseName = path.basename(baseResolved, ".js");
+      // Determine which resolver to use
+      let resolver;
 
-      // Helper to check path existence and log if found
-      const tryPath = async (filepath: string, type: string) => {
-        if (await pathExists(filepath)) {
-          log("Using %s for %s: %s", type, packageName, filepath);
-          return filepath;
-        }
-        return null;
-      };
-
-      // Try condition-specific paths first
-      for (const condition of conditions) {
-        const conditionPath = path.join(
-          packageDir,
-          `${baseName}.${condition}.js`
-        );
-        const found = await tryPath(conditionPath, `condition ${condition}`);
-        if (found) return found;
-      }
-
-      // Try mode-specific paths based on package type
-      if (packageName.includes("react-server-dom-webpack")) {
-        const [pkgBase, type, env] = packageName.split("/");
-        const filename =
-          type === "server"
-            ? `${pkgBase}-${type}.${env}.${mode}.js`
-            : `${pkgBase}-${type}.${mode}.js`;
-
-        const cjsPath = path.join(packageDir, "cjs", filename);
-        const found = await tryPath(cjsPath, `webpack ${mode} mode`);
-        if (found) {
-          return found;
+      if (environment === "worker") {
+        if (SKIP_REACT_SERVER.includes(packageName)) {
+          resolver = skipReactServerResolver;
+          log("Using skipReactServer resolver for %s", packageName);
         } else {
-          log("Using standard resolution for %s", packageName);
-          return baseResolved;
+          resolver = workerResolver;
+          log("Using worker resolver with react-server for %s", packageName);
         }
       } else {
-        const modePath = baseResolved.replace(
-          /\.js$/,
-          mode === "development" ? ".development.js" : ".production.min.js"
-        );
-        const found = await tryPath(modePath, `${mode} mode`);
-        if (found) {
-          return found;
-        }
+        resolver = clientResolver;
+        log("Using client resolver for %s", packageName);
       }
 
-      // Fall back to standard resolution
-      log("Using standard resolution for %s", packageName);
-      return baseResolved;
+      // First arg is the context directory for relative requires,
+      // second arg is the actual request
+      const resolved = resolver(ROOT_DIR, packageName);
+      if (resolved) {
+        log("Resolved %s to %s using enhanced-resolve", packageName, resolved);
+        return resolved;
+      }
     } catch (error) {
-      log("Error in custom resolution for %s: %o", packageName, error);
-      return sdkRequire.resolve(packageName);
+      log("Enhanced resolution failed for %s: %o", packageName, error);
+    }
+
+    // Fallback to standard resolution
+    try {
+      const resolved = sdkRequire.resolve(packageName);
+      log("Standard resolution for %s: %s", packageName, resolved);
+      return resolved;
+    } catch (fallbackError) {
+      log("All resolution failed for %s: %o", packageName, fallbackError);
+      throw new Error(`Failed to resolve ${packageName}`);
     }
   };
 
@@ -180,7 +138,7 @@ export const reactConditionsResolverPlugin = async ({
   const generateImports = async (packages: string[], env: string) => {
     const imports: Record<string, string> = {};
     for (const pkg of packages) {
-      imports[pkg] = await resolveWithMode(pkg, env);
+      imports[pkg] = await resolveWithConditions(pkg, env);
     }
     return imports;
   };
@@ -188,6 +146,7 @@ export const reactConditionsResolverPlugin = async ({
   // Generate import mappings for both environments
   const workerImports = await generateImports(WORKER_PACKAGES, "worker");
   const clientImports = await generateImports(CLIENT_PACKAGES, "client");
+
   // Log the resolved paths
   const logImports = (env: string, imports: Record<string, string>) => {
     log(`Resolved ${env} paths (${mode} mode):`);
@@ -215,6 +174,9 @@ export const reactConditionsResolverPlugin = async ({
       ...(config.optimizeDeps.esbuildOptions.define || {}),
       "process.env.NODE_ENV": JSON.stringify(mode),
     };
+
+    config.optimizeDeps.include ??= [];
+    config.optimizeDeps.include.push(...Object.keys(imports));
 
     // Initialize resolve config if needed
     config.resolve ??= {};

--- a/sdk/src/vite/reactConditionsResolverPlugin.mts
+++ b/sdk/src/vite/reactConditionsResolverPlugin.mts
@@ -49,7 +49,6 @@ const GLOBAL_SERVER_PACKAGES = [
 ];
 
 export const reactConditionsResolverPlugin = async ({
-  projectRootDir,
   mode = "development",
   command = "serve",
 }: {

--- a/sdk/src/vite/reactConditionsResolverPlugin.mts
+++ b/sdk/src/vite/reactConditionsResolverPlugin.mts
@@ -1,5 +1,4 @@
 import { resolve } from "path";
-import path from "path";
 import { Plugin, EnvironmentOptions } from "vite";
 import { ROOT_DIR } from "../lib/constants.mjs";
 import debug from "debug";

--- a/starters/minimal/package.json
+++ b/starters/minimal/package.json
@@ -23,7 +23,7 @@
     "types": "tsc"
   },
   "dependencies": {
-    "@redwoodjs/sdk": "0.0.65"
+    "@redwoodjs/sdk": "0.0.65-test.0"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/starters/standard/package.json
+++ b/starters/standard/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@prisma/adapter-d1": "~6.5.0",
     "@prisma/client": "~6.5.0",
-    "@redwoodjs/sdk": "0.0.65",
+    "@redwoodjs/sdk": "0.0.65-test.0",
     "@simplewebauthn/browser": "^13.1.0",
     "@simplewebauthn/server": "^13.1.1"
   },


### PR DESCRIPTION
## Context
In order to have control over the react versions we use (while RSC is stabilizing), we maintain the react versions in the sdk package itself rather than users having react packages as deps in their own apps. To accomplish this involves needing to tell vite that when doing `optimizeDeps` (since we need to de-cjs-ify react packages), that it should look for these deps as deps of the sdk instead. More on this in the initial PR where this was introduced - #331

## Problem
In the initial PR where this was introduced (#331), we used some complicated logic of our own for determining which react package to use. We needed this to have control over when to use the packages that correspond to `react-server` import conditions vs not. There were bugs in this implementation that (for one) were causing us to incorrectly resolve `react-dom` imports in the `worker` vite environment to the non `react-server` package.

## Solution
What we are needing is an import-condition-aware resolver. There are already ones out there. This PR replaces our (my) broken custom resolution logic with the resolver used under the hood by webpack: https://www.npmjs.com/package/enhanced-resolve