### PR TITLE
fix env usage in docs

### DIFF
--- a/docs/src/content/docs/core/queues.mdx
+++ b/docs/src/content/docs/core/queues.mdx
@@ -49,8 +49,10 @@ This will bind the queue to the `env.QUEUE` object in the worker. So you'll be a
 ### Sending messages
 
 ```tsx title="src/worker.tsx"
+import { env } from "cloudflare:workers";
+
 export default defineApp([
-  route('/pay-with-ai', ({ env }) => {
+  route('/pay-with-ai', () => {
     // Post a message to the queue
     env.QUEUE.send({
       userId: 1,

--- a/docs/src/content/docs/core/storage.mdx
+++ b/docs/src/content/docs/core/storage.mdx
@@ -58,9 +58,10 @@ RedwoodSDK uses the standard Request/Response objects. When uploading files, the
 ```tsx title="src/worker.tsx"
 import { defineApp } from "@redwoodjs/sdk/worker";
 import { route } from "@redwoodjs/sdk/router";
+import { env } from "cloudflare:workers";
 
 defineApp([
-  route("/upload/", async ({ request, env }) => {
+  route("/upload/", async ({ request }) => {
     const formData = await request.formData();
     const file = formData.get("file") as File;
 


### PR DESCRIPTION
When playing around with the sdk I noticed some docs that reference the usage of `env` via the `RequestInfo`. Trying to use this code gives a TS error: `Property 'env' does not exist on type 'RequestInfo<any, DefaultAppContext>'`.

I replaced the usage with this with the import of the `env` from `cloudflare:workers`