### PR TITLE
fix: `use client` transformation duplicate exports

### DIFF
--- a/sdk/src/vite/useClientPlugin.mts
+++ b/sdk/src/vite/useClientPlugin.mts
@@ -37,7 +37,7 @@ export async function transformUseClientCode(
     return;
   }
 
-  onst project = new Project({
+  const project = new Project({
     useInMemoryFileSystem: true,
     compilerOptions: {
       sourceMap: true,

--- a/sdk/src/vite/useClientPlugin.mts
+++ b/sdk/src/vite/useClientPlugin.mts
@@ -8,14 +8,11 @@ interface TransformResult {
 }
 
 interface ComponentInfo {
-  node: Node;
-  statement?: Node;
+  name: string;
   ssrName: string;
-  originalName: string;
   isDefault: boolean;
   isInlineExport: boolean;
   isAnonymousDefault?: boolean;
-  ssrExported?: boolean;
 }
 
 function isJsxFunction(text: string): boolean {
@@ -57,7 +54,7 @@ export async function transformUseClientCode(
   const components = new Map<string, ComponentInfo>();
   let anonymousDefaultCount = 0;
 
-  // Pass 1: collect all information
+  // Pass 1: Collect all component information
   // Handle function declarations
   sourceFile
     .getDescendantsOfKind(SyntaxKind.FunctionDeclaration)
@@ -79,9 +76,8 @@ export async function transformUseClientCode(
             .some((exp) => exp.getExpression().getText() === name);
 
         components.set(name, {
-          node,
+          name,
           ssrName,
-          originalName: name,
           isDefault,
           isInlineExport,
         });
@@ -116,20 +112,16 @@ export async function transformUseClientCode(
             // Handle anonymous default export
             const anonName = `DefaultComponent${anonymousDefaultCount++}`;
             components.set(anonName, {
-              node: varDecl,
-              statement,
+              name: anonName,
               ssrName: anonName,
-              originalName: anonName,
               isDefault: true,
               isInlineExport: true,
               isAnonymousDefault: true,
             });
           } else if (name) {
             components.set(name, {
-              node: varDecl,
-              statement,
+              name,
               ssrName: `${name}SSR`,
-              originalName: name,
               isDefault,
               isInlineExport,
             });
@@ -150,24 +142,46 @@ export async function transformUseClientCode(
   });
 
   // Remove inline exports for components
-  components.forEach(({ node, statement, isInlineExport }) => {
-    if (Node.isFunctionDeclaration(node) && isInlineExport) {
-      const nodeText = node.getText();
-      const newText = nodeText.replace(
-        /^export\s+(default\s+)?(async\s+)?function/,
-        "$2function"
-      );
-      node.replaceWithText(newText);
-    } else if (
-      Node.isVariableDeclaration(node) &&
-      statement &&
-      isInlineExport
-    ) {
-      const stmtText = statement.getText();
-      const newText = stmtText.replace(/^export\s+/, "");
-      statement.replaceWithText(newText);
-    }
-  });
+  // Get fresh node references before modifying
+  sourceFile
+    .getDescendantsOfKind(SyntaxKind.FunctionDeclaration)
+    .forEach((node) => {
+      const name = node.getName();
+      if (!name || !components.has(name)) return;
+
+      const component = components.get(name)!;
+      if (component.isInlineExport) {
+        const nodeText = node.getText();
+        const newText = nodeText.replace(
+          /^export\s+(default\s+)?(async\s+)?function/,
+          "$2function"
+        );
+        node.replaceWithText(newText);
+      }
+    });
+
+  // Handle variable declarations with inline exports
+  sourceFile
+    .getDescendantsOfKind(SyntaxKind.VariableStatement)
+    .forEach((statement) => {
+      if (!statement.hasModifier(SyntaxKind.ExportKeyword)) return;
+
+      const declarations = statement.getDeclarationList().getDeclarations();
+      let hasComponent = false;
+
+      declarations.forEach((varDecl) => {
+        const name = varDecl.getName();
+        if (name && components.has(name)) {
+          hasComponent = true;
+        }
+      });
+
+      if (hasComponent) {
+        const stmtText = statement.getText();
+        const newText = stmtText.replace(/^export\s+/, "");
+        statement.replaceWithText(newText);
+      }
+    });
 
   // Handle grouped exports - only remove component exports
   sourceFile
@@ -212,9 +226,8 @@ export async function transformUseClientCode(
 
         // Store info for later export
         components.set(anonName, {
-          node: expression,
+          name: anonName,
           ssrName,
-          originalName: anonName,
           isDefault: true,
           isInlineExport: true,
           isAnonymousDefault: true,
@@ -222,41 +235,51 @@ export async function transformUseClientCode(
       }
     });
 
-  // Pass 4: Rename all identifiers to SSR version
-  components.forEach(({ node, ssrName, isAnonymousDefault }) => {
-    if (!isAnonymousDefault) {
-      if (Node.isFunctionDeclaration(node)) {
-        node.rename(ssrName);
-      } else if (Node.isVariableDeclaration(node)) {
-        node.getFirstChildByKind(SyntaxKind.Identifier)?.rename(ssrName);
-      }
+  // Pass 4: rename all identifiers to SSR version
+  // Get fresh node references for each component
+  components.forEach(({ name, ssrName, isAnonymousDefault }) => {
+    if (isAnonymousDefault) return;
+
+    // Find function declarations by name
+    const funcDecls = sourceFile.getDescendantsOfKind(
+      SyntaxKind.FunctionDeclaration
+    );
+    const funcNode = funcDecls.find((decl) => decl.getName() === name);
+    if (funcNode) {
+      funcNode.rename(ssrName);
+      return;
+    }
+
+    // Find variable declarations by name
+    const varDecls = sourceFile.getDescendantsOfKind(
+      SyntaxKind.VariableDeclaration
+    );
+    const varNode = varDecls.find((decl) => decl.getName() === name);
+    if (varNode) {
+      varNode.getFirstChildByKind(SyntaxKind.Identifier)?.rename(ssrName);
     }
   });
 
   // Pass 5: Add client reference registrations
   // Add all declarations first
-  components.forEach(
-    ({ ssrName, originalName, isDefault, isAnonymousDefault }) => {
-      if (!isAnonymousDefault) {
-        sourceFile.addStatements(
-          `const ${originalName} = registerClientReference("${relativeId}", "${
-            isDefault ? "default" : originalName
-          }", ${ssrName});`
-        );
-      }
+  components.forEach(({ name, ssrName, isDefault, isAnonymousDefault }) => {
+    if (!isAnonymousDefault) {
+      sourceFile.addStatements(
+        `const ${name} = registerClientReference("${relativeId}", "${
+          isDefault ? "default" : name
+        }", ${ssrName});`
+      );
     }
-  );
+  });
 
   // Pass 6: add new exports
   // Then add all exports after declarations
-  components.forEach(({ ssrName, originalName, isDefault }) => {
+  components.forEach(({ name, ssrName, isDefault }) => {
     if (isDefault) {
       // Export the registerClientReference version as default
-      sourceFile.addStatements(
-        `export { ${originalName} as default, ${ssrName} };`
-      );
+      sourceFile.addStatements(`export { ${name} as default, ${ssrName} };`);
     } else {
-      sourceFile.addStatements(`export { ${ssrName}, ${originalName} };`);
+      sourceFile.addStatements(`export { ${ssrName}, ${name} };`);
     }
   });
 

--- a/sdk/src/vite/useClientPlugin.test.mts
+++ b/sdk/src/vite/useClientPlugin.test.mts
@@ -3,7 +3,7 @@ import { transformUseClientCode } from "./useClientPlugin.mjs";
 
 describe("transformUseClientCode", () => {
   async function transform(code: string) {
-    const result = await transformUseClientCode(code, "/test/file.tsx", true);
+    const result = await transformUseClientCode(code, "/test/file.tsx");
     return result?.code;
   }
 
@@ -20,7 +20,8 @@ export const Component = () => {
         return jsx('div', { children: 'Hello' });
       }
       const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
-      export { ComponentSSR, Component };"
+      export { ComponentSSR };
+      export { Component };"
     `);
   });
 
@@ -52,7 +53,8 @@ export const Component = async () => {
         return jsx('div', { children: 'Hello' });
       }
       const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
-      export { ComponentSSR, Component };"
+      export { ComponentSSR };
+      export { Component };"
     `);
   });
 
@@ -70,7 +72,8 @@ export function Component() {
         return jsx('div', { children: 'Hello' });
       }
       const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
-      export { ComponentSSR, Component };"
+      export { ComponentSSR };
+      export { Component };"
     `);
   });
 
@@ -88,7 +91,8 @@ export async function Component() {
         return jsx('div', { children: 'Hello' });
       }
       const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
-      export { ComponentSSR, Component };"
+      export { ComponentSSR };
+      export { Component };"
     `);
   });
 
@@ -114,8 +118,10 @@ export const Second = () => {
       }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-      export { FirstSSR, First };
-      export { SecondSSR, Second };"
+      export { FirstSSR };
+      export { First };
+      export { SecondSSR };
+      export { Second };"
     `);
   });
 
@@ -141,8 +147,10 @@ export const Second = async () => {
       }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-      export { FirstSSR, First };
-      export { SecondSSR, Second };"
+      export { FirstSSR };
+      export { First };
+      export { SecondSSR };
+      export { Second };"
     `);
   });
 
@@ -169,8 +177,10 @@ export function Second() {
       }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-      export { FirstSSR, First };
-      export { SecondSSR, Second };"
+      export { FirstSSR };
+      export { First };
+      export { SecondSSR };
+      export { Second };"
     `);
   });
 
@@ -197,8 +207,10 @@ export async function Second() {
       }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-      export { FirstSSR, First };
-      export { SecondSSR, Second };"
+      export { FirstSSR };
+      export { First };
+      export { SecondSSR };
+      export { Second };"
     `);
   });
 
@@ -228,8 +240,148 @@ export { First, Second }`)
       export { FirstSSR, SecondSSR }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-      export { FirstSSR, First };
-      export { SecondSSR, Second };"
+      export { FirstSSR };
+      export { First };
+      export { SecondSSR };
+      export { Second };"
+    `);
+  });
+
+  it.only("transforms complex grouped export cases", async () => {
+    expect(
+      await transform(`
+"use client";
+
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+import { jsx, jsxs } from "react/jsx-runtime"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "font-bold inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+        ghost:
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        icon: "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Button({
+  className,
+  variant,
+  size,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean
+  }) {
+  const Comp = asChild ? Slot : "button"
+
+  return jsx(
+    Comp,
+    {
+      "data-slot": "button",
+      className: cn(buttonVariants({ variant, size, className })),
+      ...props
+    }
+  )
+}
+
+export { Button, buttonVariants }
+`)
+    ).toMatchInlineSnapshot(`
+      "
+      import * as React from "react"
+      import { Slot } from "@radix-ui/react-slot"
+      import { cva, type VariantProps } from "class-variance-authority"
+      import { jsx, jsxs } from "react/jsx-runtime"
+
+      import { cn } from "@/lib/utils"
+      import { registerClientReference } from "@redwoodjs/sdk/worker";
+
+      const buttonVariants = cva(
+        "font-bold inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        {
+          variants: {
+            variant: {
+              default:
+                "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+              destructive:
+                "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+              outline:
+                "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+              secondary:
+                "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+              ghost:
+                "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+              link: "text-primary underline-offset-4 hover:underline",
+            },
+            size: {
+              default: "h-9 px-4 py-2 has-[>svg]:px-3",
+              sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+              lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+              icon: "size-9",
+            },
+          },
+          defaultVariants: {
+            variant: "default",
+            size: "default",
+          },
+        }
+      )
+
+      function ButtonSSR({
+        className,
+        variant,
+        size,
+        asChild = false,
+        ...props
+      }: React.ComponentProps<"button"> &
+        VariantProps<typeof buttonVariants> & {
+          asChild?: boolean
+        }) {
+        const Comp = asChild ? Slot : "button"
+
+        return jsx(
+          Comp,
+          {
+            "data-slot": "button",
+            className: cn(buttonVariants({ variant, size, className })),
+            ...props
+          }
+        )
+      }
+
+      export { ButtonSSR, buttonVariants }
+      const Button = registerClientReference("/test/file.tsx", "Button", ButtonSSR);
+      export { ButtonSSR };
+      export { Button };
+      "
     `);
   });
 
@@ -259,8 +411,10 @@ export { First, Second }`)
       export { FirstSSR, SecondSSR }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-      export { FirstSSR, First };
-      export { SecondSSR, Second };"
+      export { FirstSSR };
+      export { First };
+      export { SecondSSR };
+      export { Second };"
     `);
   });
 
