### PR TITLE
fix: Client entrypoint 404s

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,8 +166,8 @@ importers:
   starters/minimal:
     dependencies:
       '@redwoodjs/sdk':
-        specifier: 0.0.77-test.20250505004329
-        version: 0.0.77-test.20250505004329(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250428.0)
+        specifier: 0.0.77-test.20250505005503
+        version: 0.0.77-test.20250505005503(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250428.0)
     devDependencies:
       '@types/node':
         specifier: ^22.14.0
@@ -197,8 +197,8 @@ importers:
         specifier: ~6.5.0
         version: 6.5.0(prisma@6.5.0(typescript@5.8.3))(typescript@5.8.3)
       '@redwoodjs/sdk':
-        specifier: 0.0.77-test.20250505004329
-        version: 0.0.77-test.20250505004329(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250428.0)
+        specifier: 0.0.77-test.20250505005503
+        version: 0.0.77-test.20250505005503(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250428.0)
       '@simplewebauthn/browser':
         specifier: ^13.1.0
         version: 13.1.0
@@ -1225,8 +1225,8 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@redwoodjs/sdk@0.0.77-test.20250505004329':
-    resolution: {integrity: sha512-G9YgtEwCuPTQlK+Gj2ElgJxq4OCC1wkHmAAhmemHM1HjLiye/2qi1fpzVa1gvNzDrW2t0f7OpU02LAoRvFiF0A==}
+  '@redwoodjs/sdk@0.0.77-test.20250505005503':
+    resolution: {integrity: sha512-0Ik8soojte+l0nl+QPuFolFgGELgHjIVDEpbziQOu3i7S3GBKtoeoBA3OzdHiuj3AvJd385arMLRYhZKoG+Bjw==}
     hasBin: true
     peerDependencies:
       vite: ^6.2.6
@@ -4878,7 +4878,7 @@ snapshots:
     dependencies:
       dotenv: 16.4.7
 
-  '@redwoodjs/sdk@0.0.77-test.20250505004329(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250428.0)':
+  '@redwoodjs/sdk@0.0.77-test.20250505005503(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250428.0)':
     dependencies:
       '@cloudflare/vite-plugin': 1.1.0(rollup@4.40.0)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(workerd@1.20250428.0)(wrangler@4.14.1)
       '@cloudflare/workers-types': 4.20250407.0
@@ -4919,7 +4919,7 @@ snapshots:
       - webpack
       - workerd
 
-  '@redwoodjs/sdk@0.0.77-test.20250505004329(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250428.0)':
+  '@redwoodjs/sdk@0.0.77-test.20250505005503(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250428.0)':
     dependencies:
       '@cloudflare/vite-plugin': 1.1.0(rollup@4.40.0)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(workerd@1.20250428.0)(wrangler@4.14.1)
       '@cloudflare/workers-types': 4.20250407.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,8 +166,8 @@ importers:
   starters/minimal:
     dependencies:
       '@redwoodjs/sdk':
-        specifier: 0.0.77-test.20250505002148
-        version: 0.0.77-test.20250505002148(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250428.0)
+        specifier: 0.0.77-test.20250505004329
+        version: 0.0.77-test.20250505004329(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250428.0)
     devDependencies:
       '@types/node':
         specifier: ^22.14.0
@@ -197,8 +197,8 @@ importers:
         specifier: ~6.5.0
         version: 6.5.0(prisma@6.5.0(typescript@5.8.3))(typescript@5.8.3)
       '@redwoodjs/sdk':
-        specifier: 0.0.77-test.20250505002148
-        version: 0.0.77-test.20250505002148(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250428.0)
+        specifier: 0.0.77-test.20250505004329
+        version: 0.0.77-test.20250505004329(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250428.0)
       '@simplewebauthn/browser':
         specifier: ^13.1.0
         version: 13.1.0
