### PR TITLE
minimal-starter: ignore .wrangler

### DIFF
--- a/starters/minimal/.gitignore
+++ b/starters/minimal/.gitignore
@@ -62,3 +62,6 @@ coverage
 # Temporary files
 *.tmp
 *.temp
+
+# Wrangler
+.wrangler


### PR DESCRIPTION
ignore .wrangler directly even if the minimal starter doesn't need it by default