@@ -291,8 +445,10 @@ export { First, Second }`)
       export { FirstSSR, SecondSSR }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-      export { FirstSSR, First };
-      export { SecondSSR, Second };"
+      export { FirstSSR };
+      export { First };
+      export { SecondSSR };
+      export { Second };"
     `);
   });
 
@@ -323,8 +479,10 @@ export { First, Second }`)
       export { FirstSSR, SecondSSR }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-      export { FirstSSR, First };
-      export { SecondSSR, Second };"
+      export { FirstSSR };
+      export { First };
+      export { SecondSSR };
+      export { Second };"
     `);
   });
 
@@ -550,7 +708,8 @@ export function ComplexComponent({ initialCount = 0 }) {
         });
       }
       const ComplexComponent = registerClientReference("/test/file.tsx", "ComplexComponent", ComplexComponentSSR);
-      export { ComplexComponentSSR, ComplexComponent };"
+      export { ComplexComponentSSR };
+      export { ComplexComponent };"
     `);
   });
 
@@ -609,11 +768,15 @@ export { Fourth as AnotherName }`)
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
       const Fourth = registerClientReference("/test/file.tsx", "Fourth", FourthSSR);
-      export { ThirdSSR, Third };
+      export { ThirdSSR };
+      export { Third };
       export { Main as default, MainSSR };
