### PR TITLE
fix: Better support for redirect responses

### DIFF
--- a/sdk/src/runtime/lib/router.ts
+++ b/sdk/src/runtime/lib/router.ts
@@ -22,9 +22,11 @@ export type RouteMiddleware = (
 
 type RouteFunction = (requestInfo: RequestInfo) => Response | Promise<Response>;
 
+type MaybePromise<T> = T | Promise<T>;
+
 type RouteComponent = (
   requestInfo: RequestInfo
-) => React.JSX.Element | Promise<React.JSX.Element>;
+) => MaybePromise<React.JSX.Element | Response>;
 
 type RouteHandler =
   | RouteFunction

--- a/sdk/src/runtime/lib/router.ts
+++ b/sdk/src/runtime/lib/router.ts
@@ -96,11 +96,17 @@ export function defineRoutes(routes: Route[]): {
     request,
     renderPage,
     getRequestInfo,
+    onError,
     runWithRequestInfoOverrides,
   }: {
     request: Request;
-    renderPage: (requestInfo: RequestInfo, Page: React.FC) => Promise<Response>;
+    renderPage: (
+      requestInfo: RequestInfo,
+      Page: React.FC,
+      onError: (error: unknown) => void
+    ) => Promise<Response>;
     getRequestInfo: () => RequestInfo;
+    onError: (error: unknown) => void;
     runWithRequestInfoOverrides: <Result>(
       overrides: Partial<RequestInfo>,
       fn: () => Promise<Result>
@@ -114,6 +120,7 @@ export function defineRoutes(routes: Route[]): {
       request,
       renderPage,
       getRequestInfo,
+      onError,
       runWithRequestInfoOverrides,
     }) {
       const url = new URL(request.url);
@@ -156,7 +163,7 @@ export function defineRoutes(routes: Route[]): {
         const handlers = Array.isArray(handler) ? handler : [handler];
         for (const h of handlers) {
           if (isRouteComponent(h)) {
-            return await renderPage(getRequestInfo(), h as React.FC);
+            return await renderPage(getRequestInfo(), h as React.FC, onError);
           } else {
             const r = await (h(getRequestInfo()) as Promise<Response>);
             if (r instanceof Response) {

--- a/sdk/src/runtime/render/renderToRscStream.ts
+++ b/sdk/src/runtime/render/renderToRscStream.ts
@@ -5,7 +5,7 @@ import { createClientManifest } from "./createClientManifest.js";
 // the stream to avoid losing data
 function rechunkStream(
   stream: ReadableStream,
-  maxChunkSize: number = 28,
+  maxChunkSize: number = 28
 ): ReadableStream {
   const reader = stream.getReader();
   return new ReadableStream({
@@ -46,13 +46,16 @@ function rechunkStream(
 export const renderToRscStream = (app: {
   node: React.ReactElement;
   actionResult: any;
+  onError?: (error: unknown) => void;
 }): ReadableStream => {
-  const { node } = app;
+  const { node, onError } = app;
   let { actionResult } = app;
 
   if (actionResult instanceof ReadableStream) {
     actionResult = rechunkStream(actionResult);
   }
 
-  return baseRenderToRscStream({ node, actionResult }, createClientManifest());
+  return baseRenderToRscStream({ node, actionResult }, createClientManifest(), {
+    onError,
+  });
 };

--- a/sdk/src/runtime/worker.tsx
+++ b/sdk/src/runtime/worker.tsx
@@ -103,6 +103,12 @@ export const defineApp = (routes: Route[]) => {
           }
 
           const props = computePageProps(requestInfo, Page);
+          const pageResult = await Page(props);
+
+          if (pageResult instanceof Response) {
+            return pageResult;
+          }
+
           let actionResult: unknown = undefined;
           const isRSCActionHandler = url.searchParams.has("__rsc_action_id");
 
@@ -111,7 +117,7 @@ export const defineApp = (routes: Route[]) => {
           }
 
           const rscPayloadStream = renderToRscStream({
-            node: <Page {...props} />,
+            node: pageResult as React.ReactElement,
             actionResult:
               actionResult instanceof Response ? null : actionResult,
           });


### PR DESCRIPTION
## Changes
### Fix types: `MaybePromise<Response | Element>`
Previously if a component returned either a `Response` or a react element, ts would tell you the function should return one or the other but not both. Now we allow `MaybePromise<Response | Element>`

### Fix runtime for route handlers
Previously, if we detected that a function returned react elements, we did not allow for the possibility of it also potentially returning a response. We now handle both react elements or responses being returned.

### Support throwing responses
We currently do not have a way to bubble up responses nested in the component tree. This PR allows ones to do this:

```tsx
export const Child = () => {
  if (someCondition) {
    return new Response(null, {
      status: 302,
      headers: {
        Location: "/here",
      },
    });
  }

  return <div>hi</div>
};

export const Page = () => (
  <>
    <Child />
  <>
);
```