@@ -1225,8 +1225,8 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@redwoodjs/sdk@0.0.77-test.20250505002148':
-    resolution: {integrity: sha512-ud6RVDSc7zKIwVYORnGimRYndFVGwjJcR55zE2tJm82CXRPDKf/5QKQG7H3/zsIWlaLhunPzbToDOorX4b68vA==}
+  '@redwoodjs/sdk@0.0.77-test.20250505004329':
+    resolution: {integrity: sha512-G9YgtEwCuPTQlK+Gj2ElgJxq4OCC1wkHmAAhmemHM1HjLiye/2qi1fpzVa1gvNzDrW2t0f7OpU02LAoRvFiF0A==}
     hasBin: true
     peerDependencies:
       vite: ^6.2.6
@@ -4878,7 +4878,7 @@ snapshots:
     dependencies:
       dotenv: 16.4.7
 
-  '@redwoodjs/sdk@0.0.77-test.20250505002148(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250428.0)':
+  '@redwoodjs/sdk@0.0.77-test.20250505004329(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250428.0)':
     dependencies:
       '@cloudflare/vite-plugin': 1.1.0(rollup@4.40.0)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(workerd@1.20250428.0)(wrangler@4.14.1)
       '@cloudflare/workers-types': 4.20250407.0
@@ -4919,7 +4919,7 @@ snapshots:
       - webpack
       - workerd
 
-  '@redwoodjs/sdk@0.0.77-test.20250505002148(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250428.0)':
+  '@redwoodjs/sdk@0.0.77-test.20250505004329(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250428.0)':
     dependencies:
       '@cloudflare/vite-plugin': 1.1.0(rollup@4.40.0)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(workerd@1.20250428.0)(wrangler@4.14.1)
       '@cloudflare/workers-types': 4.20250407.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,8 +166,8 @@ importers:
   starters/minimal:
     dependencies:
       '@redwoodjs/sdk':
-        specifier: 0.0.77-test.20250505011655
-        version: 0.0.77-test.20250505011655(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250428.0)
+        specifier: 0.0.77-test.20250505021527
+        version: 0.0.77-test.20250505021527(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250428.0)
     devDependencies:
       '@types/node':
         specifier: ^22.14.0
@@ -197,8 +197,8 @@ importers:
         specifier: ~6.5.0
         version: 6.5.0(prisma@6.5.0(typescript@5.8.3))(typescript@5.8.3)
       '@redwoodjs/sdk':
-        specifier: 0.0.77-test.20250505011655
-        version: 0.0.77-test.20250505011655(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250428.0)
+        specifier: 0.0.77-test.20250505021527
+        version: 0.0.77-test.20250505021527(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250428.0)
       '@simplewebauthn/browser':
         specifier: ^13.1.0
         version: 13.1.0
@@ -1225,8 +1225,8 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@redwoodjs/sdk@0.0.77-test.20250505011655':
-    resolution: {integrity: sha512-A7976LWbencUT3kC9P+T6RATczh0K5Dj9sp+vaJnlGyaGz1cgyp5OmVZxynMW794S74UScCPL/C8deZ6wOLUsQ==}
+  '@redwoodjs/sdk@0.0.77-test.20250505021527':
+    resolution: {integrity: sha512-/ZxCi5bpYeA78mcJ2ecY6di19Ppu2dzJRRT5toryp10nCUo9rxOOfvNWjhxguF9dTx7Z9/cHmPtzubFgtFZK/w==}
     hasBin: true
     peerDependencies:
       vite: ^6.2.6
@@ -4878,7 +4878,7 @@ snapshots:
     dependencies:
       dotenv: 16.4.7
 
-  '@redwoodjs/sdk@0.0.77-test.20250505011655(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250428.0)':
+  '@redwoodjs/sdk@0.0.77-test.20250505021527(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250428.0)':
     dependencies:
       '@cloudflare/vite-plugin': 1.1.0(rollup@4.40.0)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(workerd@1.20250428.0)(wrangler@4.14.1)
       '@cloudflare/workers-types': 4.20250407.0