-      export { FirstSSR, First };
-      export { SecondSSR, Second };
-      export { FourthSSR, Fourth };"
+      export { FirstSSR };
+      export { First };
+      export { SecondSSR };
+      export { Second };
+      export { FourthSSR };
+      export { Fourth };"
     `);
   });
 
@@ -804,7 +967,8 @@ export function Chat() {
         }, this);
       }
       const Chat = registerClientReference("/test/file.tsx", "Chat", ChatSSR);
-      export { ChatSSR, Chat };
+      export { ChatSSR };
+      export { Chat };
       "
     `);
   });

--- a/sdk/src/vite/useClientPlugin.test.mts
+++ b/sdk/src/vite/useClientPlugin.test.mts
@@ -377,10 +377,9 @@ export { Button, buttonVariants }
         )
       }
 
-      export { ButtonSSR, buttonVariants }
+      export { buttonVariants };
       const Button = registerClientReference("/test/file.tsx", "Button", ButtonSSR);
-      export { ButtonSSR };
-      export { Button };
+      export { ButtonSSR, Button };
       "
     `);
   });

--- a/sdk/src/vite/useClientPlugin.test.mts
+++ b/sdk/src/vite/useClientPlugin.test.mts
@@ -20,8 +20,7 @@ export const Component = () => {
         return jsx('div', { children: 'Hello' });
       }
       const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
-      export { ComponentSSR };
-      export { Component };"
+      export { ComponentSSR, Component };"
     `);
   });
 
