### PR TITLE
fix: More robust check for prisma at build time

### DIFF
--- a/sdk/src/vite/checkIsUsingPrisma.mts
+++ b/sdk/src/vite/checkIsUsingPrisma.mts
@@ -1,0 +1,7 @@
+import enhancedResolve from "enhanced-resolve";
+
+export const checkIsUsingPrisma = ({
+  projectRootDir,
+}: {
+  projectRootDir: string;
+}) => Boolean(enhancedResolve.sync(projectRootDir, "@prisma/client"));

--- a/sdk/src/vite/checkIsUsingPrisma.mts
+++ b/sdk/src/vite/checkIsUsingPrisma.mts
@@ -4,4 +4,10 @@ export const checkIsUsingPrisma = ({
   projectRootDir,
 }: {
   projectRootDir: string;
-}) => Boolean(enhancedResolve.sync(projectRootDir, "@prisma/client"));
+}) => {
+  try {
+    return Boolean(enhancedResolve.sync(projectRootDir, "@prisma/client"));
+  } catch {
+    return false;
+  }
+};

--- a/sdk/src/vite/redwoodPlugin.mts
+++ b/sdk/src/vite/redwoodPlugin.mts
@@ -19,6 +19,7 @@ import { findWranglerConfig } from "../lib/findWranglerConfig.mjs";
 import { pathExists } from "fs-extra";
 import { injectVitePreamble } from "./injectVitePreamblePlugin.mjs";
 import { vitePreamblePlugin } from "./vitePreamblePlugin.mjs";
+import { checkIsUsingPrisma } from "./checkIsUsingPrisma.mjs";
 
 export type RedwoodPluginOptions = {
   silent?: boolean;
@@ -64,8 +65,7 @@ export const redwoodPlugin = async (
     })`npm run dev:init`;
   }
 
-  const usesPrisma = await $({ reject: false })`pnpm prisma --version`;
-  const isUsingPrisma = usesPrisma.exitCode === 0;
+  const isUsingPrisma = checkIsUsingPrisma({ projectRootDir });
 
   // context(justinvdm, 10 Mar 2025): We need to use vite optimizeDeps for all deps to work with @cloudflare/vite-plugin.
   // Thing is, @prisma/client has generated code. So users end up with a stale @prisma/client


### PR DESCRIPTION
## Context
We check whether the project is using prisma in order to apply build configuration specific to prisma - largely around getting prisma query engine wasm to work with deploys to cloudflare when using `@cloudflare/vite-plugin`.

## Problem
The way we (I) checked whether the project is using prisma was pretty awful: `pnpm prisma --version`
* If you're not using pnpm or corepack, we'll incorrectly take it that you're not using prisma
* If for some reason you have a prisma global install but aren't using prisma for you're project, we'll incorrectly take it that you are using prisma
* There's probably further ways this check can break

## Solution
Check whether the project has `@prisma/client` as an installed dependency by trying to resolve it (using https://www.npmjs.com/package/enhanced-resolve). If it can be resolved, we take it that you're using prisma. If the resolve returns a falsy value or throws, we can it that you aren't using prisma.


Fixes #396