@@ -4919,7 +4919,7 @@ snapshots:
       - webpack
       - workerd
 
-  '@redwoodjs/sdk@0.0.77-test.20250505011655(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250428.0)':
+  '@redwoodjs/sdk@0.0.77-test.20250505021527(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250428.0)':
     dependencies:
       '@cloudflare/vite-plugin': 1.1.0(rollup@4.40.0)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(workerd@1.20250428.0)(wrangler@4.14.1)
       '@cloudflare/workers-types': 4.20250407.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,8 +166,8 @@ importers:
   starters/minimal:
     dependencies:
       '@redwoodjs/sdk':
-        specifier: 0.0.77
-        version: 0.0.77(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250428.0)
+        specifier: 0.0.77-test.20250505002148
+        version: 0.0.77-test.20250505002148(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250428.0)
     devDependencies:
       '@types/node':
         specifier: ^22.14.0
@@ -197,8 +197,8 @@ importers:
         specifier: ~6.5.0
         version: 6.5.0(prisma@6.5.0(typescript@5.8.3))(typescript@5.8.3)
       '@redwoodjs/sdk':
-        specifier: 0.0.77
-        version: 0.0.77(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250428.0)
+        specifier: 0.0.77-test.20250505002148
+        version: 0.0.77-test.20250505002148(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250428.0)
       '@simplewebauthn/browser':
         specifier: ^13.1.0
         version: 13.1.0
@@ -1225,8 +1225,8 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@redwoodjs/sdk@0.0.77':
-    resolution: {integrity: sha512-1ghY1dsKeTmVomPe5fVrp+2gOCIV0j0EX1/AdQXECq/XHVBQiH+/hLBz5HhipmkEFXysP3pjSYb+AkppWCXRzw==}
+  '@redwoodjs/sdk@0.0.77-test.20250505002148':
+    resolution: {integrity: sha512-ud6RVDSc7zKIwVYORnGimRYndFVGwjJcR55zE2tJm82CXRPDKf/5QKQG7H3/zsIWlaLhunPzbToDOorX4b68vA==}
     hasBin: true
     peerDependencies:
       vite: ^6.2.6
@@ -4878,7 +4878,7 @@ snapshots:
     dependencies:
       dotenv: 16.4.7
 
-  '@redwoodjs/sdk@0.0.77(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250428.0)':
+  '@redwoodjs/sdk@0.0.77-test.20250505002148(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250428.0)':
     dependencies:
       '@cloudflare/vite-plugin': 1.1.0(rollup@4.40.0)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(workerd@1.20250428.0)(wrangler@4.14.1)
       '@cloudflare/workers-types': 4.20250407.0
@@ -4919,7 +4919,7 @@ snapshots:
       - webpack
       - workerd
 
-  '@redwoodjs/sdk@0.0.77(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250428.0)':
+  '@redwoodjs/sdk@0.0.77-test.20250505002148(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250428.0)':
     dependencies:
       '@cloudflare/vite-plugin': 1.1.0(rollup@4.40.0)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(workerd@1.20250428.0)(wrangler@4.14.1)
       '@cloudflare/workers-types': 4.20250407.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,8 +166,8 @@ importers:
   starters/minimal:
     dependencies:
       '@redwoodjs/sdk':
-        specifier: 0.0.77-test.20250505005503
-        version: 0.0.77-test.20250505005503(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250428.0)
+        specifier: 0.0.77-test.20250505011655
+        version: 0.0.77-test.20250505011655(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250428.0)
     devDependencies:
       '@types/node':
         specifier: ^22.14.0
@@ -197,8 +197,8 @@ importers:
         specifier: ~6.5.0
         version: 6.5.0(prisma@6.5.0(typescript@5.8.3))(typescript@5.8.3)
       '@redwoodjs/sdk':
