### PR TITLE
fix: Skip calling Page functions for client references

### DIFF
--- a/sdk/src/runtime/worker.tsx
+++ b/sdk/src/runtime/worker.tsx
@@ -104,7 +104,12 @@ export const defineApp = (routes: Route[]) => {
           }
 
           const props = computePageProps(requestInfo, Page);
-          const pageResult = await Page(props);
+
+          const pageResult = isClientReference(Page) ? (
+            <Page {...props} />
+          ) : (
+            await Page(props)
+          );
 
           if (pageResult instanceof Response) {
             return pageResult;


### PR DESCRIPTION
Since #342, we call page functions rather than letting react unroll the element tree from that level, in order to check whether the result is a response or an element.

Problem is, the Page function may be a `use client` component, in which case:
* it will never be able to return a `Response`
* The hooks that need to work in the context of ssr (e.g. `useState()`) are not set to use the correct internal react state used by ssr) if called as a function like this

To solve this, we avoid calling page functions if they are client component (since we won't be getting a `Response` from them anyways).