### PR TITLE
fix: Catch errors that Page-level throws

### DIFF
--- a/sdk/src/runtime/worker.tsx
+++ b/sdk/src/runtime/worker.tsx
@@ -159,15 +159,19 @@ export const defineApp = (routes: Route[]) => {
           outerRequestInfo,
           async () =>
             new Promise<Response>(async (resolve, reject) => {
-              const response = await router.handle({
-                request,
-                renderPage,
-                getRequestInfo,
-                runWithRequestInfoOverrides,
-                onError: reject,
-              });
-
-              resolve(response);
+              try {
+                resolve(
+                  await router.handle({
+                    request,
+                    renderPage,
+                    getRequestInfo,
+                    runWithRequestInfoOverrides,
+                    onError: reject,
+                  })
+                );
+              } catch (e) {
+                reject(e);
+              }
             })
         );
 


### PR DESCRIPTION
#342 added support for throwing responses to bubble them up in the component tree. What we (I) didn't handle, was throws that happen at the Page (root) level. This PR makes sure both cases are covered.