-        specifier: 0.0.77-test.20250505005503
-        version: 0.0.77-test.20250505005503(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250428.0)
+        specifier: 0.0.77-test.20250505011655
+        version: 0.0.77-test.20250505011655(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250428.0)
       '@simplewebauthn/browser':
         specifier: ^13.1.0
         version: 13.1.0
@@ -1225,8 +1225,8 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@redwoodjs/sdk@0.0.77-test.20250505005503':
-    resolution: {integrity: sha512-0Ik8soojte+l0nl+QPuFolFgGELgHjIVDEpbziQOu3i7S3GBKtoeoBA3OzdHiuj3AvJd385arMLRYhZKoG+Bjw==}
+  '@redwoodjs/sdk@0.0.77-test.20250505011655':
+    resolution: {integrity: sha512-A7976LWbencUT3kC9P+T6RATczh0K5Dj9sp+vaJnlGyaGz1cgyp5OmVZxynMW794S74UScCPL/C8deZ6wOLUsQ==}
     hasBin: true
     peerDependencies:
       vite: ^6.2.6
@@ -4878,7 +4878,7 @@ snapshots:
     dependencies:
       dotenv: 16.4.7
 
-  '@redwoodjs/sdk@0.0.77-test.20250505005503(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250428.0)':
+  '@redwoodjs/sdk@0.0.77-test.20250505011655(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250428.0)':
     dependencies:
       '@cloudflare/vite-plugin': 1.1.0(rollup@4.40.0)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(workerd@1.20250428.0)(wrangler@4.14.1)
       '@cloudflare/workers-types': 4.20250407.0
@@ -4919,7 +4919,7 @@ snapshots:
       - webpack
       - workerd
 
-  '@redwoodjs/sdk@0.0.77-test.20250505005503(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250428.0)':
+  '@redwoodjs/sdk@0.0.77-test.20250505011655(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250428.0)':
     dependencies:
       '@cloudflare/vite-plugin': 1.1.0(rollup@4.40.0)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(workerd@1.20250428.0)(wrangler@4.14.1)
       '@cloudflare/workers-types': 4.20250407.0

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redwoodjs/sdk",
-  "version": "0.0.77-test.20250505004329",
+  "version": "0.0.77-test.20250505005503",
   "description": "Build fast, server-driven webapps on Cloudflare with SSR, RSC, and realtime",
   "type": "module",
   "bin": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redwoodjs/sdk",
-  "version": "0.0.77",
+  "version": "0.0.77-test.20250505002148",
   "description": "Build fast, server-driven webapps on Cloudflare with SSR, RSC, and realtime",
   "type": "module",
   "bin": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redwoodjs/sdk",
-  "version": "0.0.77-test.20250505002148",
+  "version": "0.0.77-test.20250505004329",
   "description": "Build fast, server-driven webapps on Cloudflare with SSR, RSC, and realtime",
   "type": "module",
   "bin": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redwoodjs/sdk",
-  "version": "0.0.77-test.20250505011655",
+  "version": "0.0.77-test.20250505021527",
   "description": "Build fast, server-driven webapps on Cloudflare with SSR, RSC, and realtime",
   "type": "module",
   "bin": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redwoodjs/sdk",
-  "version": "0.0.77-test.20250505005503",
+  "version": "0.0.77-test.20250505011552",
   "description": "Build fast, server-driven webapps on Cloudflare with SSR, RSC, and realtime",
   "type": "module",
   "bin": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redwoodjs/sdk",