@@ -53,8 +52,7 @@ export const Component = async () => {
         return jsx('div', { children: 'Hello' });
       }
       const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
-      export { ComponentSSR };
-      export { Component };"
+      export { ComponentSSR, Component };"
     `);
   });
 
@@ -72,8 +70,7 @@ export function Component() {
         return jsx('div', { children: 'Hello' });
       }
       const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
-      export { ComponentSSR };
-      export { Component };"
+      export { ComponentSSR, Component };"
     `);
   });
 
@@ -91,8 +88,7 @@ export async function Component() {
         return jsx('div', { children: 'Hello' });
       }
       const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
-      export { ComponentSSR };
-      export { Component };"
+      export { ComponentSSR, Component };"
     `);
   });
 
@@ -118,10 +114,8 @@ export const Second = () => {
       }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-      export { FirstSSR };
-      export { First };
-      export { SecondSSR };
-      export { Second };"
+      export { FirstSSR, First };
+      export { SecondSSR, Second };"
     `);
   });
 
@@ -147,10 +141,8 @@ export const Second = async () => {
       }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-      export { FirstSSR };
-      export { First };
-      export { SecondSSR };
-      export { Second };"
+      export { FirstSSR, First };
+      export { SecondSSR, Second };"
     `);
   });
 
@@ -177,10 +169,8 @@ export function Second() {
       }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-      export { FirstSSR };
-      export { First };
-      export { SecondSSR };
-      export { Second };"
+      export { FirstSSR, First };
+      export { SecondSSR, Second };"
     `);
   });
 
@@ -207,10 +197,8 @@ export async function Second() {
       }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-      export { FirstSSR };
-      export { First };
-      export { SecondSSR };
-      export { Second };"
+      export { FirstSSR, First };
+      export { SecondSSR, Second };"
     `);
   });
 
@@ -236,18 +224,14 @@ export { First, Second }`)
       const SecondSSR = () => {
         return jsx('div', { children: 'Second' });
       }
