### PR TITLE
docs: Tutorial edits

### DIFF
--- a/docs/src/content/docs/tutorial/full-stack-app/1-setup.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/1-setup.mdx
@@ -80,8 +80,8 @@ I've also exported all the images from the Figma file and packaged them together
 
 Before we start, you'll need:
 - [Cloudflare account](https://www.cloudflare.com/plans/). They have a generous free tier that should include everything you need to follow along.
-- [Node.js](https://nodejs.org/en/download/) version 22 or later installed on your machine. (If you need help, check out [our blog post on using nvm]())
-- A Code Editor. We recommend [Cursor](https://www.cursor.com/). In fact, [we have a custom `.cursorrules` file that should improve its AI recommendations]().
+- [Node.js](https://nodejs.org/en/download/) version 22 or later installed on your machine. (If you need help, check out [using nvm](https://docs.redwoodjs.com/docs/how-to/using-nvm/) from our old docs.)
+- A Code Editor. We recommend [Cursor](https://www.cursor.com/). In fact, the standard starter [ships with Cursor rules](https://github.com/redwoodjs/sdk/tree/main/starters/standard/.cursor/rules) that improves its suggestions.
 - A Terminal. We recommend [Warp](https://warp.dev/) or [atuin.sh](https://atuin.sh/).
 - Basic knowledge of:
   - JavaScript, TypeScript, and React

--- a/docs/src/content/docs/tutorial/full-stack-app/1-setup.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/1-setup.mdx
@@ -80,7 +80,7 @@ I've also exported all the images from the Figma file and packaged them together
 
 Before we start, you'll need:
 - [Cloudflare account](https://www.cloudflare.com/plans/). They have a generous free tier that should include everything you need to follow along.
-- [Node.js](https://nodejs.org/en/download/) version 22 or later installed on your machine. (If you need help, check out [using nvm](https://docs.redwoodjs.com/docs/how-to/using-nvm/) from our old docs.)
+- [Node.js](https://nodejs.org/en/download/) version 22 or later installed on your machine.
 - A Code Editor. We recommend [Cursor](https://www.cursor.com/). In fact, the standard starter [ships with Cursor rules](https://github.com/redwoodjs/sdk/tree/main/starters/standard/.cursor/rules) that improves its suggestions.
 - A Terminal. We recommend [Warp](https://warp.dev/) or [atuin.sh](https://atuin.sh/).
 - Basic knowledge of:
@@ -103,6 +103,4 @@ You can find the final code on [GitHub](https://github.com/ahaywood/applywize).
 
 ## Further Reading
 
-{/* TODO: Write these blog posts */}
 - [Using nvm to install Node.js](https://nodejs.org/en/download)
-- [Figma for Developers]() - TODO: Write this blog post

--- a/docs/src/content/docs/tutorial/full-stack-app/2-create-app.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/2-create-app.mdx
@@ -679,7 +679,7 @@ Now, when you visit https://localhost:5173/user/login, you should see styled but
 Perfect, now that we have our project setup, and all the frontend components installed, [let's start building the backend.](/tutorial/full-stack-app/database-setup)
 
 <Aside type="tip" title="Code on GitHub">
-You can find the final code for this step on [GitHub](https://github.com/redwoodjs/applywize).
+You can find the final code for this step on [GitHub](https://github.com/ahaywood/applywize/tree/main/end-of-2).
 </Aside>
 
 ## Further reading

--- a/docs/src/content/docs/tutorial/full-stack-app/2-create-app.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/2-create-app.mdx
@@ -86,7 +86,7 @@ Inside, the `applywize` directory, you should have the following files and folde
 - types
   - vite.d.ts # Vite types
 - vite.config.mts # Vite configuration
-- worker-configuration.d.ts # Cloudflare worker configuration
+- worker-configuration.d.ts # Generated types based on your worker config
 - wrangler.jsonc # Cloudflare configuration
 </FileTree>
 

--- a/docs/src/content/docs/tutorial/full-stack-app/3-database-setup.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/3-database-setup.mdx
@@ -703,7 +703,7 @@ You can also leverage libraries, like [Faker](https://fakerjs.dev/) and [Snaplet
 
 
 <Aside type="tip" title="Code on GitHub">
-You can find the final code for this step on [GitHub](https://github.com/redwoodjs/applywize).
+You can find the final code for this step on [GitHub](https://github.com/ahaywood/applywize/tree/main/end-of-3).
 </Aside>
 
 ## Further reading

--- a/docs/src/content/docs/tutorial/full-stack-app/3-database-setup.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/3-database-setup.mdx
@@ -317,7 +317,7 @@ model Contact {
 }
 ```
 
-1. On the `Contact` model, we added a `companyId` field. This stores the ID of the related `Company` record. Because the `id` field on the `Company` model is a string, our `companyId` field is also a string. This is needed by the database to establish the relationship, and is the only information that gets stored.
+1. On the `Contact` model, we added a `companyId` field. This stores the ID of the related `Company` record. Because the `id` field on the `Company` model is a string, our `companyId` field is also a string.
 2. On the `Contact` model, we also added a `company` field. This describes the Contact↔Company relationship to Prisma.
     - You can read this as: "A contact belongs to a company."
     - It is connected to the `Company` model. You can also think of this as having a type of `Company`.

--- a/docs/src/content/docs/tutorial/full-stack-app/3-database-setup.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/3-database-setup.mdx
@@ -292,7 +292,7 @@ When establishing a relationship within your schema, there are 3 parts.
 
 Let's look at this in practice. On the `Company` and `Contact` models:
 
-```prisma {"3. The reverse relationship definition": 4-5} {"1. The field that holds the relationship": 16-17} {"2. The relationship definition": 18-19} title="src/db/schema.prisma"
+```prisma {"3. The Implicit Relationship Field": 4-5} {"1. The Foreign Key": 16-17} {"2. The Relation Field": 18-19} title="src/db/schema.prisma"
 model Company {
   id           String        @id @default(uuid())
   name         String
@@ -317,17 +317,19 @@ model Contact {
 }
 ```
 
-1. On the `Contact` model, we added a `companyId` field. This stores the ID of the related `Company` record. Because the `id` field on the `Company` model is a string, our `companyId` field is also a string.
-2. On the `Contact` model, we also added a `company` field, that defines the relationship.
+1. On the `Contact` model, we added a `companyId` field. This stores the ID of the related `Company` record. Because the `id` field on the `Company` model is a string, our `companyId` field is also a string. This is needed by the database to establish the relationship, and is the only information that gets stored.
+2. On the `Contact` model, we also added a `company` field. This describes the Contact↔Company relationship to Prisma.
+    - You can read this as: "A contact belongs to a company."
     - It is connected to the `Company` model. You can also think of this as having a type of `Company`.
     - It uses the `companyId` field on the `Contact` model to connect the two models.
     - It references the `id` field on the `Company` model.
-3. On the `Company` model, we added a `contacts` field.
+3. On the `Company` model, we added a `contacts` field. This describes the Company↔Contact relationship to Prisma.
+    - You can read this as: "A company has many contacts."
     - The type of content will be an array `[]` of `Contact` records.
 
 ![](./images/prisma-relationship-field.png)
 
-In some cases, you might need to give the relationship a name. This is particularly useful when you have multiple relationships between the same models.
+In some cases, you might need to give the relationship a name. This is particularly useful when you have multiple relationships between the same models. You can read more about when this is needed in the [Prisma documentation](https://www.prisma.io/docs/orm/prisma-schema/data-model/relations#disambiguating-relations).
 
 Here, I've named the relationship `CompanyContacts`.
 
@@ -509,7 +511,7 @@ You'll notice the `url` is referencing the `DATABASE_URL` environment variable.
 
 We need this to set this up in the `.env` file so Prisma Studio can connect to the database.
 
-First, let's go to our `d1` database. This is inside the `.wrangler/state/v3/d1/miniflare-D1DatabaseObject` directory.
+First, let's go to our [locally mirrored](https://developers.cloudflare.com/d1/best-practices/local-development/) `d1` database. This is inside the `.wrangler/state/v3/d1/miniflare-D1DatabaseObject` directory.
 
 ![](./images/local-wrangler-d1-database.png)
 
@@ -519,7 +521,7 @@ Inside your `.env` file, create a `DATABASE_URL` variable and paste in the datab
 
 ![](./images/database-url-full-url.png)
 
-Right now, the database url uses the absolute path, we need to make this path relative. Remove everything in front of `.wrangler` and replace it with `../`. We also need to specify that this is a `file`:
+Right now, the database url uses the absolute path — we need to make this path relative. Remove everything in front of `.wrangler` and replace it with `../`. We also need to specify that this is a `file`:
 
 ```
 DATABASE_URL="file:../.wrangler/state/v3/d1/miniflare-D1DatabaseObject/84daca3a95ca09403c82fcd535a8a092abf9029357d742c62ecaab59bcc13d30.sqlite"
@@ -550,7 +552,7 @@ Right now, we don't have any data in our table, but at least we can tell that ou
 
 The [VS Code extension, SQLite Viewer](https://marketplace.visualstudio.com/items?itemName=qwtel.sqlite-viewer) is perfect for previewing your SQLite database directly within VS Code.
 
-Within the file explorer, navigate to your SQLite database. You can find it in the `.wrangler > state > v3 > d1 > miniflare-D1DatabaseObject` folder.
+Within the file explorer, navigate to your [locally mirrored](https://developers.cloudflare.com/d1/best-practices/local-development/) D1 database. You can find it in the `.wrangler > state > v3 > d1 > miniflare-D1DatabaseObject` folder.
 
 <FileTree>
 - .wrangler
@@ -622,7 +624,7 @@ If you want to start fresh with your own seed file, you could delete lines 7-17,
 <Aside type="tip" title="Seed File Structure">
   In order for our seed file to run properly, we have to run it inside a Cloudflare worker.
 
-  Why? We're using a Cloudflare D1 database, we need a worker in order to access it.
+  Why? We're using a Cloudflare D1 database, so we need a worker in order to access it. You can read more about D1 local development [in the D1 documentation](https://developers.cloudflare.com/d1/best-practices/local-development/).
 </Aside>
 
 You can copy and paste the following code to your project:
@@ -698,7 +700,7 @@ The seed file we just created is perfect for a brand new database, whether we're
 
 Typically, I'll also create seed files to test the application with various sets of data. This is much easier (and faster) than manually adding data again and again.
 
-You can also leverage libraries, like [Faker](https://fakerjs.dev/) and [Snaplet](https://snaplet.dev/), to make it easier to create realistic data sets.
+You can also leverage libraries, like [Faker](https://fakerjs.dev/) and [Snaplet](https://snaplet-seed.netlify.app/seed/getting-started/overview), to make it easier to create realistic data sets.
 </Aside>
 
 

--- a/docs/src/content/docs/tutorial/full-stack-app/4-auth.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/4-auth.mdx
@@ -16,7 +16,7 @@ Since we're using the [standard starter kit](https://github.com/redwoodjs/sdk/tr
 Passkey authentication is a passwordless authentication method that uses a biometric or device authentication to verify the user's identity.
 
 **How it Works**:
-1. A use creates a passkey during the registration process.
+1. A user creates a passkey during the registration process.
 2. A unique public-private key pair is generated.
 3. The private key remains securely stored on the user's device or [in a password manager](https://developer.apple.com/passkeys/).
 4. The public key is shared with the service.

--- a/docs/src/content/docs/tutorial/full-stack-app/4-auth.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/4-auth.mdx
@@ -170,7 +170,7 @@ The router highlights the request-response lifecycle. The first parameter is the
 We can change that to return the `Home` component by changing the second parameter:
 
 ```tsx title="src/worker.tsx" startLineNumber=50
-route("/", () => Home),
+route("/", Home),
 ```
 
 We can also change the home page route to use the `index` method:

--- a/docs/src/content/docs/tutorial/full-stack-app/4-auth.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/4-auth.mdx
@@ -9,7 +9,7 @@ description: A guide in my new Starlight docs site.
 import { Aside, FileTree } from '@astrojs/starlight/components';
 
 ## Existing Authentication Code
-Since we're using the [standard starter kit](https://github.com/redwoodjs/sdk/tree/main/starters/standard), it already has passkey authentication setup.
+Since we're using the [standard starter kit](https://github.com/redwoodjs/sdk/tree/main/starters/standard), it already has passkey authentication set up.
 
 <Aside type="note" title="Passkey Authentication">
 ### What is Passkey Authentication?
@@ -18,7 +18,7 @@ Passkey authentication is a passwordless authentication method that uses a biome
 **How it Works**:
 1. A use creates a passkey during the registration process.
 2. A unique public-private key pair is generated.
-3. The private key remains securely stored on the user's device.
+3. The private key remains securely stored on the user's device or [in a password manager](https://support.apple.com/guide/iphone/use-passkeys-to-sign-in-to-websites-and-apps-iphf538ea8d0/ios).
 4. The public key is shared with the service.
 5. When the user logs in, they have to "prove" they have access to the private key.
 6. The service verifies the user's identity using the public key.
@@ -156,7 +156,8 @@ async ({ ctx, request, headers }) => {
 ```tsx title="src/worker.tsx" startLineNumber=49
 render(Document, [
 ```
-- On **line 49**, we're setting up our document. This document is referencing our `src/app/Document.tsx` file. It contains our `html`, `head`, and `body` tags and wraps _all_ of our pages. **_RedwoodSDK only supports one document._**
+- On **line 49**, we're setting up our document. This document is referencing our `src/app/Document.tsx` file. It contains our `html`, `head`, and `body` tags and wraps _all_ of our pages.
+  - One of the powerful yet simple features of RedwoodSDK is that it supports per-route documents. Read more about this [on our blog](https://rwsdk.com/blog/redwoodsdk-multiple-documents).
 
 ```tsx title="src/worker.tsx" startLineNumber=49
 render(Document, [

--- a/docs/src/content/docs/tutorial/full-stack-app/4-auth.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/4-auth.mdx
@@ -18,7 +18,7 @@ Passkey authentication is a passwordless authentication method that uses a biome
 **How it Works**:
 1. A use creates a passkey during the registration process.
 2. A unique public-private key pair is generated.
-3. The private key remains securely stored on the user's device or [in a password manager](https://support.apple.com/guide/iphone/use-passkeys-to-sign-in-to-websites-and-apps-iphf538ea8d0/ios).
+3. The private key remains securely stored on the user's device or [in a password manager](https://developer.apple.com/passkeys/).
 4. The public key is shared with the service.
 5. When the user logs in, they have to "prove" they have access to the private key.
 6. The service verifies the user's identity using the public key.
@@ -165,15 +165,15 @@ render(Document, [
 ```
 - On **line 50**, we're setting up our home page route. Here, we're just returning a standard response.
 
-The router, highlights the request response life cycle. The first parameter is the route we're requesting and the second parameter is the response. This can be a standard response, or it can be a React component. On line 50, we're returning a standard response that says `Hello World!`.
+The router highlights the request-response lifecycle. The first parameter is the route we're requesting and the second parameter is the response. This can be a standard response, or it can be a React component. On line 50, we're returning a standard response that says `Hello World!`.
 
-We could change that to return the `Home` component, by changing the second parameter:
+We can change that to return the `Home` component by changing the second parameter:
 
 ```tsx title="src/worker.tsx" startLineNumber=50
 route("/", () => Home),
 ```
 
-We could also change the home page route to use the `index` method:
+We can also change the home page route to use the `index` method:
 
 ```tsx title="src/worker.tsx" showLineNumbers={false}
 import { index, route, render, prefix } from "@redwoodjs/sdk/router";
@@ -181,9 +181,9 @@ import { index, route, render, prefix } from "@redwoodjs/sdk/router";
 index([Home]);
 ```
 
-The `index` method is similar to the `route` method, but instead of taking two parameters, it only takes one, the response.
+The `index` method is just [a wrapper around the `route` method that passes `/` as the path](https://github.com/redwoodjs/sdk/blob/b943792e5b651f0c82a102fdd21db1d6f834cf93/sdk/src/runtime/lib/router.ts#L196). As such, instead of taking two parameters, it only takes one — the response.
 
-If we move further down our `render` method, the next route is a `/protected` route.
+If we move further down our `render` method, the next route is a protected route at the `/protected` path.
 
 ```tsx title="src/worker.tsx" startLineNumber=51
 route("/protected", [
@@ -204,7 +204,7 @@ Here, we're using an **interrupter** to see if the user is logged in. This is a 
 <Aside type="note" title="Middleware vs Interrupters">
 #### Middleware
 
-Middleware is a function that runs _in the middle_, between your request to the server and the server's response.
+Middleware is a function that runs _in the middle_, between the server receiving requests and the server's handling of those requests.
 
 It allows you to:
 
@@ -215,21 +215,21 @@ It allows you to:
 
 #### Interrupters
 
-Interrupters will _interrupt_ the flow. Before, the server returns a response, the interrupter will run.
+Interrupters will _interrupt_ the flow. They run as part of the handling of a given request, and before the response is returned.
 
 #### These sound similar, what's the difference?
 
 - Middleware will run before _every single route_.
 - Interrupters will only run _on specific routes._
 
-In our code, we're using middleware to attach the user session to our context object, on every request. But, we're only checking to see if the user is logged in on the home page.
+In our code, we're using middleware to attach the user session to our context object *on every request*. But, we're only checking to see if the user is logged in *on the home page*.
 </Aside>
 
-```tsx title="src/worker.tsx" startLineNumber=60
+```tsx title="src/worker.tsx" startLineNumber=62
 prefix("/user", userRoutes),
 ```
-- On **line 62**, we're prefixing all of our auth routes with `/user`. Meaning, our `login` route will be `/user/login` and our `logout` route will be `/user/logout`.
-  - `login` and `logout` are defined within the `userRoutes` file, imported on line 6. One of the cool things about the RedwoodSDK router is the parameter is defined through an array. This means, we can define our route information in a separate file and then import it into our `worker.tsx` file.
+- On **line 62**, we're prefixing all of our auth routes with `/user`. This means our `login` route will be `/user/login` and our `logout` route will be `/user/logout`.
+  - `login` and `logout` are defined within the `userRoutes` file, imported on line 6. One of the cool things about the RedwoodSDK router is that the response parameter can be an array. This means we can define our route information in a separate file and then import it into our `worker.tsx` file.
 
 We're co-locating the file that defines our auth routes with our auth pages.
 
@@ -257,7 +257,7 @@ export const userRoutes = [
 
 We're defining 2 routes:
 - `/login` - This is displaying our login page (on line 6).
-- `/logout` - This is our logout route (on line 7), but instead of returning JSX, we're removing the session (line 9) and redirecting the user to the home page (line 10). Then, returning the response (line 12-15).
+- `/logout` - This is our logout route (on line 7), but instead of returning JSX, we're removing the session (line 9) and redirecting the user to the home page (line 10). Then, we return the response (line 12-15). The [response code of 302](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/302) means we're doing a redirect to the `Location` header.
 
 <Aside type="note" title="Prefixed Routes">
 Remember, even though these routes are defined as `/login` and `/logout`, we've prefixed them in our `worker.tsx` file with `/user` So, in order to access them, you'll go to `/user/login` and `/user/logout`.
@@ -715,7 +715,7 @@ Within the browser, go to http://localhost:2332/user/signup.
 
 Add a `username` and click "Register with passkey".
 
-If you're using a Password Manager, like [1Password](https://1password.com/), it's easy to create and manage your passkeys. Of course, there are other tools to choose from. [Apple even has their own native solution](https://developer.apple.com/passkeys/).
+If you're using a Password Manager, like [1Password](https://1password.com/product/passkeys), it's easy to create and manage your passkeys. Of course, there are other tools to choose from. [Apple even has their own native solution](https://developer.apple.com/passkeys/).
 
 ![](./images/register-with-passkey.png)
 
@@ -1382,7 +1382,7 @@ At the very bottom of our `styles.css` file, let's start by setting up `@layer` 
 ```
 
 <Aside type="tip" title="CSS Layers">
-Did these `@layer`s give you déjà vu. Feels similar to Tailwind v3? It's the exact same concept! But, because these layers are no longer established in Tailwind, we have to define the order ourselves: `@layer base, components, page;`
+Did these `@layer` names give you déjà vu? Feels similar to Tailwind v3? It's the exact same concept! But because these layers [are no longer established in Tailwind as of v4](https://tailwindcss.com/docs/upgrade-guide#removed-tailwind-directives), we have to define the order ourselves: `@layer base, components, page;`
 
 Technically, we could list our layers in any order we want:
 ```css showLineNumbers=false
@@ -1391,7 +1391,7 @@ Technically, we could list our layers in any order we want:
 @layer base {}
 ```
 
-It will still be applied in the correct order because we set the ordering, here:
+It will still be applied in the correct order because we set the ordering here:
 ```css showLineNumbers=false
 @layer base, components, page;
 ```

--- a/docs/src/content/docs/tutorial/full-stack-app/4-auth.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/4-auth.mdx
@@ -2555,7 +2555,7 @@ export function SignupPage() {
 </details>
 
 <Aside type="tip" title="Code on GitHub">
-You can find the final code for this step on [GitHub](https://github.com/redwoodjs/applywize).
+You can find the final code for this step on [GitHub](https://github.com/ahaywood/applywize/tree/main/end-of-4).
 </Aside>
 
 ## Further reading

--- a/docs/src/content/docs/tutorial/full-stack-app/5-jobs-list.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/5-jobs-list.mdx
@@ -1984,5 +1984,5 @@ export { List }
 
 
 <Aside type="tip" title="Code on GitHub">
-You can find the final code for this step on [GitHub](https://github.com/redwoodjs/applywize).
+You can find the final code for this step on [GitHub](https://github.com/ahaywood/applywize/tree/main/end-of-5).
 </Aside>

--- a/docs/src/content/docs/tutorial/full-stack-app/5-jobs-list.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/5-jobs-list.mdx
@@ -106,7 +106,7 @@ Now, we can also update our protected page route to use the `isAuthenticated` fu
 route("/protected", [ isAuthenticated, Home ]),
 ```
 
-Actually, let's refactor this. The `protected` route was really meant as an example. We don't need `/protected`, but we do want to protect our home page: `route("/", Home),`. We could change `/protected` to `/`, and then delete `route("/", Home),`.
+Actually, let's refactor this. The `protected` route was really meant as an example. We don't need `/protected`, but we do want to protect our home page: `route("/", Home),`. We *could* change `/protected` to `/`, and then delete `route("/", Home),`.
 
 ```tsx startLineNumber=61
 route("/", [ isAuthenticated, Home ]),
@@ -423,7 +423,7 @@ All the data from the database is returned as an array and saved in a variable c
 
 Easy, right?! Since we're using React Server Components, this code runs on the server. We're able to make database calls directly from the page and don't need to worry about creating API routes. 🎉
 
-Also, if you look right click on the page and select **View Source**, you'll see that the data is being rendered directly on the page.
+Also, if you right click on the page and select **View Source**, you'll see that the data is being sent as part of the HTML, rather than rendered client side by JavaScript.
 
 ![](./images/applications-list-view-source.png)
 

--- a/docs/src/content/docs/tutorial/full-stack-app/5-jobs-list.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/5-jobs-list.mdx
@@ -371,7 +371,7 @@ When you're creating custom seed files, this does take more time on the frontend
 
 ### Option 2: Prisma Studio
 
-Another option is to use Prisma Studio. This option is easier, but requires manual entry and can take more time in the long run. ([We already set up Prisma Studio, here.](http://localhost:4321/tutorial/full-stack-app/database-setup#prisma-studio-recommended))
+Another option is to use Prisma Studio. This option is easier, but requires manual entry and can take more time in the long run. ([We already set up Prisma Studio, here.](/tutorial/full-stack-app/database-setup#prisma-studio-recommended))
 
 ```shell
 npx prisma studio

--- a/docs/src/content/docs/tutorial/full-stack-app/6-jobs-form.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/6-jobs-form.mdx
@@ -307,7 +307,7 @@ Now, let's start building out our form.
 </form>
 ```
 
-This is a big chunk of code, but it should be pretty straight forward. It's a standard form, using HTML labels and inputs with fields for:
+This is a big chunk of code, but it should be pretty straightforward. It's a standard form, using HTML labels and inputs with fields for:
 - Company Name
 - Job Title
 - Job Description / Requirements
@@ -645,7 +645,7 @@ Here, we're using a shadcn/ui `Select` component. We'll need to import this at t
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select"
 ```
 
-Let's look a little bit more at the shadcn/ui `Select` component. You can also [check out the official documentation.](https://ui.shadcn.com/docs/components/select)
+Let's look a little bit more at the shadcn/ui `Select` component. You can also [check out the official documentation](https://ui.shadcn.com/docs/components/select).
 
 The `Select` component has a trigger (`SelectTrigger`). This is essentially a button that opens the dropdown. I'm using a `placeholder` here that says "Select a Status." Then, the content (`SelectContent`) is the dropdown menu. For now, I only have one item in the dropdown, for "new", but we want to make this dynamic so that it's pulling all our application statuses from our database.
 
@@ -698,7 +698,7 @@ Test this out in the browser. If you click on the Application Status dropdown, y
 
 ![](./images/browser-application-status-expanded.png)
 
-Now, let's set up the basics for our Contacts box. We'll, set up the bare minimum now, and [revisit this in the next section](/tutorial/full-stack-app/contacts/).
+Now, let's set up the basics for our Contacts box. We'll set up the bare minimum now, and [revisit this in the next section](/tutorial/full-stack-app/contacts/).
 
 ```tsx
 <div className="box">
@@ -804,7 +804,7 @@ This is personal preference, but I like co-locating my actions with the pages th
 If it's a shared action, you can put it in a folder like `src/app/lib/actions` and naming the file based on the action.
 </Aside>
 
-At the top of our `actions.ts` file, we need the `"use server"` directive, to ensure this code runs on the server.
+At the top of our `actions.ts` file, we need the `"use server"` directive to mark server-side functions that can be called from client-side code (see the [React documentation on this](https://react.dev/reference/rsc/use-server) for more info).
 
 ```tsx title="/src/app/pages/applications/actions.ts"
 "use server"
@@ -823,7 +823,7 @@ export const createApplication = async (formData: FormData) => {
   }
 }
 ---
-- You'll notice we're `export`ing the function, so that we can use it in our `ApplicationForm` component.
+- You'll notice we're `export`ing the function so that we can use it in our `ApplicationForm` component.
 - Since this is a server action, we can use `async` / `await`. When the time comes, we'll want to `await` our database call.
 - This function accepts all the `formData` we collected. -- Form Data is part of the Web API ([further documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/API/FormData))
 - We set up a `try` / `catch` block. Inside the `try` block we'll eventually add our database call. Assuming that works, we'll return an object with `success` as `true` and `error` as `null`.

--- a/docs/src/content/docs/tutorial/full-stack-app/6-jobs-form.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/6-jobs-form.mdx
@@ -935,7 +935,7 @@ If you're interested in reading more on handling forms in React 19, here are a f
 </Aside>
 
 <Aside type="tip" title="Code on GitHub">
-You can find the final code for this step on [GitHub](https://github.com/redwoodjs/applywize).
+You can find the final code for this step on [GitHub](https://github.com/ahaywood/applywize/tree/main/end-of-6).
 </Aside>
 
 ## Further reading

--- a/docs/src/content/docs/tutorial/full-stack-app/7-contacts.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/7-contacts.mdx
@@ -1123,6 +1123,6 @@ Now, try running this in the browser again. You should see the contact deleted a
 Lovely!
 
 <Aside type="tip" title="Code on GitHub">
-You can find the final code for this step on [GitHub](https://github.com/redwoodjs/applywize).
+You can find the final code for this step on [GitHub](https://github.com/ahaywood/applywize/tree/main/end-of-7).
 </Aside>
 

--- a/docs/src/content/docs/tutorial/full-stack-app/7-contacts.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/7-contacts.mdx
@@ -314,13 +314,11 @@ You can also check Prisma Studio (`npx prisma studio`) to see the new contact in
 
 This _works_, kind of. -- It works, but it's not the best user experience. It would be better if we could see a success (or error) message in browser.
 
-Fortunate for us, [shadcn/ui has a toast component](https://ui.shadcn.com/docs/components/sonner) that we can use. This component works a little differently than the other components we've used. It has two parts. It needs the `Toaster` and the `Toast`.
+Fortunate for us, [shadcn/ui has a toast component](https://ui.shadcn.com/docs/components/sonner) that we can use. This component works a little differently than the other components we've used. It has two parts — a `Toaster` and the `Toast`:
 
-The `Toaster` handles where the message gets displayed. We can also cue up or show several messages at once. So, the `Toaster` "holds" the `Toast`.
-
-The `Toaster` component typically lives in a layout component.
-
-Then, components nested inside, can trigger `Toast` messages.
+- The `Toaster` handles where the message gets displayed. We can also cue up or show several messages at once. So, the `Toaster` "holds" and then "pops out" the `Toast`.
+- The `Toaster` typically lives in a layout component that parents the rest of the app.
+- Then, child components can `Toast` messages.
 
 This might make more sense as we build it out.
 
@@ -449,7 +447,7 @@ const ContactForm = ({ callback }: { callback: () => void }) => {
   }
 ```
 
-If you test everything out in the browser, you should still see the successful toaster message and the `Sheet` will close. 😎
+If you test everything out in the browser, you should still see the successful toast and the `Sheet` will close. 😎
 
 Now, we need a way to see the contacts we've added.
 
@@ -476,7 +474,7 @@ Let's start by displaying all contacts that aren't associated with a company.
 
 ### Getting the Contacts from the Database
 
-Even though our contacts will be displayed in the `ApplicationForm` component, the `ApplicationForm` is a client component. It'd be better if we could grab the data inside a server component and then pass it in. (You'll remember, we did the ame thing with our application statuses).
+Even though our contacts will be displayed in the `ApplicationForm` component, the `ApplicationForm` is a client component. It'd be better if we could grab the data inside a server component and then pass it in. (You'll remember, we did the same thing with our application statuses).
 
 Inside our `New` page, let's get all of our contacts, where the `companyId` is `null`:
 
@@ -684,7 +682,7 @@ When you run this, you'll probably get an error:
 
 ![](./images/error-running-new-migration.png)
 
-The reason is because we already have contacts in our database. When we added the `userId` column to the `Contact` model, we said that it was a required field. This creates a problem for all existing contact entries that don't have a user associated with them.
+The reason is that we already have contacts in our database. When we added the `userId` column to the `Contact` model, we said that it was a required field. This creates a problem for all existing contact entries that don't have a user associated with them.
 
 If you read the error message, the migration file was created, but not applied.
 
@@ -869,7 +867,7 @@ company: {
 },
 ```
 
-Now, when you create a new job application, any contacts you've listed, will be associated with the company and job application you created.
+Now, when you create a new job application, any contacts you've listed will be associated with the company and job application you created.
 
 ![](./images/associated-contact-in-applications-table.png)
 

--- a/docs/src/content/docs/tutorial/full-stack-app/8-jobs-details.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/8-jobs-details.mdx
@@ -10,7 +10,7 @@ import { Aside, FileTree } from '@astrojs/starlight/components';
 
 Can you believe it?! This is the last piece we need before deploying our application.
 
-We've already done the bulk of our set up, so this part should easier-ly. 🙃
+We've already done the bulk of our set up, so this part should be easy...er? 🙃
 
 First, let's take a look at [what we're building in Figma](https://www.figma.com/design/nqBPIIfe0MO4W8zOfW4oae/RedwoodSDK---Applywize?node-id=12-327&t=OsDs4uB62Y6faUen-1).
 
@@ -238,7 +238,7 @@ Now, that we know we're getting the right application back, let's update our `<B
 + <BreadcrumbPage>{application?.jobTitle} at {application?.company?.name}</BreadcrumbPage>
 ```
 
-We're using the Elvis operator (`?.`) or optional chaining to ensure that we don't throw an error if the application object is `null`.
+We're using the Elvis operator (`?.`) (optional chaining) to ensure that we don't throw an error if the application object is `null`.
 
 When you preview this in the browser, you might be surprised to see that the company information is not showing up.
 
@@ -880,11 +880,9 @@ Now, let's go back to our `Details.tsx` file and add our `DeleteApplicationButto
 +<DeleteApplicationButton applicationId={application?.id as string} />
 ```
 
-Let's test this out in the browser.
+Go test this out in the browser — everything should be working. 🙌
 
-🙌 Looks like everything is working.
-
-Before we can move on, we need to set up the "Nevermind" button to close the dialog box.
+Before we can move on, we need to set up the "Nevermind" button for closing the dialog box.
 
 ### Closing the Dialog Box
 

--- a/docs/src/content/docs/tutorial/full-stack-app/8-jobs-details.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/8-jobs-details.mdx
@@ -1425,5 +1425,5 @@ Perfect! Now test the update form within the browser. You should be able to edit
 💥 We did it! Now, we just need to get our application online where people can use it!
 
 <Aside type="tip" title="Code on GitHub">
-You can find the final code for this step on [GitHub](https://github.com/redwoodjs/applywize).
+You can find the final code for this step on [GitHub](https://github.com/ahaywood/applywize/tree/main).
 </Aside>

--- a/docs/src/content/docs/tutorial/full-stack-app/9-deploying.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/9-deploying.mdx
@@ -91,5 +91,5 @@ If you click on the **Details** link, it will take you to a dedicated page withi
 Congrats! You should know everything you need to know to build your own application, using RedwoodSDK. We'd love to see what you build. Please share your work and stay in touch by registering for our [newsletter](https://rwsdk.com).
 
 <Aside type="tip" title="Code on GitHub">
-You can find the final code for this step on [GitHub](https://github.com/redwoodjs/applywize).
+You can find the final code for this step on [GitHub](https://github.com/ahaywood/applywize/tree/main/finished).
 </Aside>


### PR DESCRIPTION
Going through the tutorial and opening a PR with any edits/feedback. Included:
- Small edits
- Add links to docs for further exploration & learning
- Fix broken links. Some are worth discussing:
  - The link at the end to each page is to https://github.com/redwoodjs/applywize, which doesn't exist. Updated to link to @ahaywood's repo
    - Note: that repo is missing the finished state for step 8
  - The Snaplet link at the end of step 3 is broken. Is the site down, or was it shut down? Updated to the Snaplet Seed Netlify link (cc @peterp)
  - There was a blank link to a blog post on using nvm, but as far as I can tell this blog post doesn't exist. Replaced it with a link to [a docs page from RedwoodGraphQL on using nvm](https://docs.redwoodjs.com/docs/how-to/using-nvm/), but this will likely be confusing to folks new to the world of Redwood. This is a good candidate for a page that we can just copy over to the new docs, and there's likely others.
- I suppose when this was first written, RWSDK only supported a single document? Updated this note and added a link to Peter's recent blog post