### PR TITLE
minimal-starter: update import paths to match standard starter

### DIFF
--- a/starters/minimal/src/worker.tsx
+++ b/starters/minimal/src/worker.tsx
@@ -1,9 +1,9 @@
 import { defineApp } from "@redwoodjs/sdk/worker";
 import { index, render } from "@redwoodjs/sdk/router";
 
-import { Document } from "@/Document";
-import { Home } from "@/pages/Home";
-import { setCommonHeaders } from "@/headers";
+import { Document } from "@/app/Document";
+import { Home } from "@/app/pages/Home";
+import { setCommonHeaders } from "@/app/headers";
 
 export type AppContext = {};
 

--- a/starters/minimal/tsconfig.json
+++ b/starters/minimal/tsconfig.json
@@ -20,7 +20,7 @@
       "./types/vite.d.ts"
     ],
     "paths": {
-      "@/*": ["./src/app/*"]
+      "@/*": ["./src/*"]
     },
     /* Enable importing .json files */
     "resolveJsonModule": true,


### PR DESCRIPTION
small update to make the alias match between the minimal starter and the standard one.

the idea is to make the documentation work for both (especially for the [shadcn/ui](https://docs.rwsdk.com/guides/frontend/shadcn/) docs) that uses the alias heavily due to the nature of shadcn/ui