-  "version": "0.0.77-test.20250505011552",
+  "version": "0.0.77-test.20250505011655",
   "description": "Build fast, server-driven webapps on Cloudflare with SSR, RSC, and realtime",
   "type": "module",
   "bin": {

--- a/sdk/src/vite/transformJsxScriptTagsPlugin.mts
+++ b/sdk/src/vite/transformJsxScriptTagsPlugin.mts
@@ -387,11 +387,19 @@ export const transformJsxScriptTagsPlugin = ({
     },
 
     async transform(code, id) {
-      console.log("########", this.environment.name, id);
       let manifest = {};
+
       if (isBuild) {
         manifest = await readManifest(manifestPath);
       }
+
+      if (id.includes("Document.tsx")) {
+        console.log("########", {
+          env: this.environment.name,
+          manifest,
+        });
+      }
+
       return transformJsxScriptTagsCode(code, manifest);
     },
   };

--- a/sdk/src/vite/transformJsxScriptTagsPlugin.mts
+++ b/sdk/src/vite/transformJsxScriptTagsPlugin.mts
@@ -390,19 +390,12 @@ export const transformJsxScriptTagsPlugin = ({
       isBuild = config.command === "build";
     },
 
-    async transform(code, id) {
+    async transform(code) {
       if (this.environment.name !== "worker") {
         return;
       }
 
       const manifest = isBuild ? await readManifest(manifestPath) : {};
-
-      if (id.includes("Document.tsx")) {
-        console.log("########", {
-          env: this.environment.name,
-          manifest,
-        });
-      }
 
       return transformJsxScriptTagsCode(code, manifest);
     },

--- a/sdk/src/vite/transformJsxScriptTagsPlugin.mts
+++ b/sdk/src/vite/transformJsxScriptTagsPlugin.mts
@@ -3,20 +3,20 @@ import { type Plugin } from "vite";
 import { readFile } from "node:fs/promises";
 import { pathExists } from "fs-extra";
 
-// Use a Map to cache manifests by path
-const manifestCache = new Map<string, Record<string, { file: string }>>();
+let manifestCache: Record<string, { file: string }> | undefined;
 
 const readManifest = async (
   manifestPath: string,
 ): Promise<Record<string, { file: string }>> => {
-  if (!manifestCache.has(manifestPath)) {
+  if (manifestCache === undefined) {
     const exists = await pathExists(manifestPath);
-    const content = exists
-      ? JSON.parse(await readFile(manifestPath, "utf-8"))
-      : {};
-    manifestCache.set(manifestPath, content);
+
+    if (exists) {
+      manifestCache = JSON.parse(await readFile(manifestPath, "utf-8"));
+    }
   }
-  return manifestCache.get(manifestPath)!;
+
+  return manifestCache ?? {};
 };
 
 // Check if a string includes any jsx function calls

--- a/sdk/src/vite/transformJsxScriptTagsPlugin.mts
+++ b/sdk/src/vite/transformJsxScriptTagsPlugin.mts
@@ -386,7 +386,8 @@ export const transformJsxScriptTagsPlugin = ({
       isBuild = config.command === "build";
     },
 
-    async transform(code) {
+    async transform(code, id) {
+      console.log("########", this.environment.name, id);
       let manifest = {};
       if (isBuild) {
         manifest = await readManifest(manifestPath);

--- a/starters/minimal/package.json
+++ b/starters/minimal/package.json
@@ -22,7 +22,7 @@
     "types": "tsc"
   },
   "dependencies": {
-    "@redwoodjs/sdk": "0.0.77-test.20250505011655"
+    "@redwoodjs/sdk": "0.0.77-test.20250505021527"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/starters/minimal/package.json
+++ b/starters/minimal/package.json
@@ -22,7 +22,7 @@
     "types": "tsc"
   },
   "dependencies": {
-    "@redwoodjs/sdk": "0.0.77-test.20250505004329"
+    "@redwoodjs/sdk": "0.0.77-test.20250505005503"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/starters/minimal/package.json
+++ b/starters/minimal/package.json
@@ -22,7 +22,7 @@
     "types": "tsc"
   },
   "dependencies": {
-    "@redwoodjs/sdk": "0.0.77-test.20250505002148"
+    "@redwoodjs/sdk": "0.0.77-test.20250505004329"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/starters/minimal/package.json
+++ b/starters/minimal/package.json
@@ -22,7 +22,7 @@
     "types": "tsc"
   },
   "dependencies": {
-    "@redwoodjs/sdk": "0.0.77-test.20250505005503"
+    "@redwoodjs/sdk": "0.0.77-test.20250505011655"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/starters/minimal/package.json
+++ b/starters/minimal/package.json
@@ -22,7 +22,7 @@
     "types": "tsc"
   },
   "dependencies": {
-    "@redwoodjs/sdk": "0.0.77"
+    "@redwoodjs/sdk": "0.0.77-test.20250505002148"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/starters/standard/package.json
+++ b/starters/standard/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@prisma/adapter-d1": "~6.5.0",
     "@prisma/client": "~6.5.0",
-    "@redwoodjs/sdk": "0.0.77-test.20250505004329",
+    "@redwoodjs/sdk": "0.0.77-test.20250505005503",
     "@simplewebauthn/browser": "^13.1.0",
     "@simplewebauthn/server": "^13.1.1"
   },

--- a/starters/standard/package.json
+++ b/starters/standard/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@prisma/adapter-d1": "~6.5.0",
     "@prisma/client": "~6.5.0",
-    "@redwoodjs/sdk": "0.0.77-test.20250505002148",
+    "@redwoodjs/sdk": "0.0.77-test.20250505004329",
     "@simplewebauthn/browser": "^13.1.0",
     "@simplewebauthn/server": "^13.1.1"
   },

--- a/starters/standard/package.json
+++ b/starters/standard/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@prisma/adapter-d1": "~6.5.0",
     "@prisma/client": "~6.5.0",
-    "@redwoodjs/sdk": "0.0.77",
+    "@redwoodjs/sdk": "0.0.77-test.20250505002148",
     "@simplewebauthn/browser": "^13.1.0",
     "@simplewebauthn/server": "^13.1.1"
   },

--- a/starters/standard/package.json
+++ b/starters/standard/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@prisma/adapter-d1": "~6.5.0",
     "@prisma/client": "~6.5.0",
-    "@redwoodjs/sdk": "0.0.77-test.20250505011655",
+    "@redwoodjs/sdk": "0.0.77-test.20250505021527",
     "@simplewebauthn/browser": "^13.1.0",
     "@simplewebauthn/server": "^13.1.1"
   },

--- a/starters/standard/package.json
+++ b/starters/standard/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@prisma/adapter-d1": "~6.5.0",
     "@prisma/client": "~6.5.0",
-    "@redwoodjs/sdk": "0.0.77-test.20250505005503",
+    "@redwoodjs/sdk": "0.0.77-test.20250505011655",
     "@simplewebauthn/browser": "^13.1.0",
     "@simplewebauthn/server": "^13.1.1"
   },


### PR DESCRIPTION
## Context
We have two vite environments: `client` (for client side) and `worker` (for code run in cloudflare worker).

The build step of `worker` relies on the build manifest vite generates for `client` - this asset includes mappings from the entry point source paths to their corresponding built destination paths.

It relies on the manifest so that we can replace references to client entry points in jsx (e.g. in `Document.tsx`) with their corresponding built assets.

## Problem
We read the client manifest from disk the first time, then hold onto it in memory and use the in memory value instead for subsequent attempts to read it. However, when reading the client manifest, we do not check whether the current context is the `worker` environment (not the `client` environment). This causes two issues:
* if this is the first build/release for the project on your machine, there won't be a manifest yet by the time we read => we'll default to an empty lookup for it (`{}`)
* if you had released before with different code, the new manifest hasn't been generated yet by the time we read => we'll use an outdated manifest
  * Seen here
     * #378 
     * #399

## Solution
* Change the plugin that relies on the manifest to only run for the `worker` environment (it should not be running for `client` anyways).
* We also now throw rather than default to `{}` so that we can catch issues if for some reason we are still needing the manifest before it exists