### PR TITLE
fix: Ensure we always handle actions before re-rendering

### DIFF
--- a/sdk/src/runtime/worker.tsx
+++ b/sdk/src/runtime/worker.tsx
@@ -103,6 +103,13 @@ export const defineApp = (routes: Route[]) => {
             });
           }
 
+          let actionResult: unknown = undefined;
+          const isRSCActionHandler = url.searchParams.has("__rsc_action_id");
+
+          if (isRSCActionHandler) {
+            actionResult = await rscActionHandler(request);
+          }
+
           const props = computePageProps(requestInfo, Page);
 
           const pageResult = isClientReference(Page) ? (
@@ -113,13 +120,6 @@ export const defineApp = (routes: Route[]) => {
 
           if (pageResult instanceof Response) {
             return pageResult;
-          }
-
-          let actionResult: unknown = undefined;
-          const isRSCActionHandler = url.searchParams.has("__rsc_action_id");
-
-          if (isRSCActionHandler) {
-            actionResult = await rscActionHandler(request);
           }
 
           const rscPayloadStream = renderToRscStream({


### PR DESCRIPTION
## Problem
Since #342, we call page functions to unroll the first level, rather than creating an element for react to unroll later. We do this to determine whether the page returned an element or not.

This had an important implication for the way we do RSC: We are now calling the page function _before_ handling actions, whereas previously this would only happen _after_ handling actions (indirectly, via react).

## Solution
Make sure action handling always happens first.

### Side note: `() => Element | Response`
We should maybe re-consider whether we do in fact want page functions to either return an element or response. A subtle implication is that we are effectively needing to unroll the first step in the component tree. That should be react's job, and bad things might happen if we are doing it ourselves. e.g. react has not yet set up its internal state, which it does before starting rendering.