### PR TITLE
docs: fix mention of prisma starter

### DIFF
--- a/docs/src/content/docs/core/database.mdx
+++ b/docs/src/content/docs/core/database.mdx
@@ -40,11 +40,11 @@ We've run a command to create a database called `my-database`. Copy those values
 
 ## Usage with Prisma
 
-<Aside type="note" title="Prisma Starter">
-RedwoodSDK ships with a [Prisma starter project](https://github.com/redwoodjs/sdk/tree/main/starters/prisma), you can use it to get started with a database in seconds.
+<Aside type="note" title="Standard Starter">
+RedwoodSDK ships with a [Standard starter project](https://github.com/redwoodjs/sdk/tree/main/starters/standard), you can use it to get started with a database in seconds.
 
 ```bash frame="none"
-npx degit redwoodjs/sdk/starters/prisma#main <project-name>
+npx degit redwoodjs/sdk/starters/standard#main <project-name>
 ```
 
 </Aside>


### PR DESCRIPTION
replace the mention of prisma starter with the standard starter as it seems the prisma starter doesn't exist (yet?)