### PR TITLE
standard-starter: updated shared links to include auth pages

### DIFF
--- a/starters/standard/src/app/shared/links.ts
+++ b/starters/standard/src/app/shared/links.ts
@@ -1,3 +1,3 @@
 import { defineLinks } from "@redwoodjs/sdk/router";
 
-export const link = defineLinks(["/"]);
+export const link = defineLinks(["/", "/user/login", "/user/logout"]);


### PR DESCRIPTION
The standard starter only had shared links for the homepage. I updated the links to include `/user/login` and `/user/logout`.