### PR TITLE
Fix 2 docs links to Quick Start 

### DIFF
--- a/docs/src/content/docs/core/authentication.mdx
+++ b/docs/src/content/docs/core/authentication.mdx
@@ -18,7 +18,7 @@ import importedCodeStandardLogin from "../../../../../starters/standard/src/app/
 We've baked authentication right into the [**standard starter**](https://github.com/redwoodjs/sdk/tree/main/starters/standard), giving you everything you need to handle users, sessions, and logins out of the box. The standard starter uses **passkeys ([WebAuthn](https://webauthn.guide/))** for passwordless authentication (keys can be shared on multiple devices), **session persistence via [Cloudflare Durable Objects](https://developers.cloudflare.com/durable-objects/)**, and **bot protection with [Cloudflare Turnstile](https://developers.cloudflare.com/turnstile/)**. The database layer is powered by **[Cloudflare D1](https://developers.cloudflare.com/d1/)** and **[Prisma](https://www.prisma.io/)**.
 
 <Aside type="caution">
-  The [Quick Start Guide](getting-started/quick-start) uses the **minimal
+  The [Quick Start Guide](/getting-started/quick-start) uses the **minimal
   starter**, you should use the **standard starter** to get you set up and ready
   for using Database, Queues, Sessions and Authentication.
 </Aside>

--- a/docs/src/content/docs/core/database.mdx
+++ b/docs/src/content/docs/core/database.mdx
@@ -6,7 +6,7 @@ description: Store & retrieve data from the database.
 import { Aside, Tabs, TabItem, LinkCard } from "@astrojs/starlight/components";
 
 <Aside type="caution">
-  The [Quick Start Guide](getting-started/quick-start) uses the **minimal
+  The [Quick Start Guide](/getting-started/quick-start) uses the **minimal
   starter**, you should use the **standard starter** to get you set up and ready
   for using Database, Queues, Sessions and Authentication.
 </Aside>


### PR DESCRIPTION
Fix 404 for relative links to [Quick Start Guide](https://docs.rwsdk.com/getting-started/quick-start/) on: 

- https://docs.rwsdk.com/core/database/
- https://docs.rwsdk.com/core/authentication/ 