-
-      export { FirstSSR, SecondSSR }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-      export { FirstSSR };
-      export { First };
-      export { SecondSSR };
-      export { Second };"
+      export { FirstSSR, First };
+      export { SecondSSR, Second };"
     `);
   });
 
-  it.only("transforms complex grouped export cases", async () => {
+  it("transforms complex grouped export cases", async () => {
     expect(
       await transform(`
 "use client";
@@ -406,14 +390,10 @@ export { First, Second }`)
       const SecondSSR = async () => {
         return jsx('div', { children: 'Second' });
       }
-
-      export { FirstSSR, SecondSSR }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-      export { FirstSSR };
-      export { First };
-      export { SecondSSR };
-      export { Second };"
+      export { FirstSSR, First };
+      export { SecondSSR, Second };"
     `);
   });
 
@@ -440,14 +420,10 @@ export { First, Second }`)
       function SecondSSR() {
         return jsx('div', { children: 'Second' });
       }
-
-      export { FirstSSR, SecondSSR }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-      export { FirstSSR };
-      export { First };
-      export { SecondSSR };
-      export { Second };"
+      export { FirstSSR, First };
+      export { SecondSSR, Second };"
     `);
   });
 
@@ -474,14 +450,10 @@ export { First, Second }`)
       async function SecondSSR() {
         return jsx('div', { children: 'Second' });
       }
-
-      export { FirstSSR, SecondSSR }
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-      export { FirstSSR };
-      export { First };
-      export { SecondSSR };
-      export { Second };"
+      export { FirstSSR, First };
+      export { SecondSSR, Second };"
     `);
   });
 
@@ -707,8 +679,7 @@ export function ComplexComponent({ initialCount = 0 }) {
         });
       }
       const ComplexComponent = registerClientReference("/test/file.tsx", "ComplexComponent", ComplexComponentSSR);
-      export { ComplexComponentSSR };
-      export { ComplexComponent };"
+      export { ComplexComponentSSR, ComplexComponent };"
     `);
   });
 
@@ -759,23 +730,16 @@ export { Fourth as AnotherName }`)
       function MainSSR() {
         return jsx('div', { children: 'Main' });
       }
-
-      export { SecondSSR, ThirdSSR }
-      export { FourthSSR as AnotherName }
       const Third = registerClientReference("/test/file.tsx", "Third", ThirdSSR);
       const Main = registerClientReference("/test/file.tsx", "default", MainSSR);
       const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
       const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
       const Fourth = registerClientReference("/test/file.tsx", "Fourth", FourthSSR);
-      export { ThirdSSR };
-      export { Third };
+      export { ThirdSSR, Third };
       export { Main as default, MainSSR };
-      export { FirstSSR };
-      export { First };
-      export { SecondSSR };
-      export { Second };
-      export { FourthSSR };
-      export { Fourth };"
+      export { FirstSSR, First };
+      export { SecondSSR, Second };
+      export { FourthSSR, Fourth };"
     `);
   });
 
@@ -966,18 +930,13 @@ export function Chat() {
         }, this);
       }
       const Chat = registerClientReference("/test/file.tsx", "Chat", ChatSSR);
-      export { ChatSSR };
-      export { Chat };
+      export { ChatSSR, Chat };
       "
     `);
   });
 
   it("Does not transform when 'use client' is not directive", async () => {
     expect(await transform(`const message = "use client";`))
-      .toMatchInlineSnapshot(`
-      "import { registerClientReference } from "@redwoodjs/sdk/worker";
-
-      const message = "use client";"
-    `);
+      .toMatchInlineSnapshot(`undefined`);
   });
 });


### PR DESCRIPTION
## Context
When transforming `use client` modules for worker environment
* we keep the original components code as the SSR form the components (and export under name `<Component>SSR`) - this is used for SSR rendering
* we transform the existing component exports to instead be registered client references (since the actual component code is only relevant to client environment)

## Problem
* When adding SSR exports, we'd accidentally rename existing grouped exports too (e.g. `export { Button }` -> `export { ButtonSSR }`)
* We'd then later remove all original component exports and add them back ourselves together with their SSR equivalents
* But we'd look at the _original_ names when finding the original exports to remove them - except they are now named `<Component>SSR`

## Solution
Follow a more robust implementation with several passes:
1. collect info
2. remove exports
3. transform
4. add back exports
