### PR TITLE
feat: Rename @redwoodjs/sdk to rwsdk

### DIFF
--- a/docs/src/content/docs/core/react-server-components.mdx
+++ b/docs/src/content/docs/core/react-server-components.mdx
@@ -69,7 +69,7 @@ Allow you to execute code on the server from a client component.
 ```tsx title="@/pages/todos/functions.tsx" mark={1}
 "use server";
 
-import { requestInfo } from "rwsdk/worker";
+import { requestInfo } from "@redwoodjs/sdk/worker";
 
 export async function addTodo(formData: FormData) {
   const { ctx } = requestInfo;

--- a/docs/src/content/docs/core/react-server-components.mdx
+++ b/docs/src/content/docs/core/react-server-components.mdx
@@ -69,7 +69,7 @@ Allow you to execute code on the server from a client component.
 ```tsx title="@/pages/todos/functions.tsx" mark={1}
 "use server";
 
-import { requestInfo } from "@redwoodjs/sdk/worker";
+import { requestInfo } from "rwsdk/worker";
 
 export async function addTodo(formData: FormData) {
   const { ctx } = requestInfo;

--- a/docs/src/content/docs/core/realtime.mdx
+++ b/docs/src/content/docs/core/realtime.mdx
@@ -24,7 +24,7 @@ You'll need to connect three parts:
 On the client side, initialize the realtime connection with a `key`. This `key` determines which group of clients should share updates. More on this below.
 
 ```ts title="src/client.tsx"
-import { initRealtimeClient } from "rwsdk/realtime/client";
+import { initRealtimeClient } from "@redwoodjs/sdk/realtime/client";
 
 initRealtimeClient({
   key: window.location.pathname, // Used to group related clients
@@ -34,13 +34,13 @@ initRealtimeClient({
 ### 2. Export the Durable Object
 
 ```ts title="src/worker.ts"
-export { RealtimeDurableObject } from "rwsdk/realtime/durableObject";
+export { RealtimeDurableObject } from "@redwoodjs/sdk/realtime/durableObject";
 ```
 
 ### 3. Wire Up the Worker Route
 
 ```ts title="src/worker.ts"
-import { realtimeRoute } from "rwsdk/realtime/worker";
+import { realtimeRoute } from "@redwoodjs/sdk/realtime/worker";
 import { env } from "cloudflare:workers";
 
 export default defineApp([
@@ -127,7 +127,7 @@ You can update clients even when the event didn't originate from a user action â
 Use `renderRealtimeClients()` to trigger a re-render for all clients connected to a given `key`:
 
 ```ts
-import { renderRealtimeClients } from "rwsdk/realtime/worker";
+import { renderRealtimeClients } from "@redwoodjs/sdk/realtime/worker";
 import { env } from "cloudflare:workers";
 
 await renderRealtimeClients({

--- a/docs/src/content/docs/core/realtime.mdx
+++ b/docs/src/content/docs/core/realtime.mdx
@@ -24,7 +24,7 @@ You'll need to connect three parts:
 On the client side, initialize the realtime connection with a `key`. This `key` determines which group of clients should share updates. More on this below.
 
 ```ts title="src/client.tsx"
-import { initRealtimeClient } from "@redwoodjs/sdk/realtime/client";
+import { initRealtimeClient } from "rwsdk/realtime/client";
 
 initRealtimeClient({
   key: window.location.pathname, // Used to group related clients
@@ -34,13 +34,13 @@ initRealtimeClient({
 ### 2. Export the Durable Object
 
 ```ts title="src/worker.ts"
-export { RealtimeDurableObject } from "@redwoodjs/sdk/realtime/durableObject";
+export { RealtimeDurableObject } from "rwsdk/realtime/durableObject";
 ```
 
 ### 3. Wire Up the Worker Route
 
 ```ts title="src/worker.ts"
-import { realtimeRoute } from "@redwoodjs/sdk/realtime/worker";
+import { realtimeRoute } from "rwsdk/realtime/worker";
 import { env } from "cloudflare:workers";
 
 export default defineApp([
@@ -127,7 +127,7 @@ You can update clients even when the event didn't originate from a user action â
 Use `renderRealtimeClients()` to trigger a re-render for all clients connected to a given `key`:
 
 ```ts
-import { renderRealtimeClients } from "@redwoodjs/sdk/realtime/worker";
+import { renderRealtimeClients } from "rwsdk/realtime/worker";
 import { env } from "cloudflare:workers";
 
 await renderRealtimeClients({

--- a/docs/src/content/docs/core/routing.mdx
+++ b/docs/src/content/docs/core/routing.mdx
@@ -8,8 +8,8 @@ import { Aside, Tabs, TabItem, LinkCard } from "@astrojs/starlight/components";
 The request/response paradigm is at the heart of web development - when a browser makes a request, your server needs to respond with content. RedwoodSDK makes this easy with the `defineApp` function, which lets you elegantly handle incoming requests and return the right responses.
 
 ```tsx title="src/worker.tsx"
-import { defineApp } from "rwsdk/worker";
-import { route } from "rwsdk/router";
+import { defineApp } from "@redwoodjs/sdk/worker";
+import { route } from "@redwoodjs/sdk/router";
 import { env } from "cloudflare:workers";
 
 export default defineApp([
@@ -35,7 +35,7 @@ The `defineApp` function takes an array of middleware and route handlers that ar
 Routes are matched in the order they are defined. You define routes using the `route` function. Trailing slashes are optional and normalized internally.
 
 ```tsx title="src/worker.tsx" mark={4}
-import { route } from "rwsdk/router";
+import { route } from "@redwoodjs/sdk/router";
 
 defineApp([
   route("/match-this", () => new Response("Hello, world!"))
@@ -85,7 +85,7 @@ route("/files/*/download/*", ...)
 The request handler is a function, or array of functions (See [Interruptors](#interruptors)), that are executed when a request is matched.
 
 ```tsx title="src/worker.tsx" mark={4-9}
-import { route } from "rwsdk/router";
+import { route } from "@redwoodjs/sdk/router";
 
 defineApp([
   route("/a-standard-response", ({ request, params, ctx }) => {
@@ -110,8 +110,8 @@ Return values:
 Interruptors are an array of functions that are executed in sequence for each matched request. They can be used to modify the request, context, or to short-circuit the response. A typical use-case is to check for authentication on a per-request basis, as an example you're trying to ensure that a specific user can access a specific resource.
 
 ```tsx title="src/worker.tsx" mark={5-10, 13} collapse={1-2}
-import { defineApp } from "rwsdk/worker";
-import { route } from "rwsdk/router";
+import { defineApp } from "@redwoodjs/sdk/worker";
+import { route } from "@redwoodjs/sdk/router";
 import { EditBlogPage } from "src/pages/blog/EditBlogPage";
 
 function isAuthenticated({ request, ctx }) {
@@ -137,8 +137,8 @@ The context object (`ctx`) is a mutable object that is passed to each request ha
 Middleware runs before the request is matched to a route. You can specify multiple middleware functions, they'll be executed in the order they are defined.
 
 ```tsx title="src/worker.tsx" mark={5-10}
-import { defineApp } from "rwsdk/worker";
-import { route } from "rwsdk/router";
+import { defineApp } from "@redwoodjs/sdk/worker";
+import { route } from "@redwoodjs/sdk/router";
 import { env } from "cloudflare:workers";
 
 defineApp([
@@ -177,8 +177,8 @@ The context object:
 Documents are how you define the "shell" of your application's html: the `<html>`, `<head>`, `<meta>` tags, scripts, stylesheets, `<body>`, and where in the `<body>` your actual page content is rendered. In RedwoodSDK, you tell it which document to use with the `render()` function in `defineApp`. In other words, you're asking RedwoodSDK to "render" the document.
 
 ```tsx title="src/worker.tsx" "document"
-import { defineApp } from "rwsdk/worker";
-import { route, render } from "rwsdk/router";
+import { defineApp } from "@redwoodjs/sdk/worker";
+import { route, render } from "@redwoodjs/sdk/router";
 
 import { Document } from "@/pages/Document";
 import { HomePage } from "@/pages/HomePage";
@@ -217,10 +217,10 @@ export const Document = ({ children }) => (
 
 ## Request Info
 
-The `requestInfo` object is available in server functions and provides access to the current request's context. Import it from `rwsdk/worker`:
+The `requestInfo` object is available in server functions and provides access to the current request's context. Import it from `@redwoodjs/sdk/worker`:
 
 ```tsx
-import { requestInfo } from "rwsdk/worker";
+import { requestInfo } from "@redwoodjs/sdk/worker";
 
 export async function myServerFunction() {
   const { request, headers, ctx } = requestInfo;

--- a/docs/src/content/docs/core/routing.mdx
+++ b/docs/src/content/docs/core/routing.mdx
@@ -8,8 +8,8 @@ import { Aside, Tabs, TabItem, LinkCard } from "@astrojs/starlight/components";
 The request/response paradigm is at the heart of web development - when a browser makes a request, your server needs to respond with content. RedwoodSDK makes this easy with the `defineApp` function, which lets you elegantly handle incoming requests and return the right responses.
 
 ```tsx title="src/worker.tsx"
-import { defineApp } from "@redwoodjs/sdk/worker";
-import { route } from "@redwoodjs/sdk/router";
+import { defineApp } from "rwsdk/worker";
+import { route } from "rwsdk/router";
 import { env } from "cloudflare:workers";
 
 export default defineApp([
@@ -35,7 +35,7 @@ The `defineApp` function takes an array of middleware and route handlers that ar
 Routes are matched in the order they are defined. You define routes using the `route` function. Trailing slashes are optional and normalized internally.
 
 ```tsx title="src/worker.tsx" mark={4}
-import { route } from "@redwoodjs/sdk/router";
+import { route } from "rwsdk/router";
 
 defineApp([
   route("/match-this", () => new Response("Hello, world!"))
@@ -85,7 +85,7 @@ route("/files/*/download/*", ...)
 The request handler is a function, or array of functions (See [Interruptors](#interruptors)), that are executed when a request is matched.
 
 ```tsx title="src/worker.tsx" mark={4-9}
-import { route } from "@redwoodjs/sdk/router";
+import { route } from "rwsdk/router";
 
 defineApp([
   route("/a-standard-response", ({ request, params, ctx }) => {
@@ -110,8 +110,8 @@ Return values:
 Interruptors are an array of functions that are executed in sequence for each matched request. They can be used to modify the request, context, or to short-circuit the response. A typical use-case is to check for authentication on a per-request basis, as an example you're trying to ensure that a specific user can access a specific resource.
 
 ```tsx title="src/worker.tsx" mark={5-10, 13} collapse={1-2}
-import { defineApp } from "@redwoodjs/sdk/worker";
-import { route } from "@redwoodjs/sdk/router";
+import { defineApp } from "rwsdk/worker";
+import { route } from "rwsdk/router";
 import { EditBlogPage } from "src/pages/blog/EditBlogPage";
 
 function isAuthenticated({ request, ctx }) {
@@ -137,8 +137,8 @@ The context object (`ctx`) is a mutable object that is passed to each request ha
 Middleware runs before the request is matched to a route. You can specify multiple middleware functions, they'll be executed in the order they are defined.
 
 ```tsx title="src/worker.tsx" mark={5-10}
-import { defineApp } from "@redwoodjs/sdk/worker";
-import { route } from "@redwoodjs/sdk/router";
+import { defineApp } from "rwsdk/worker";
+import { route } from "rwsdk/router";
 import { env } from "cloudflare:workers";
 
 defineApp([
@@ -177,8 +177,8 @@ The context object:
 Documents are how you define the "shell" of your application's html: the `<html>`, `<head>`, `<meta>` tags, scripts, stylesheets, `<body>`, and where in the `<body>` your actual page content is rendered. In RedwoodSDK, you tell it which document to use with the `render()` function in `defineApp`. In other words, you're asking RedwoodSDK to "render" the document.
 
 ```tsx title="src/worker.tsx" "document"
-import { defineApp } from "@redwoodjs/sdk/worker";
-import { route, render } from "@redwoodjs/sdk/router";
+import { defineApp } from "rwsdk/worker";
+import { route, render } from "rwsdk/router";
 
 import { Document } from "@/pages/Document";
 import { HomePage } from "@/pages/HomePage";
@@ -217,10 +217,10 @@ export const Document = ({ children }) => (
 
 ## Request Info
 
-The `requestInfo` object is available in server functions and provides access to the current request's context. Import it from `@redwoodjs/sdk/worker`:
+The `requestInfo` object is available in server functions and provides access to the current request's context. Import it from `rwsdk/worker`:
 
 ```tsx
-import { requestInfo } from "@redwoodjs/sdk/worker";
+import { requestInfo } from "rwsdk/worker";
 
 export async function myServerFunction() {
   const { request, headers, ctx } = requestInfo;

--- a/docs/src/content/docs/core/storage.mdx
+++ b/docs/src/content/docs/core/storage.mdx
@@ -60,8 +60,8 @@ RedwoodSDK uses the standard Request/Response objects. When uploading files, the
 ### Uploading Files
 
 ```tsx title="src/worker.tsx"
-import { defineApp } from "rwsdk/worker";
-import { route } from "rwsdk/router";
+import { defineApp } from "@redwoodjs/sdk/worker";
+import { route } from "@redwoodjs/sdk/router";
 import { env } from "cloudflare:workers";
 
 defineApp([
@@ -90,8 +90,8 @@ defineApp([
 ### Downloading Files
 
 ```tsx title="src/worker.tsx"
-import { defineApp } from "rwsdk/worker";
-import { route } from "rwsdk/router";
+import { defineApp } from "@redwoodjs/sdk/worker";
+import { route } from "@redwoodjs/sdk/router";
 
 defineApp([
   route("/download/*", async ({ request, params, env }) => {

--- a/docs/src/content/docs/core/storage.mdx
+++ b/docs/src/content/docs/core/storage.mdx
@@ -60,8 +60,8 @@ RedwoodSDK uses the standard Request/Response objects. When uploading files, the
 ### Uploading Files
 
 ```tsx title="src/worker.tsx"
-import { defineApp } from "@redwoodjs/sdk/worker";
-import { route } from "@redwoodjs/sdk/router";
+import { defineApp } from "rwsdk/worker";
+import { route } from "rwsdk/router";
 import { env } from "cloudflare:workers";
 
 defineApp([
@@ -90,8 +90,8 @@ defineApp([
 ### Downloading Files
 
 ```tsx title="src/worker.tsx"
-import { defineApp } from "@redwoodjs/sdk/worker";
-import { route } from "@redwoodjs/sdk/router";
+import { defineApp } from "rwsdk/worker";
+import { route } from "rwsdk/router";
 
 defineApp([
   route("/download/*", async ({ request, params, env }) => {

--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -98,8 +98,8 @@ The entry point of your webapp is `src/worker.tsx`, open that file in your favor
 Here you'll see the `defineApp` function, this is the main function that "defines your webapp," where the purpose is to handle requests by returning responses to the client.
 
 ```tsx title="src/worker.tsx" showLineNumbers=false "defineApp"
-import { defineApp } from "@redwoodjs/sdk/worker";
-import { route, render } from "@redwoodjs/sdk/router";
+import { defineApp } from "rwsdk/worker";
+import { route, render } from "rwsdk/router";
 
 import { Document } from "@/app/Document";
 import { Home } from "@/app/pages/Home";
@@ -112,8 +112,8 @@ export default defineApp([
 You're going to add your own route, insert the `"/ping"` route handler:
 
 ```tsx title="src/worker.tsx" ins={7-9} showLineNumbers=false
-import { defineApp } from "@redwoodjs/sdk/worker";
-import { route, render } from "@redwoodjs/sdk/router";
+import { defineApp } from "rwsdk/worker";
+import { route, render } from "rwsdk/router";
 
 export default defineApp([
   render(Document, [

--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -98,8 +98,8 @@ The entry point of your webapp is `src/worker.tsx`, open that file in your favor
 Here you'll see the `defineApp` function, this is the main function that "defines your webapp," where the purpose is to handle requests by returning responses to the client.
 
 ```tsx title="src/worker.tsx" showLineNumbers=false "defineApp"
-import { defineApp } from "rwsdk/worker";
-import { route, render } from "rwsdk/router";
+import { defineApp } from "@redwoodjs/sdk/worker";
+import { route, render } from "@redwoodjs/sdk/router";
 
 import { Document } from "@/app/Document";
 import { Home } from "@/app/pages/Home";
@@ -112,8 +112,8 @@ export default defineApp([
 You're going to add your own route, insert the `"/ping"` route handler:
 
 ```tsx title="src/worker.tsx" ins={7-9} showLineNumbers=false
-import { defineApp } from "rwsdk/worker";
-import { route, render } from "rwsdk/router";
+import { defineApp } from "@redwoodjs/sdk/worker";
+import { route, render } from "@redwoodjs/sdk/router";
 
 export default defineApp([
   render(Document, [

--- a/docs/src/content/docs/guides/frontend/documents.mdx
+++ b/docs/src/content/docs/guides/frontend/documents.mdx
@@ -3,8 +3,8 @@ title: Documents
 description: How to create custom HTML documents for different routes in your Redwood SDK project
 ---
 
-import { Aside, Steps } from '@astrojs/starlight/components';
-import { FileTree } from '@astrojs/starlight/components';
+import { Aside, Steps } from "@astrojs/starlight/components";
+import { FileTree } from "@astrojs/starlight/components";
 
 In RedwoodSDK, Document components give you complete control over the HTML structure of each route. Unlike many frameworks that use a fixed HTML document structure, Redwood lets you define custom documents per route, controlling everything from the doctype to scripts and hydration strategy.
 
@@ -31,21 +31,22 @@ In RedwoodSDK, Document components give you complete control over the HTML struc
     );
     ```
 
-2. Use the Document component in your routes:
+2.  Use the Document component in your routes:
     ```tsx title="src/worker.tsx" "Document" {4,8}
-    import { defineApp } from '@redwoodjs/sdk/worker'
-    import { render, route } from '@redwoodjs/sdk/router'
+    import { defineApp } from 'rwsdk/worker'
+    import { render, route } from 'rwsdk/router'
 
-    import { Document } from '@/app/Document.tsx'
-    import { HomePage } from '@/app/pages/HomePage.tsx'
+        import { Document } from '@/app/Document.tsx'
+        import { HomePage } from '@/app/pages/HomePage.tsx'
 
-    export default defineApp([
-      render(Document, [
-        route('/', HomePage),
-      ])
-    ])
-    ```
-</Steps>
+        export default defineApp([
+          render(Document, [
+            route('/', HomePage),
+          ])
+        ])
+        ```
+
+    </Steps>
 
 ## Multiple Document Types
 
@@ -54,37 +55,33 @@ One of the most powerful features of RedwoodSDK is the ability to use different 
 You can create a specialized Document component for a static document, a realtime document, or an application document.
 
 Then, use different Documents for different routes:
+
 ```tsx title="src/worker.tsx" "StaticDocument" "ApplicationDocument" "RealtimeDocument" collapse={8-11}
-import { defineApp } from '@redwoodjs/sdk/worker'
-import { render, route, prefix } from '@redwoodjs/sdk/router'
+import { defineApp } from "rwsdk/worker";
+import { render, route, prefix } from "rwsdk/router";
 
-import { StaticDocument } from '@/app/StaticDocument.tsx'
-import { ApplicationDocument } from '@/app/ApplicationDocument.tsx'
-import { RealtimeDocument } from '@/app/RealtimeDocument.tsx'
+import { StaticDocument } from "@/app/StaticDocument.tsx";
+import { ApplicationDocument } from "@/app/ApplicationDocument.tsx";
+import { RealtimeDocument } from "@/app/RealtimeDocument.tsx";
 
-import { HomePage } from '@/app/pages/HomePage.tsx'
-import { blogRoutes } from '@/app/routes/blog.tsx'
-import { userRoutes } from '@/app/routes/user.tsx'
-import { dashboardRoutes } from '@/app/routes/dashboard.tsx'
+import { HomePage } from "@/app/pages/HomePage.tsx";
+import { blogRoutes } from "@/app/routes/blog.tsx";
+import { userRoutes } from "@/app/routes/user.tsx";
+import { dashboardRoutes } from "@/app/routes/dashboard.tsx";
 
 export default defineApp([
-  render(StaticDocument, [
-    route('/', HomePage),
-    prefix('/blog', blogRoutes),
-  ]),
+  render(StaticDocument, [route("/", HomePage), prefix("/blog", blogRoutes)]),
 
-  render(ApplicationDocument, [
-    prefix('/app/user', userRoutes),
-  ]),
+  render(ApplicationDocument, [prefix("/app/user", userRoutes)]),
 
-  render(RealtimeDocument, [
-    prefix('/app/dashboard', dashboardRoutes),
-  ])
-])
+  render(RealtimeDocument, [prefix("/app/dashboard", dashboardRoutes)]),
+]);
 ```
 
 <Aside type="tip" title="Performance Optimization">
-  Only include JavaScript when you need it. For static content like blog posts or marketing pages, consider using a StaticDocument with no client-side JavaScript for maximum performance.
+  Only include JavaScript when you need it. For static content like blog posts
+  or marketing pages, consider using a StaticDocument with no client-side
+  JavaScript for maximum performance.
 </Aside>
 
 ## Further Reading

--- a/docs/src/content/docs/guides/frontend/documents.mdx
+++ b/docs/src/content/docs/guides/frontend/documents.mdx
@@ -3,8 +3,8 @@ title: Documents
 description: How to create custom HTML documents for different routes in your Redwood SDK project
 ---
 
-import { Aside, Steps } from "@astrojs/starlight/components";
-import { FileTree } from "@astrojs/starlight/components";
+import { Aside, Steps } from '@astrojs/starlight/components';
+import { FileTree } from '@astrojs/starlight/components';
 
 In RedwoodSDK, Document components give you complete control over the HTML structure of each route. Unlike many frameworks that use a fixed HTML document structure, Redwood lets you define custom documents per route, controlling everything from the doctype to scripts and hydration strategy.
 
@@ -31,22 +31,21 @@ In RedwoodSDK, Document components give you complete control over the HTML struc
     );
     ```
 
-2.  Use the Document component in your routes:
+2. Use the Document component in your routes:
     ```tsx title="src/worker.tsx" "Document" {4,8}
-    import { defineApp } from 'rwsdk/worker'
-    import { render, route } from 'rwsdk/router'
+    import { defineApp } from '@redwoodjs/sdk/worker'
+    import { render, route } from '@redwoodjs/sdk/router'
 
-        import { Document } from '@/app/Document.tsx'
-        import { HomePage } from '@/app/pages/HomePage.tsx'
+    import { Document } from '@/app/Document.tsx'
+    import { HomePage } from '@/app/pages/HomePage.tsx'
 
-        export default defineApp([
-          render(Document, [
-            route('/', HomePage),
-          ])
-        ])
-        ```
-
-    </Steps>
+    export default defineApp([
+      render(Document, [
+        route('/', HomePage),
+      ])
+    ])
+    ```
+</Steps>
 
 ## Multiple Document Types
 
@@ -55,33 +54,37 @@ One of the most powerful features of RedwoodSDK is the ability to use different 
 You can create a specialized Document component for a static document, a realtime document, or an application document.
 
 Then, use different Documents for different routes:
-
 ```tsx title="src/worker.tsx" "StaticDocument" "ApplicationDocument" "RealtimeDocument" collapse={8-11}
-import { defineApp } from "rwsdk/worker";
-import { render, route, prefix } from "rwsdk/router";
+import { defineApp } from '@redwoodjs/sdk/worker'
+import { render, route, prefix } from '@redwoodjs/sdk/router'
 
-import { StaticDocument } from "@/app/StaticDocument.tsx";
-import { ApplicationDocument } from "@/app/ApplicationDocument.tsx";
-import { RealtimeDocument } from "@/app/RealtimeDocument.tsx";
+import { StaticDocument } from '@/app/StaticDocument.tsx'
+import { ApplicationDocument } from '@/app/ApplicationDocument.tsx'
+import { RealtimeDocument } from '@/app/RealtimeDocument.tsx'
 
-import { HomePage } from "@/app/pages/HomePage.tsx";
-import { blogRoutes } from "@/app/routes/blog.tsx";
-import { userRoutes } from "@/app/routes/user.tsx";
-import { dashboardRoutes } from "@/app/routes/dashboard.tsx";
+import { HomePage } from '@/app/pages/HomePage.tsx'
+import { blogRoutes } from '@/app/routes/blog.tsx'
+import { userRoutes } from '@/app/routes/user.tsx'
+import { dashboardRoutes } from '@/app/routes/dashboard.tsx'
 
 export default defineApp([
-  render(StaticDocument, [route("/", HomePage), prefix("/blog", blogRoutes)]),
+  render(StaticDocument, [
+    route('/', HomePage),
+    prefix('/blog', blogRoutes),
+  ]),
 
-  render(ApplicationDocument, [prefix("/app/user", userRoutes)]),
+  render(ApplicationDocument, [
+    prefix('/app/user', userRoutes),
+  ]),
 
-  render(RealtimeDocument, [prefix("/app/dashboard", dashboardRoutes)]),
-]);
+  render(RealtimeDocument, [
+    prefix('/app/dashboard', dashboardRoutes),
+  ])
+])
 ```
 
 <Aside type="tip" title="Performance Optimization">
-  Only include JavaScript when you need it. For static content like blog posts
-  or marketing pages, consider using a StaticDocument with no client-side
-  JavaScript for maximum performance.
+  Only include JavaScript when you need it. For static content like blog posts or marketing pages, consider using a StaticDocument with no client-side JavaScript for maximum performance.
 </Aside>
 
 ## Further Reading

--- a/docs/src/content/docs/guides/frontend/documents.mdx
+++ b/docs/src/content/docs/guides/frontend/documents.mdx
@@ -33,8 +33,8 @@ In RedwoodSDK, Document components give you complete control over the HTML struc
 
 2. Use the Document component in your routes:
     ```tsx title="src/worker.tsx" "Document" {4,8}
-    import { defineApp } from '@redwoodjs/sdk/worker'
-    import { render, route } from '@redwoodjs/sdk/router'
+    import { defineApp } from 'rwsdk/worker'
+    import { render, route } from 'rwsdk/router'
 
     import { Document } from '@/app/Document.tsx'
     import { HomePage } from '@/app/pages/HomePage.tsx'
@@ -55,8 +55,8 @@ You can create a specialized Document component for a static document, a realtim
 
 Then, use different Documents for different routes:
 ```tsx title="src/worker.tsx" "StaticDocument" "ApplicationDocument" "RealtimeDocument" collapse={8-11}
-import { defineApp } from '@redwoodjs/sdk/worker'
-import { render, route, prefix } from '@redwoodjs/sdk/router'
+import { defineApp } from 'rwsdk/worker'
+import { render, route, prefix } from 'rwsdk/router'
 
 import { StaticDocument } from '@/app/StaticDocument.tsx'
 import { ApplicationDocument } from '@/app/ApplicationDocument.tsx'

--- a/docs/src/content/docs/guides/frontend/tailwind.mdx
+++ b/docs/src/content/docs/guides/frontend/tailwind.mdx
@@ -3,8 +3,8 @@ title: TailwindCSS
 description: A step-by-step guide for installing and configuring TailwindCSS v4 in Redwood SDK projects, including customization options and font integration techniques.
 ---
 
-import { Aside } from "@astrojs/starlight/components";
-import { Steps } from "@astrojs/starlight/components";
+import { Aside } from '@astrojs/starlight/components';
+import { Steps } from '@astrojs/starlight/components';
 
 ## Installing Tailwind
 
@@ -17,52 +17,52 @@ Since the RedwoodSDK is based on React and Vite, we can work through the ["Using
     ```
 
 2. Configure the Vite Plugin
+    ```ts ins="import tailwindcss from '@tailwindcss/vite'" ins="tailwindcss(),"
+    // vite.config.mts
+    import { defineConfig } from "vite";
+    import tailwindcss from '@tailwindcss/vite'
+    import { redwood } from "@redwoodjs/sdk/vite";
 
-   ```ts ins="import tailwindcss from '@tailwindcss/vite'" ins="tailwindcss(),"
-   // vite.config.mts
-   import { defineConfig } from "vite";
-   import tailwindcss from "@tailwindcss/vite";
-   import { redwood } from "rwsdk/vite";
+    export default defineConfig({
+      environments: {
+        ssr: {},
+      },
+      plugins: [
+        redwood(),
+        tailwindcss(),
+      ],
+    });
+    ```
 
-   export default defineConfig({
-     environments: {
-       ssr: {},
-     },
-     plugins: [redwood(), tailwindcss()],
-   });
-   ```
+    <Aside type="note" title="Environment Configuration">
+    Tailwindcss currently uses [the non-deprecated internal `createResolver()` vite API method.](https://github.com/tailwindlabs/tailwindcss/blob/main/packages/%40tailwindcss-vite/src/index.ts#L22) [The code and its docstring indicate that it relies on an `ssr` being present](https://github.com/vitejs/vite/blob/c0e3dba3108e479ab839205cfb046db327bdaf43/packages/vite/src/node/config.ts#L1498).
 
-   <Aside type="note" title="Environment Configuration">
-Tailwindcss currently uses [the non-deprecated internal `createResolver()` vite API method.](https://github.com/tailwindlabs/tailwindcss/blob/main/packages/%40tailwindcss-vite/src/index.ts#L22) [The code and its docstring indicate that it relies on an `ssr` being present](https://github.com/vitejs/vite/blob/c0e3dba3108e479ab839205cfb046db327bdaf43/packages/vite/src/node/config.ts#L1498).
-
-   This isn't the case for us, since we only have a `worker` environment instead of `ssr`. To prevent builds from getting blocked on this, we stub out the ssr environment here.
-
-   </Aside>
+    This isn't the case for us, since we only have a `worker` environment instead of `ssr`. To prevent builds from getting blocked on this, we stub out the ssr environment here.
+    </Aside>
 
 3. Import Tailwind CSS
-   Create a `src/app/styles.css` file.
-
-   ```css
-   @import "tailwindcss";
-   ```
+    Create a `src/app/styles.css` file.
+    ```css
+    @import "tailwindcss";
+    ```
 
 4. Import your CSS and add a `<link>` to the `styles.css` file.
-   In the `Document.tsx` file, within the `<head>` section, add:
+    In the `Document.tsx` file, within the `<head>` section, add:
 
-   ```tsx title="src/app/Document.tsx" {3}
-   import styles from "./styles.css?url";
-   ...
-   <head>
-     ...
-     <link rel="stylesheet" href={styles} />
-     ...
-   </head>
-   ```
+    ```tsx title="src/app/Document.tsx" {3}
+    import styles from "./styles.css?url";
+    ...
+    <head>
+      ...
+      <link rel="stylesheet" href={styles} />
+      ...
+    </head>
+    ```
 
 5. Now, you can run `pnpm run dev` and the "Hello World" text should look different.
-   ```bash
-   pnpm run dev
-   ```
+    ```bash
+    pnpm run dev
+    ```
 
 </Steps>
 

--- a/docs/src/content/docs/guides/frontend/tailwind.mdx
+++ b/docs/src/content/docs/guides/frontend/tailwind.mdx
@@ -21,7 +21,7 @@ Since the RedwoodSDK is based on React and Vite, we can work through the ["Using
     // vite.config.mts
     import { defineConfig } from "vite";
     import tailwindcss from '@tailwindcss/vite'
-    import { redwood } from "@redwoodjs/sdk/vite";
+    import { redwood } from "rwsdk/vite";
 
     export default defineConfig({
       environments: {

--- a/docs/src/content/docs/guides/frontend/tailwind.mdx
+++ b/docs/src/content/docs/guides/frontend/tailwind.mdx
@@ -3,8 +3,8 @@ title: TailwindCSS
 description: A step-by-step guide for installing and configuring TailwindCSS v4 in Redwood SDK projects, including customization options and font integration techniques.
 ---
 
-import { Aside } from '@astrojs/starlight/components';
-import { Steps } from '@astrojs/starlight/components';
+import { Aside } from "@astrojs/starlight/components";
+import { Steps } from "@astrojs/starlight/components";
 
 ## Installing Tailwind
 
@@ -17,52 +17,52 @@ Since the RedwoodSDK is based on React and Vite, we can work through the ["Using
     ```
 
 2. Configure the Vite Plugin
-    ```ts ins="import tailwindcss from '@tailwindcss/vite'" ins="tailwindcss(),"
-    // vite.config.mts
-    import { defineConfig } from "vite";
-    import tailwindcss from '@tailwindcss/vite'
-    import { redwood } from "@redwoodjs/sdk/vite";
 
-    export default defineConfig({
-      environments: {
-        ssr: {},
-      },
-      plugins: [
-        redwood(),
-        tailwindcss(),
-      ],
-    });
-    ```
+   ```ts ins="import tailwindcss from '@tailwindcss/vite'" ins="tailwindcss(),"
+   // vite.config.mts
+   import { defineConfig } from "vite";
+   import tailwindcss from "@tailwindcss/vite";
+   import { redwood } from "rwsdk/vite";
 
-    <Aside type="note" title="Environment Configuration">
-    Tailwindcss currently uses [the non-deprecated internal `createResolver()` vite API method.](https://github.com/tailwindlabs/tailwindcss/blob/main/packages/%40tailwindcss-vite/src/index.ts#L22) [The code and its docstring indicate that it relies on an `ssr` being present](https://github.com/vitejs/vite/blob/c0e3dba3108e479ab839205cfb046db327bdaf43/packages/vite/src/node/config.ts#L1498).
+   export default defineConfig({
+     environments: {
+       ssr: {},
+     },
+     plugins: [redwood(), tailwindcss()],
+   });
+   ```
 
-    This isn't the case for us, since we only have a `worker` environment instead of `ssr`. To prevent builds from getting blocked on this, we stub out the ssr environment here.
-    </Aside>
+   <Aside type="note" title="Environment Configuration">
+Tailwindcss currently uses [the non-deprecated internal `createResolver()` vite API method.](https://github.com/tailwindlabs/tailwindcss/blob/main/packages/%40tailwindcss-vite/src/index.ts#L22) [The code and its docstring indicate that it relies on an `ssr` being present](https://github.com/vitejs/vite/blob/c0e3dba3108e479ab839205cfb046db327bdaf43/packages/vite/src/node/config.ts#L1498).
+
+   This isn't the case for us, since we only have a `worker` environment instead of `ssr`. To prevent builds from getting blocked on this, we stub out the ssr environment here.
+
+   </Aside>
 
 3. Import Tailwind CSS
-    Create a `src/app/styles.css` file.
-    ```css
-    @import "tailwindcss";
-    ```
+   Create a `src/app/styles.css` file.
+
+   ```css
+   @import "tailwindcss";
+   ```
 
 4. Import your CSS and add a `<link>` to the `styles.css` file.
-    In the `Document.tsx` file, within the `<head>` section, add:
+   In the `Document.tsx` file, within the `<head>` section, add:
 
-    ```tsx title="src/app/Document.tsx" {3}
-    import styles from "./styles.css?url";
-    ...
-    <head>
-      ...
-      <link rel="stylesheet" href={styles} />
-      ...
-    </head>
-    ```
+   ```tsx title="src/app/Document.tsx" {3}
+   import styles from "./styles.css?url";
+   ...
+   <head>
+     ...
+     <link rel="stylesheet" href={styles} />
+     ...
+   </head>
+   ```
 
 5. Now, you can run `pnpm run dev` and the "Hello World" text should look different.
-    ```bash
-    pnpm run dev
-    ```
+   ```bash
+   pnpm run dev
+   ```
 
 </Steps>
 

--- a/docs/src/content/docs/guides/rsc-streams.mdx
+++ b/docs/src/content/docs/guides/rsc-streams.mdx
@@ -30,7 +30,7 @@ Now on the client component, we can use the `consumeEventStream` function to par
 
 import { sendMessage } from "./functions";
 import { useState } from "react";
-import { consumeEventStream } from "@redwoodjs/sdk/client";
+import { consumeEventStream } from "rwsdk/client";
 
 export function Chat() {
   const [message, setMessage] = useState("");

--- a/docs/src/content/docs/guides/rsc-streams.mdx
+++ b/docs/src/content/docs/guides/rsc-streams.mdx
@@ -30,7 +30,7 @@ Now on the client component, we can use the `consumeEventStream` function to par
 
 import { sendMessage } from "./functions";
 import { useState } from "react";
-import { consumeEventStream } from "rwsdk/client";
+import { consumeEventStream } from "@redwoodjs/sdk/client";
 
 export function Chat() {
   const [message, setMessage] = useState("");
@@ -53,7 +53,7 @@ export function Chat() {
             return (prev += JSON.parse(event.data).response);
           });
         },
-      }),
+      })
     );
   };
 

--- a/docs/src/content/docs/guides/rsc-streams.mdx
+++ b/docs/src/content/docs/guides/rsc-streams.mdx
@@ -30,7 +30,7 @@ Now on the client component, we can use the `consumeEventStream` function to par
 
 import { sendMessage } from "./functions";
 import { useState } from "react";
-import { consumeEventStream } from "@redwoodjs/sdk/client";
+import { consumeEventStream } from "rwsdk/client";
 
 export function Chat() {
   const [message, setMessage] = useState("");
@@ -53,7 +53,7 @@ export function Chat() {
             return (prev += JSON.parse(event.data).response);
           });
         },
-      })
+      }),
     );
   };
 

--- a/docs/src/content/docs/reference/sdk-router.mdx
+++ b/docs/src/content/docs/reference/sdk-router.mdx
@@ -4,14 +4,14 @@ description: The RedwoodSDK router
 next: false
 ---
 
-RedwoodSDK's router is a lightweight server-side router that's designed to work with `defineApp` from `@redwoodjs/sdk/worker`.
+RedwoodSDK's router is a lightweight server-side router that's designed to work with `defineApp` from `rwsdk/worker`.
 
 ## `route`
 
 The `route` function is used to define a route.
 
 ```ts
-import { route } from "@redwoodjs/sdk/router";
+import { route } from "rwsdk/router";
 
 route("/", () => new Response("Hello, World!"));
 ```
@@ -21,7 +21,7 @@ route("/", () => new Response("Hello, World!"));
 The `prefix` function is used to modify the matched string of a group of routes, by adding a prefix to the matched string. This essentially allows you to group related functionality into a seperate file, import those routes and place it into your `defineApp` function.
 
 ```ts title="app/pages/user/routes.ts"
-import { route } from "@redwoodjs/sdk/router";
+import { route } from "rwsdk/router";
 
 import { LoginPage } from "./LoginPage";
 
@@ -34,7 +34,7 @@ export const routes = [
 ```
 
 ```ts title="worker.ts"
-import { prefix } from "@redwoodjs/sdk/router";
+import { prefix } from "rwsdk/router";
 
 import { routes as userRoutes } from "@/app/pages/user/routes";
 
@@ -50,7 +50,7 @@ This will match `/user/login` and `/user/logout`
 The `render` function is used to statically render the contents of a JSX element. It cannot contain any dynamic content. Use this to control the output of your HTML.
 
 ```tsx
-import { render } from "@redwoodjs/sdk/router";
+import { render } from "rwsdk/router";
 
 import { ReactDocument } from "@/app/Document";
 import { StaticDocument } from "@/app/Document";

--- a/docs/src/content/docs/reference/sdk-router.mdx
+++ b/docs/src/content/docs/reference/sdk-router.mdx
@@ -4,14 +4,14 @@ description: The RedwoodSDK router
 next: false
 ---
 
-RedwoodSDK's router is a lightweight server-side router that's designed to work with `defineApp` from `rwsdk/worker`.
+RedwoodSDK's router is a lightweight server-side router that's designed to work with `defineApp` from `@redwoodjs/sdk/worker`.
 
 ## `route`
 
 The `route` function is used to define a route.
 
 ```ts
-import { route } from "rwsdk/router";
+import { route } from "@redwoodjs/sdk/router";
 
 route("/", () => new Response("Hello, World!"));
 ```
@@ -21,7 +21,7 @@ route("/", () => new Response("Hello, World!"));
 The `prefix` function is used to modify the matched string of a group of routes, by adding a prefix to the matched string. This essentially allows you to group related functionality into a seperate file, import those routes and place it into your `defineApp` function.
 
 ```ts title="app/pages/user/routes.ts"
-import { route } from "rwsdk/router";
+import { route } from "@redwoodjs/sdk/router";
 
 import { LoginPage } from "./LoginPage";
 
@@ -34,7 +34,7 @@ export const routes = [
 ```
 
 ```ts title="worker.ts"
-import { prefix } from "rwsdk/router";
+import { prefix } from "@redwoodjs/sdk/router";
 
 import { routes as userRoutes } from "@/app/pages/user/routes";
 
@@ -50,7 +50,7 @@ This will match `/user/login` and `/user/logout`
 The `render` function is used to statically render the contents of a JSX element. It cannot contain any dynamic content. Use this to control the output of your HTML.
 
 ```tsx
-import { render } from "rwsdk/router";
+import { render } from "@redwoodjs/sdk/router";
 
 import { ReactDocument } from "@/app/Document";
 import { StaticDocument } from "@/app/Document";

--- a/docs/src/content/docs/reference/sdk-worker.mdx
+++ b/docs/src/content/docs/reference/sdk-worker.mdx
@@ -4,7 +4,7 @@ description: The RedwoodSDK worker
 next: false
 ---
 
-The `@redwoodjs/sdk/worker` module exports the `defineApp` function, which is the entry point for your Cloudflare Worker.
+The `rwsdk/worker` module exports the `defineApp` function, which is the entry point for your Cloudflare Worker.
 
 This is the shape of a Cloudflare Worker:
 
@@ -19,7 +19,7 @@ export default {
 This is the shape of a RedwoodSDK Worker:
 
 ```ts
-import { defineApp } from "@redwoodjs/sdk/worker";
+import { defineApp } from "rwsdk/worker";
 
 const app = defineApp();
 export default {
@@ -32,8 +32,8 @@ export default {
 The `defineApp` function is used to manage how Cloudflare Workers should process requests and subsequently return a response.
 
 ```ts
-import { defineApp } from '@redwoodjs/sdk/worker'
-import { route } from '@redwoodjs/sdk/router'
+import { defineApp } from 'rwsdk/worker'
+import { route } from 'rwsdk/router'
 
 defineApp([
   // Middleware
@@ -58,7 +58,7 @@ In this example above a request would be processed by the middleware, then the c
 The `ErrorResponse` class is used to return an errors that includes a status code, a message, and a stack trace. You'll be able to extract this information in try-catch blocks, handle it, or return a proper request response.
 
 ```ts
-import { ErrorResponse } from "@redwoodjs/sdk/worker";
+import { ErrorResponse } from "rwsdk/worker";
 
 export default defineApp([
   function middleware({ request, ctx }) {
@@ -84,7 +84,7 @@ export default defineApp([
 The `requestInfo` object is used to get information about the current request. It's a singleton that's populated for each request, and constains the following information.
 
 ```ts
-import { requestInfo } from "@redwoodjs/sdk/worker";
+import { requestInfo } from "rwsdk/worker";
 
 requestInfo.request.url;
 requestInfo.request.method;

--- a/docs/src/content/docs/reference/sdk-worker.mdx
+++ b/docs/src/content/docs/reference/sdk-worker.mdx
@@ -4,7 +4,7 @@ description: The RedwoodSDK worker
 next: false
 ---
 
-The `rwsdk/worker` module exports the `defineApp` function, which is the entry point for your Cloudflare Worker.
+The `@redwoodjs/sdk/worker` module exports the `defineApp` function, which is the entry point for your Cloudflare Worker.
 
 This is the shape of a Cloudflare Worker:
 
@@ -19,7 +19,7 @@ export default {
 This is the shape of a RedwoodSDK Worker:
 
 ```ts
-import { defineApp } from "rwsdk/worker";
+import { defineApp } from "@redwoodjs/sdk/worker";
 
 const app = defineApp();
 export default {
@@ -32,8 +32,8 @@ export default {
 The `defineApp` function is used to manage how Cloudflare Workers should process requests and subsequently return a response.
 
 ```ts
-import { defineApp } from 'rwsdk/worker'
-import { route } from 'rwsdk/router'
+import { defineApp } from '@redwoodjs/sdk/worker'
+import { route } from '@redwoodjs/sdk/router'
 
 defineApp([
   // Middleware
@@ -58,7 +58,7 @@ In this example above a request would be processed by the middleware, then the c
 The `ErrorResponse` class is used to return an errors that includes a status code, a message, and a stack trace. You'll be able to extract this information in try-catch blocks, handle it, or return a proper request response.
 
 ```ts
-import { ErrorResponse } from "rwsdk/worker";
+import { ErrorResponse } from "@redwoodjs/sdk/worker";
 
 export default defineApp([
   function middleware({ request, ctx }) {
@@ -84,7 +84,7 @@ export default defineApp([
 The `requestInfo` object is used to get information about the current request. It's a singleton that's populated for each request, and constains the following information.
 
 ```ts
-import { requestInfo } from "rwsdk/worker";
+import { requestInfo } from "@redwoodjs/sdk/worker";
 
 requestInfo.request.url;
 requestInfo.request.method;

--- a/docs/src/content/docs/tutorial/full-stack-app/2-create-app.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/2-create-app.mdx
@@ -6,7 +6,13 @@ sidebar:
 description: A guide in my new Starlight docs site.
 ---
 
-import { FileTree, Aside, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+import {
+  FileTree,
+  Aside,
+  Steps,
+  Tabs,
+  TabItem,
+} from "@astrojs/starlight/components";
 
 ## Project Generation and Structure
 
@@ -14,28 +20,16 @@ The first thing we'll do is set up our project.
 
 <Tabs>
   <TabItem label="pnpm">
-  ```shell
-  npx degit redwoodjs/sdk/starters/standard applywize
-  cd applywize
-  pnpm install
-  pnpm dev
-  ```
+    ```shell npx degit redwoodjs/sdk/starters/standard applywize cd applywize
+    pnpm install pnpm dev ```
   </TabItem>
   <TabItem label="npm">
-  ```shell
-  npx degit redwoodjs/sdk/starters/standard applywize
-  cd applywize
-  npm install
-  npm run dev
-  ```
+    ```shell npx degit redwoodjs/sdk/starters/standard applywize cd applywize
+    npm install npm run dev ```
   </TabItem>
   <TabItem label="yarn">
-  ```shell
-  npx degit redwoodjs/sdk/starters/standard applywize
-  cd applywize
-  yarn install
-  yarn run dev
-  ```
+    ```shell npx degit redwoodjs/sdk/starters/standard applywize cd applywize
+    yarn install yarn run dev ```
   </TabItem>
 </Tabs>
 
@@ -50,48 +44,28 @@ The commands you just ran created a directory called `applywize` with the Redwoo
 Inside, the `applywize` directory, you should have the following files and folders:
 
 <FileTree>
-- .dev.vars # environment variables for development
-- .env # environment variables
-- .env.example # example environment variables
-- .gitignore # files to ignore in git
-- .prettierrc # prettier configuration
-- .wrangler # Cloudflare configuration
-- migrations # database migrations
-  - 0001_init.sql # initial migration
-- node_modules # dependencies
-- package.json # lists all the dependencies and scripts
-- pnpm-lock.yaml # lock file for pnpm
-- prisma # prisma configuration
-  - schema.prisma # database schema
-- README.md # project overview
-- src
-  - app
-    - Document.tsx # Main HTML document
-    - headers.ts # Sets up page headers
-    - pages
-      - Home.tsx # Home page
-      - user
-        - functions.ts # authentication functions
-        - Login.tsx # Login page
-        - routes.ts # authentication routes
-      - shared
-        - links.ts # list of links
-  - client.tsx # initializes the client
-  - db.ts # database client
-  - scripts
-    - seed.ts # seed the database
-  - session # sets up sessions for authentication
-  - worker.tsx # Cloudflare worker
-- tsconfig.json # TypeScript configuration
-- types
-  - vite.d.ts # Vite types
-- vite.config.mts # Vite configuration
-- worker-configuration.d.ts # Generated types based on your worker config
-- wrangler.jsonc # Cloudflare configuration
+  - .dev.vars # environment variables for development - .env # environment
+  variables - .env.example # example environment variables - .gitignore # files
+  to ignore in git - .prettierrc # prettier configuration - .wrangler #
+  Cloudflare configuration - migrations # database migrations - 0001_init.sql #
+  initial migration - node_modules # dependencies - package.json # lists all the
+  dependencies and scripts - pnpm-lock.yaml # lock file for pnpm - prisma #
+  prisma configuration - schema.prisma # database schema - README.md # project
+  overview - src - app - Document.tsx # Main HTML document - headers.ts # Sets
+  up page headers - pages - Home.tsx # Home page - user - functions.ts #
+  authentication functions - Login.tsx # Login page - routes.ts # authentication
+  routes - shared - links.ts # list of links - client.tsx # initializes the
+  client - db.ts # database client - scripts - seed.ts # seed the database -
+  session # sets up sessions for authentication - worker.tsx # Cloudflare worker
+  - tsconfig.json # TypeScript configuration - types - vite.d.ts # Vite types -
+  vite.config.mts # Vite configuration - worker-configuration.d.ts # Generated
+  types based on your worker config - wrangler.jsonc # Cloudflare configuration
 </FileTree>
 
 <Aside type="note" title="Starter Projects">
-  For the tutorial, we're starting with the standard starter project. When you start building your own projects, if you use a different starter template, the files and folders may vary slightly.
+  For the tutorial, we're starting with the standard starter project. When you
+  start building your own projects, if you use a different starter template, the
+  files and folders may vary slightly.
 </Aside>
 
 ## Setting up our Database
@@ -118,18 +92,20 @@ Copy the database ID provided and paste it into your project's `wrangler.jsonc` 
     {
       "binding": "DB",
       "database_name": "__change_me__",
-      "database_id": "__change_me__"
-    }
-  ]
+      "database_id": "__change_me__",
+    },
+  ],
 }
 ```
 
 While we're in our `wrangler.jsonc` file, let's also update our worker name:
+
 ```jsonc title="wrangler.jsonc" startLineNumber={6}
 "name": "applywize",
 ```
 
 and the `APP_name`:
+
 ```jsonc title="wrangler.jsonc" startLineNumber={36}
 "vars": {
   "APP_NAME": "applywize"
@@ -137,6 +113,7 @@ and the `APP_name`:
 ```
 
 ### Generating Secret Keys
+
 Next, we need to generate a strong `SECRET_KEY` for signing session IDs. You can generate a secure random key using OpenSSL. This command will generate a 32-byte random key and encode it as a base64 string.
 
 ```shell
@@ -154,7 +131,8 @@ npx wrangler secret put SECRET_KEY
 ![](./images/wrangler-secret-key.png)
 
 <Aside type="caution" title="Secrets">
-  Never use the same secret key for development and production environments, and avoid committing your secret keys to version control.
+  Never use the same secret key for development and production environments, and
+  avoid committing your secret keys to version control.
 </Aside>
 
 For production, set your domain as the `RP_ID` via Cloudflare secrets:
@@ -168,10 +146,12 @@ npx wrangler secret put RP_ID
 When prompted, enter your production domain (e.g., my-app.example.com).
 
 <Aside type="caution" title="RP_ID">
-The RP_ID must be a valid domain that matches your application's origin. For security reasons, WebAuthn will not work if these don't match.
+  The RP_ID must be a valid domain that matches your application's origin. For
+  security reasons, WebAuthn will not work if these don't match.
 </Aside>
 
 ### Setting up Cloudflare Turnstile
+
 Next, let's set up Cloudflare Turnstile for bot protection.
 
 <Steps>
@@ -233,54 +213,56 @@ Since the RedwoodSDK is based on React and Vite, we can work through the ["Using
     </Tabs>
 
 2. Configure the Vite Plugin
-    ```ts ins="import tailwindcss from '@tailwindcss/vite'" ins="tailwindcss()," title="vite.config.mts"
-    import { defineConfig } from "vite";
-    import tailwindcss from '@tailwindcss/vite'
-    import { redwood } from "@redwoodjs/sdk/vite";
 
-    export default defineConfig({
-      environments: {
-        ssr: {},
-      },
-      plugins: [
-        redwood(),
-        tailwindcss(),
-      ],
-    });
-    ```
+   ```ts ins="import tailwindcss from '@tailwindcss/vite'" ins="tailwindcss()," title="vite.config.mts"
+   import { defineConfig } from "vite";
+   import tailwindcss from "@tailwindcss/vite";
+   import { redwood } from "rwsdk/vite";
 
-    <Aside type="note" title="Environment Configuration">
-    Tailwindcss currently uses [the non-deprecated internal `createResolver()` vite API method.](https://github.com/tailwindlabs/tailwindcss/blob/main/packages/%40tailwindcss-vite/src/index.ts#L22) [The code and its docstring indicate that it relies on an `ssr` being present](https://github.com/vitejs/vite/blob/c0e3dba3108e479ab839205cfb046db327bdaf43/packages/vite/src/node/config.ts#L1498).
+   export default defineConfig({
+     environments: {
+       ssr: {},
+     },
+     plugins: [redwood(), tailwindcss()],
+   });
+   ```
 
-    This isn't the case for us, since we only have a `worker` environment instead of `ssr`. To prevent builds from getting blocked on this, we stub out the ssr environment here.
-    </Aside>
+   <Aside type="note" title="Environment Configuration">
+Tailwindcss currently uses [the non-deprecated internal `createResolver()` vite API method.](https://github.com/tailwindlabs/tailwindcss/blob/main/packages/%40tailwindcss-vite/src/index.ts#L22) [The code and its docstring indicate that it relies on an `ssr` being present](https://github.com/vitejs/vite/blob/c0e3dba3108e479ab839205cfb046db327bdaf43/packages/vite/src/node/config.ts#L1498).
+
+   This isn't the case for us, since we only have a `worker` environment instead of `ssr`. To prevent builds from getting blocked on this, we stub out the ssr environment here.
+
+   </Aside>
 
 3. Import Tailwind CSS. (You'll need to create the `src/app/styles.css` file.)
-    ```css title="src/app/styles.css"
-    @import "tailwindcss";
-    ```
+
+   ```css title="src/app/styles.css"
+   @import "tailwindcss";
+   ```
 
 4. Import the CSS file at the top of your file and include a `link` tag in the `head` of the `Document.tsx` file.
-    ```tsx title="src/app/Document.tsx" {3}
-    import styles from "./styles.css?url";
-    ...
-    <head>
-      ...
-      <link rel="stylesheet" href={styles} />
-      ...
-    </head>
-    ```
+
+   ```tsx title="src/app/Document.tsx" {3}
+   import styles from "./styles.css?url";
+   ...
+   <head>
+     ...
+     <link rel="stylesheet" href={styles} />
+     ...
+   </head>
+   ```
 
 5. Now, you can run `pnpm run dev` and go to `http://localhost:5173/user/login`.
-    ```bash
+   `bash
     pnpm run dev
-    ```
-    ![](./images/passkey-starter-tailwind-working.png)
-    For reference, before adding TailwindCSS, the login page looked like this:
-    ![](./images/passkey-form-before-tailwind.png)
-</Steps>
+    `
+   ![](./images/passkey-starter-tailwind-working.png)
+   For reference, before adding TailwindCSS, the login page looked like this:
+   ![](./images/passkey-form-before-tailwind.png)
+   </Steps>
 
 You can test this even further by going to the `src/app/pages/user/Login.tsx` file and adding an `h1` at the top of the return statement:
+
 ```tsx title="src/app/pages/user/Login.tsx" startLineNumber={63} collapse={4-17} {3}
 return (
   <>
@@ -330,8 +312,8 @@ Next, select the `@import` radio button and copy the code.
 Paste the code at the top of our `styles.css` file. Then, remove the `<style>` tags:
 
 ```css title="src/app/styles.css" {1-2}
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@500;700&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@500;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap");
 
 @import "tailwindcss";
 ```
@@ -339,7 +321,8 @@ Paste the code at the top of our `styles.css` file. Then, remove the `<style>` t
 Next, we need to add a custom configuration. In TailwindCSS v4, all customizations happen in the CSS file, _not_ `tailwind.config.js`.
 
 <Aside type="note" title="tailwind.config.js Support">
-Technically, you can still use `tailwind.config.js`, but it's not recommended as long-term support is unknown.
+  Technically, you can still use `tailwind.config.js`, but it's not recommended
+  as long-term support is unknown.
 </Aside>
 
 Below the `@import "tailwindcss";` line, add the following:
@@ -352,8 +335,10 @@ Below the `@import "tailwindcss";` line, add the following:
 ```
 
 <Aside type="note" title="Theme Variables">
-In Tailwind, all theme variables are defined inside the `@theme` directive. These influence which utility classes exist within our project.
-You can find more information in the [TailwindCSS Docs.](https://tailwindcss.com/docs/theme)
+  In Tailwind, all theme variables are defined inside the `@theme` directive.
+  These influence which utility classes exist within our project. You can find
+  more information in the [TailwindCSS
+  Docs.](https://tailwindcss.com/docs/theme)
 </Aside>
 
 If you're unsure how the font-family is written, you can find it in the CSS class definition on the Google Fonts page. Here, Poppins and Inter are both in quotes and capitalized.
@@ -365,38 +350,38 @@ Now, you can use the class `font-display` and `font-body` in your project.
 Before this will work in production, we need to update our security headers to allow `googleapis` and `fonts.gstatic`:
 
 ```tsx title="src/app/headers.ts" collapse={1-26} {30}
-import { RouteMiddleware } from "@redwoodjs/sdk/router";
-import { IS_DEV } from "@redwoodjs/sdk/constants";
+import { RouteMiddleware } from "rwsdk/router";
+import { IS_DEV } from "rwsdk/constants";
 
 export const setCommonHeaders =
-(): RouteMiddleware =>
-({ headers, rw: { nonce } }) => {
-  if (!IS_DEV) {
-    // Forces browsers to always use HTTPS for a specified time period (2 years)
+  (): RouteMiddleware =>
+  ({ headers, rw: { nonce } }) => {
+    if (!IS_DEV) {
+      // Forces browsers to always use HTTPS for a specified time period (2 years)
+      headers.set(
+        "Strict-Transport-Security",
+        "max-age=63072000; includeSubDomains; preload",
+      );
+    }
+
+    // Forces browser to use the declared content-type instead of trying to guess/sniff it
+    headers.set("X-Content-Type-Options", "nosniff");
+
+    // Stops browsers from sending the referring webpage URL in HTTP headers
+    headers.set("Referrer-Policy", "no-referrer");
+
+    // Explicitly disables access to specific browser features/APIs
     headers.set(
-      "Strict-Transport-Security",
-      "max-age=63072000; includeSubDomains; preload"
+      "Permissions-Policy",
+      "geolocation=(), microphone=(), camera=()",
     );
-  }
 
-  // Forces browser to use the declared content-type instead of trying to guess/sniff it
-  headers.set("X-Content-Type-Options", "nosniff");
-
-  // Stops browsers from sending the referring webpage URL in HTTP headers
-  headers.set("Referrer-Policy", "no-referrer");
-
-  // Explicitly disables access to specific browser features/APIs
-  headers.set(
-    "Permissions-Policy",
-    "geolocation=(), microphone=(), camera=()"
-  );
-
-  // Defines trusted sources for content loading and script execution:
-  headers.set(
-    "Content-Security-Policy",
-    `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; frame-src https://challenges.cloudflare.com; object-src 'none';`
-  );
-};
+    // Defines trusted sources for content loading and script execution:
+    headers.set(
+      "Content-Security-Policy",
+      `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; frame-src https://challenges.cloudflare.com; object-src 'none';`,
+    );
+  };
 ```
 
 ### Setting up our Custom Color Palette
@@ -435,8 +420,8 @@ Full `styles.css` file
 </summary>
 
 ```css title="src/app/styles.css"
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@500;700&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@500;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap");
 
 @import "tailwindcss";
 
@@ -458,6 +443,7 @@ Full `styles.css` file
   --color-tag-offer: #aae198;
 }
 ```
+
 </details>
 
 Let's test to make sure our custom colors are working. On the `Login.tsx` file, let's change the React fragment `<></>` to a `<main>` tag and add a `className` of `bg-bg`:
@@ -519,7 +505,7 @@ You can also use the [shadcn/ui Vite Installation instructions](https://ui.shadc
     },
     ```
 
-2. Add path aliases to `tsconfig.json`:
+2.  Add path aliases to `tsconfig.json`:
     ```diff title="tsconfig.json"
     {
       "compilerOptions": {
@@ -530,16 +516,17 @@ You can also use the [shadcn/ui Vite Installation instructions](https://ui.shadc
       }
     }
     ```
-4. Install `@types/node`
+3.  Install `@types/node`
     ```bash
     pnpm add -D @types/node
     ```
-5. Add resolve alias config to `vite.config.mts`:
+4.  Add resolve alias config to `vite.config.mts`:
+
     ```diff title="vite.config.mts"
     +import path from "path"
     import { defineConfig } from "vite";
     import tailwindcss from "@tailwindcss/vite"
-    import { redwood } from "@redwoodjs/sdk/vite";
+    import { redwood } from "rwsdk/vite";
 
     export default defineConfig({
       plugins: [redwood(), tailwindcss()],
@@ -550,54 +537,49 @@ You can also use the [shadcn/ui Vite Installation instructions](https://ui.shadc
     + },
     )
     ```
-6. You should now be able to add components:
-    ```bash
+
+5.  You should now be able to add components:
+    `bash
     pnpm dlx shadcn@latest add
-    ```
+    `
 
-    Select the following by hitting the `Space` key:
-    - Alert
-    - Avatar
-    - Badge
-    - Breadcrumb
-    - Button
-    - Calendar
-    - Dialog
-    - Popover
-    - Select
-    - Sheet
-    - Sonner
-    - Table
+        Select the following by hitting the `Space` key:
+        - Alert
+        - Avatar
+        - Badge
+        - Breadcrumb
+        - Button
+        - Calendar
+        - Dialog
+        - Popover
+        - Select
+        - Sheet
+        - Sonner
+        - Table
 
-    ![](./images/terminal-shadcn-bulk-add.png)
+        ![](./images/terminal-shadcn-bulk-add.png)
 
-    When you've selected all the components you want to add, hit `Enter`. This will add all the components inside the `src/app/components/ui` folder.
+        When you've selected all the components you want to add, hit `Enter`. This will add all the components inside the `src/app/components/ui` folder.
 
-    ![](./images/terminal-shadcn-bulk-add-result.png)
+        ![](./images/terminal-shadcn-bulk-add-result.png)
 
-    This will install all of our components into the `src/app/components/ui` folder.
+        This will install all of our components into the `src/app/components/ui` folder.
 
-    ![](./images/shad-cn-components-in-finder.png)
+        ![](./images/shad-cn-components-in-finder.png)
 
-    <Aside type="tip" title="Adding shadcn/ui Components individually">
-      Instead of selecting components from a list, you can also add them individually by running `pnpm dlx shadcn@latest add <component-name>`.
-    </Aside>
+        <Aside type="tip" title="Adding shadcn/ui Components individually">
+          Instead of selecting components from a list, you can also add them individually by running `pnpm dlx shadcn@latest add <component-name>`.
+        </Aside>
 
-    <Aside type="note" title="shadcn/ui Components">
-      You can find a list of all the components [here](https://ui.shadcn.com/docs/components).
-    </Aside>
-</Steps>
+        <Aside type="note" title="shadcn/ui Components">
+          You can find a list of all the components [here](https://ui.shadcn.com/docs/components).
+        </Aside>
+
+    </Steps>
 
 Even though we specified the path to the `lib` directory in the `components.json` file, the script still placed the folder inside the `src` directory. You'll need to move it into the `app` directory.
 
-<FileTree>
-- src/
-  - app/
-    - components/
-      - ui/
-    - lib/
-      - utils.ts
-</FileTree>
+<FileTree>- src/ - app/ - components/ - ui/ - lib/ - utils.ts</FileTree>
 
 We also need the date picker component, but it can't be installed using the `pnpm dlx shadcn@latest add` command.
 
@@ -608,33 +590,34 @@ Within the `src/app/components/ui` folder, create a new file called `datepicker.
 <Aside type="note" title="Component Naming Conventions">
   Normally, I like to capitalize and camel case my component file names (`DatePicker.tsx`), but since this code is coming from shadcn/ui, I'll use their naming convention and put and put it in the `components/ui` folder.
 
-  Any custom components we make, will live in the `components` directory and be named like `CustomComponent.tsx`.
+Any custom components we make, will live in the `components` directory and be named like `CustomComponent.tsx`.
 
-  Any shadcn/ui components will live in the `components/ui` folder.
+Any shadcn/ui components will live in the `components/ui` folder.
 
-  Even though, we're creating the `datepicker.tsx` file manually, it's still a shadcn/ui component, so it will still live in the `components/ui` folder.
+Even though, we're creating the `datepicker.tsx` file manually, it's still a shadcn/ui component, so it will still live in the `components/ui` folder.
+
 </Aside>
 
 Add the following code to the `datepicker.tsx` file:
 
 ```tsx title="src/app/components/ui/datepicker.tsx"
-"use client"
+"use client";
 
-import * as React from "react"
-import { format } from "date-fns"
-import { Calendar as CalendarIcon } from "lucide-react"
+import * as React from "react";
+import { format } from "date-fns";
+import { Calendar as CalendarIcon } from "lucide-react";
 
-import { cn } from "@/app/lib/utils"
-import { Button } from "@/app/components/ui/button"
-import { Calendar } from "@/app/components/ui/calendar"
+import { cn } from "@/app/lib/utils";
+import { Button } from "@/app/components/ui/button";
+import { Calendar } from "@/app/components/ui/calendar";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from "@/app/components/ui/popover"
+} from "@/app/components/ui/popover";
 
 export function DatePicker() {
-  const [date, setDate] = React.useState<Date>()
+  const [date, setDate] = React.useState<Date>();
 
   return (
     <Popover>
@@ -643,7 +626,7 @@ export function DatePicker() {
           variant={"outline"}
           className={cn(
             "w-[280px] justify-start text-left font-normal",
-            !date && "text-muted-foreground"
+            !date && "text-muted-foreground",
           )}
         >
           <CalendarIcon className="mr-2 h-4 w-4" />
@@ -659,7 +642,7 @@ export function DatePicker() {
         />
       </PopoverContent>
     </Popover>
-  )
+  );
 }
 ```
 
@@ -727,11 +710,11 @@ Now, when you visit https://localhost:5173/user/login, you should see styled but
 Perfect, now that we have our project setup, and all the frontend components installed, [let's start building the backend.](/tutorial/full-stack-app/database-setup)
 
 <Aside type="tip" title="Code on GitHub">
-You can find the final code for this step on [GitHub](https://github.com/ahaywood/applywize/tree/main/end-of-2).
+  You can find the final code for this step on
+  [GitHub](https://github.com/ahaywood/applywize/tree/main/end-of-2).
 </Aside>
 
 ## Further reading
 
 - [TailwindCSS](https://tailwindcss.com/)
 - [shadcn/ui](https://ui.shadcn.com/)
-

--- a/docs/src/content/docs/tutorial/full-stack-app/2-create-app.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/2-create-app.mdx
@@ -236,7 +236,7 @@ Since the RedwoodSDK is based on React and Vite, we can work through the ["Using
     ```ts ins="import tailwindcss from '@tailwindcss/vite'" ins="tailwindcss()," title="vite.config.mts"
     import { defineConfig } from "vite";
     import tailwindcss from '@tailwindcss/vite'
-    import { redwood } from "@redwoodjs/sdk/vite";
+    import { redwood } from "rwsdk/vite";
 
     export default defineConfig({
       environments: {
@@ -365,8 +365,8 @@ Now, you can use the class `font-display` and `font-body` in your project.
 Before this will work in production, we need to update our security headers to allow `googleapis` and `fonts.gstatic`:
 
 ```tsx title="src/app/headers.ts" collapse={1-26} {30}
-import { RouteMiddleware } from "@redwoodjs/sdk/router";
-import { IS_DEV } from "@redwoodjs/sdk/constants";
+import { RouteMiddleware } from "rwsdk/router";
+import { IS_DEV } from "rwsdk/constants";
 
 export const setCommonHeaders =
 (): RouteMiddleware =>
@@ -539,7 +539,7 @@ You can also use the [shadcn/ui Vite Installation instructions](https://ui.shadc
     +import path from "path"
     import { defineConfig } from "vite";
     import tailwindcss from "@tailwindcss/vite"
-    import { redwood } from "@redwoodjs/sdk/vite";
+    import { redwood } from "rwsdk/vite";
 
     export default defineConfig({
       plugins: [redwood(), tailwindcss()],

--- a/docs/src/content/docs/tutorial/full-stack-app/2-create-app.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/2-create-app.mdx
@@ -6,13 +6,7 @@ sidebar:
 description: A guide in my new Starlight docs site.
 ---
 
-import {
-  FileTree,
-  Aside,
-  Steps,
-  Tabs,
-  TabItem,
-} from "@astrojs/starlight/components";
+import { FileTree, Aside, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 
 ## Project Generation and Structure
 
@@ -20,16 +14,28 @@ The first thing we'll do is set up our project.
 
 <Tabs>
   <TabItem label="pnpm">
-    ```shell npx degit redwoodjs/sdk/starters/standard applywize cd applywize
-    pnpm install pnpm dev ```
+  ```shell
+  npx degit redwoodjs/sdk/starters/standard applywize
+  cd applywize
+  pnpm install
+  pnpm dev
+  ```
   </TabItem>
   <TabItem label="npm">
-    ```shell npx degit redwoodjs/sdk/starters/standard applywize cd applywize
-    npm install npm run dev ```
+  ```shell
+  npx degit redwoodjs/sdk/starters/standard applywize
+  cd applywize
+  npm install
+  npm run dev
+  ```
   </TabItem>
   <TabItem label="yarn">
-    ```shell npx degit redwoodjs/sdk/starters/standard applywize cd applywize
-    yarn install yarn run dev ```
+  ```shell
+  npx degit redwoodjs/sdk/starters/standard applywize
+  cd applywize
+  yarn install
+  yarn run dev
+  ```
   </TabItem>
 </Tabs>
 
@@ -44,28 +50,48 @@ The commands you just ran created a directory called `applywize` with the Redwoo
 Inside, the `applywize` directory, you should have the following files and folders:
 
 <FileTree>
-  - .dev.vars # environment variables for development - .env # environment
-  variables - .env.example # example environment variables - .gitignore # files
-  to ignore in git - .prettierrc # prettier configuration - .wrangler #
-  Cloudflare configuration - migrations # database migrations - 0001_init.sql #
-  initial migration - node_modules # dependencies - package.json # lists all the
-  dependencies and scripts - pnpm-lock.yaml # lock file for pnpm - prisma #
-  prisma configuration - schema.prisma # database schema - README.md # project
-  overview - src - app - Document.tsx # Main HTML document - headers.ts # Sets
-  up page headers - pages - Home.tsx # Home page - user - functions.ts #
-  authentication functions - Login.tsx # Login page - routes.ts # authentication
-  routes - shared - links.ts # list of links - client.tsx # initializes the
-  client - db.ts # database client - scripts - seed.ts # seed the database -
-  session # sets up sessions for authentication - worker.tsx # Cloudflare worker
-  - tsconfig.json # TypeScript configuration - types - vite.d.ts # Vite types -
-  vite.config.mts # Vite configuration - worker-configuration.d.ts # Generated
-  types based on your worker config - wrangler.jsonc # Cloudflare configuration
+- .dev.vars # environment variables for development
+- .env # environment variables
+- .env.example # example environment variables
+- .gitignore # files to ignore in git
+- .prettierrc # prettier configuration
+- .wrangler # Cloudflare configuration
+- migrations # database migrations
+  - 0001_init.sql # initial migration
+- node_modules # dependencies
+- package.json # lists all the dependencies and scripts
+- pnpm-lock.yaml # lock file for pnpm
+- prisma # prisma configuration
+  - schema.prisma # database schema
+- README.md # project overview
+- src
+  - app
+    - Document.tsx # Main HTML document
+    - headers.ts # Sets up page headers
+    - pages
+      - Home.tsx # Home page
+      - user
+        - functions.ts # authentication functions
+        - Login.tsx # Login page
+        - routes.ts # authentication routes
+      - shared
+        - links.ts # list of links
+  - client.tsx # initializes the client
+  - db.ts # database client
+  - scripts
+    - seed.ts # seed the database
+  - session # sets up sessions for authentication
+  - worker.tsx # Cloudflare worker
+- tsconfig.json # TypeScript configuration
+- types
+  - vite.d.ts # Vite types
+- vite.config.mts # Vite configuration
+- worker-configuration.d.ts # Generated types based on your worker config
+- wrangler.jsonc # Cloudflare configuration
 </FileTree>
 
 <Aside type="note" title="Starter Projects">
-  For the tutorial, we're starting with the standard starter project. When you
-  start building your own projects, if you use a different starter template, the
-  files and folders may vary slightly.
+  For the tutorial, we're starting with the standard starter project. When you start building your own projects, if you use a different starter template, the files and folders may vary slightly.
 </Aside>
 
 ## Setting up our Database
@@ -92,20 +118,18 @@ Copy the database ID provided and paste it into your project's `wrangler.jsonc` 
     {
       "binding": "DB",
       "database_name": "__change_me__",
-      "database_id": "__change_me__",
-    },
-  ],
+      "database_id": "__change_me__"
+    }
+  ]
 }
 ```
 
 While we're in our `wrangler.jsonc` file, let's also update our worker name:
-
 ```jsonc title="wrangler.jsonc" startLineNumber={6}
 "name": "applywize",
 ```
 
 and the `APP_name`:
-
 ```jsonc title="wrangler.jsonc" startLineNumber={36}
 "vars": {
   "APP_NAME": "applywize"
@@ -113,7 +137,6 @@ and the `APP_name`:
 ```
 
 ### Generating Secret Keys
-
 Next, we need to generate a strong `SECRET_KEY` for signing session IDs. You can generate a secure random key using OpenSSL. This command will generate a 32-byte random key and encode it as a base64 string.
 
 ```shell
@@ -131,8 +154,7 @@ npx wrangler secret put SECRET_KEY
 ![](./images/wrangler-secret-key.png)
 
 <Aside type="caution" title="Secrets">
-  Never use the same secret key for development and production environments, and
-  avoid committing your secret keys to version control.
+  Never use the same secret key for development and production environments, and avoid committing your secret keys to version control.
 </Aside>
 
 For production, set your domain as the `RP_ID` via Cloudflare secrets:
@@ -146,12 +168,10 @@ npx wrangler secret put RP_ID
 When prompted, enter your production domain (e.g., my-app.example.com).
 
 <Aside type="caution" title="RP_ID">
-  The RP_ID must be a valid domain that matches your application's origin. For
-  security reasons, WebAuthn will not work if these don't match.
+The RP_ID must be a valid domain that matches your application's origin. For security reasons, WebAuthn will not work if these don't match.
 </Aside>
 
 ### Setting up Cloudflare Turnstile
-
 Next, let's set up Cloudflare Turnstile for bot protection.
 
 <Steps>
@@ -213,56 +233,54 @@ Since the RedwoodSDK is based on React and Vite, we can work through the ["Using
     </Tabs>
 
 2. Configure the Vite Plugin
+    ```ts ins="import tailwindcss from '@tailwindcss/vite'" ins="tailwindcss()," title="vite.config.mts"
+    import { defineConfig } from "vite";
+    import tailwindcss from '@tailwindcss/vite'
+    import { redwood } from "@redwoodjs/sdk/vite";
 
-   ```ts ins="import tailwindcss from '@tailwindcss/vite'" ins="tailwindcss()," title="vite.config.mts"
-   import { defineConfig } from "vite";
-   import tailwindcss from "@tailwindcss/vite";
-   import { redwood } from "rwsdk/vite";
+    export default defineConfig({
+      environments: {
+        ssr: {},
+      },
+      plugins: [
+        redwood(),
+        tailwindcss(),
+      ],
+    });
+    ```
 
-   export default defineConfig({
-     environments: {
-       ssr: {},
-     },
-     plugins: [redwood(), tailwindcss()],
-   });
-   ```
+    <Aside type="note" title="Environment Configuration">
+    Tailwindcss currently uses [the non-deprecated internal `createResolver()` vite API method.](https://github.com/tailwindlabs/tailwindcss/blob/main/packages/%40tailwindcss-vite/src/index.ts#L22) [The code and its docstring indicate that it relies on an `ssr` being present](https://github.com/vitejs/vite/blob/c0e3dba3108e479ab839205cfb046db327bdaf43/packages/vite/src/node/config.ts#L1498).
 
-   <Aside type="note" title="Environment Configuration">
-Tailwindcss currently uses [the non-deprecated internal `createResolver()` vite API method.](https://github.com/tailwindlabs/tailwindcss/blob/main/packages/%40tailwindcss-vite/src/index.ts#L22) [The code and its docstring indicate that it relies on an `ssr` being present](https://github.com/vitejs/vite/blob/c0e3dba3108e479ab839205cfb046db327bdaf43/packages/vite/src/node/config.ts#L1498).
-
-   This isn't the case for us, since we only have a `worker` environment instead of `ssr`. To prevent builds from getting blocked on this, we stub out the ssr environment here.
-
-   </Aside>
+    This isn't the case for us, since we only have a `worker` environment instead of `ssr`. To prevent builds from getting blocked on this, we stub out the ssr environment here.
+    </Aside>
 
 3. Import Tailwind CSS. (You'll need to create the `src/app/styles.css` file.)
-
-   ```css title="src/app/styles.css"
-   @import "tailwindcss";
-   ```
+    ```css title="src/app/styles.css"
+    @import "tailwindcss";
+    ```
 
 4. Import the CSS file at the top of your file and include a `link` tag in the `head` of the `Document.tsx` file.
-
-   ```tsx title="src/app/Document.tsx" {3}
-   import styles from "./styles.css?url";
-   ...
-   <head>
-     ...
-     <link rel="stylesheet" href={styles} />
-     ...
-   </head>
-   ```
+    ```tsx title="src/app/Document.tsx" {3}
+    import styles from "./styles.css?url";
+    ...
+    <head>
+      ...
+      <link rel="stylesheet" href={styles} />
+      ...
+    </head>
+    ```
 
 5. Now, you can run `pnpm run dev` and go to `http://localhost:5173/user/login`.
-   `bash
+    ```bash
     pnpm run dev
-    `
-   ![](./images/passkey-starter-tailwind-working.png)
-   For reference, before adding TailwindCSS, the login page looked like this:
-   ![](./images/passkey-form-before-tailwind.png)
-   </Steps>
+    ```
+    ![](./images/passkey-starter-tailwind-working.png)
+    For reference, before adding TailwindCSS, the login page looked like this:
+    ![](./images/passkey-form-before-tailwind.png)
+</Steps>
 
 You can test this even further by going to the `src/app/pages/user/Login.tsx` file and adding an `h1` at the top of the return statement:
-
 ```tsx title="src/app/pages/user/Login.tsx" startLineNumber={63} collapse={4-17} {3}
 return (
   <>
@@ -312,8 +330,8 @@ Next, select the `@import` radio button and copy the code.
 Paste the code at the top of our `styles.css` file. Then, remove the `<style>` tags:
 
 ```css title="src/app/styles.css" {1-2}
-@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@500;700&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap");
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@500;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
 
 @import "tailwindcss";
 ```
@@ -321,8 +339,7 @@ Paste the code at the top of our `styles.css` file. Then, remove the `<style>` t
 Next, we need to add a custom configuration. In TailwindCSS v4, all customizations happen in the CSS file, _not_ `tailwind.config.js`.
 
 <Aside type="note" title="tailwind.config.js Support">
-  Technically, you can still use `tailwind.config.js`, but it's not recommended
-  as long-term support is unknown.
+Technically, you can still use `tailwind.config.js`, but it's not recommended as long-term support is unknown.
 </Aside>
 
 Below the `@import "tailwindcss";` line, add the following:
@@ -335,10 +352,8 @@ Below the `@import "tailwindcss";` line, add the following:
 ```
 
 <Aside type="note" title="Theme Variables">
-  In Tailwind, all theme variables are defined inside the `@theme` directive.
-  These influence which utility classes exist within our project. You can find
-  more information in the [TailwindCSS
-  Docs.](https://tailwindcss.com/docs/theme)
+In Tailwind, all theme variables are defined inside the `@theme` directive. These influence which utility classes exist within our project.
+You can find more information in the [TailwindCSS Docs.](https://tailwindcss.com/docs/theme)
 </Aside>
 
 If you're unsure how the font-family is written, you can find it in the CSS class definition on the Google Fonts page. Here, Poppins and Inter are both in quotes and capitalized.
@@ -350,38 +365,38 @@ Now, you can use the class `font-display` and `font-body` in your project.
 Before this will work in production, we need to update our security headers to allow `googleapis` and `fonts.gstatic`:
 
 ```tsx title="src/app/headers.ts" collapse={1-26} {30}
-import { RouteMiddleware } from "rwsdk/router";
-import { IS_DEV } from "rwsdk/constants";
+import { RouteMiddleware } from "@redwoodjs/sdk/router";
+import { IS_DEV } from "@redwoodjs/sdk/constants";
 
 export const setCommonHeaders =
-  (): RouteMiddleware =>
-  ({ headers, rw: { nonce } }) => {
-    if (!IS_DEV) {
-      // Forces browsers to always use HTTPS for a specified time period (2 years)
-      headers.set(
-        "Strict-Transport-Security",
-        "max-age=63072000; includeSubDomains; preload",
-      );
-    }
-
-    // Forces browser to use the declared content-type instead of trying to guess/sniff it
-    headers.set("X-Content-Type-Options", "nosniff");
-
-    // Stops browsers from sending the referring webpage URL in HTTP headers
-    headers.set("Referrer-Policy", "no-referrer");
-
-    // Explicitly disables access to specific browser features/APIs
+(): RouteMiddleware =>
+({ headers, rw: { nonce } }) => {
+  if (!IS_DEV) {
+    // Forces browsers to always use HTTPS for a specified time period (2 years)
     headers.set(
-      "Permissions-Policy",
-      "geolocation=(), microphone=(), camera=()",
+      "Strict-Transport-Security",
+      "max-age=63072000; includeSubDomains; preload"
     );
+  }
 
-    // Defines trusted sources for content loading and script execution:
-    headers.set(
-      "Content-Security-Policy",
-      `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; frame-src https://challenges.cloudflare.com; object-src 'none';`,
-    );
-  };
+  // Forces browser to use the declared content-type instead of trying to guess/sniff it
+  headers.set("X-Content-Type-Options", "nosniff");
+
+  // Stops browsers from sending the referring webpage URL in HTTP headers
+  headers.set("Referrer-Policy", "no-referrer");
+
+  // Explicitly disables access to specific browser features/APIs
+  headers.set(
+    "Permissions-Policy",
+    "geolocation=(), microphone=(), camera=()"
+  );
+
+  // Defines trusted sources for content loading and script execution:
+  headers.set(
+    "Content-Security-Policy",
+    `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; frame-src https://challenges.cloudflare.com; object-src 'none';`
+  );
+};
 ```
 
 ### Setting up our Custom Color Palette
@@ -420,8 +435,8 @@ Full `styles.css` file
 </summary>
 
 ```css title="src/app/styles.css"
-@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@500;700&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap");
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@500;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
 
 @import "tailwindcss";
 
@@ -443,7 +458,6 @@ Full `styles.css` file
   --color-tag-offer: #aae198;
 }
 ```
-
 </details>
 
 Let's test to make sure our custom colors are working. On the `Login.tsx` file, let's change the React fragment `<></>` to a `<main>` tag and add a `className` of `bg-bg`:
@@ -505,7 +519,7 @@ You can also use the [shadcn/ui Vite Installation instructions](https://ui.shadc
     },
     ```
 
-2.  Add path aliases to `tsconfig.json`:
+2. Add path aliases to `tsconfig.json`:
     ```diff title="tsconfig.json"
     {
       "compilerOptions": {
@@ -516,17 +530,16 @@ You can also use the [shadcn/ui Vite Installation instructions](https://ui.shadc
       }
     }
     ```
-3.  Install `@types/node`
+4. Install `@types/node`
     ```bash
     pnpm add -D @types/node
     ```
-4.  Add resolve alias config to `vite.config.mts`:
-
+5. Add resolve alias config to `vite.config.mts`:
     ```diff title="vite.config.mts"
     +import path from "path"
     import { defineConfig } from "vite";
     import tailwindcss from "@tailwindcss/vite"
-    import { redwood } from "rwsdk/vite";
+    import { redwood } from "@redwoodjs/sdk/vite";
 
     export default defineConfig({
       plugins: [redwood(), tailwindcss()],
@@ -537,49 +550,54 @@ You can also use the [shadcn/ui Vite Installation instructions](https://ui.shadc
     + },
     )
     ```
-
-5.  You should now be able to add components:
-    `bash
+6. You should now be able to add components:
+    ```bash
     pnpm dlx shadcn@latest add
-    `
+    ```
 
-        Select the following by hitting the `Space` key:
-        - Alert
-        - Avatar
-        - Badge
-        - Breadcrumb
-        - Button
-        - Calendar
-        - Dialog
-        - Popover
-        - Select
-        - Sheet
-        - Sonner
-        - Table
+    Select the following by hitting the `Space` key:
+    - Alert
+    - Avatar
+    - Badge
+    - Breadcrumb
+    - Button
+    - Calendar
+    - Dialog
+    - Popover
+    - Select
+    - Sheet
+    - Sonner
+    - Table
 
-        ![](./images/terminal-shadcn-bulk-add.png)
+    ![](./images/terminal-shadcn-bulk-add.png)
 
-        When you've selected all the components you want to add, hit `Enter`. This will add all the components inside the `src/app/components/ui` folder.
+    When you've selected all the components you want to add, hit `Enter`. This will add all the components inside the `src/app/components/ui` folder.
 
-        ![](./images/terminal-shadcn-bulk-add-result.png)
+    ![](./images/terminal-shadcn-bulk-add-result.png)
 
-        This will install all of our components into the `src/app/components/ui` folder.
+    This will install all of our components into the `src/app/components/ui` folder.
 
-        ![](./images/shad-cn-components-in-finder.png)
+    ![](./images/shad-cn-components-in-finder.png)
 
-        <Aside type="tip" title="Adding shadcn/ui Components individually">
-          Instead of selecting components from a list, you can also add them individually by running `pnpm dlx shadcn@latest add <component-name>`.
-        </Aside>
+    <Aside type="tip" title="Adding shadcn/ui Components individually">
+      Instead of selecting components from a list, you can also add them individually by running `pnpm dlx shadcn@latest add <component-name>`.
+    </Aside>
 
-        <Aside type="note" title="shadcn/ui Components">
-          You can find a list of all the components [here](https://ui.shadcn.com/docs/components).
-        </Aside>
-
-    </Steps>
+    <Aside type="note" title="shadcn/ui Components">
+      You can find a list of all the components [here](https://ui.shadcn.com/docs/components).
+    </Aside>
+</Steps>
 
 Even though we specified the path to the `lib` directory in the `components.json` file, the script still placed the folder inside the `src` directory. You'll need to move it into the `app` directory.
 
-<FileTree>- src/ - app/ - components/ - ui/ - lib/ - utils.ts</FileTree>
+<FileTree>
+- src/
+  - app/
+    - components/
+      - ui/
+    - lib/
+      - utils.ts
+</FileTree>
 
 We also need the date picker component, but it can't be installed using the `pnpm dlx shadcn@latest add` command.
 
@@ -590,34 +608,33 @@ Within the `src/app/components/ui` folder, create a new file called `datepicker.
 <Aside type="note" title="Component Naming Conventions">
   Normally, I like to capitalize and camel case my component file names (`DatePicker.tsx`), but since this code is coming from shadcn/ui, I'll use their naming convention and put and put it in the `components/ui` folder.
 
-Any custom components we make, will live in the `components` directory and be named like `CustomComponent.tsx`.
+  Any custom components we make, will live in the `components` directory and be named like `CustomComponent.tsx`.
 
-Any shadcn/ui components will live in the `components/ui` folder.
+  Any shadcn/ui components will live in the `components/ui` folder.
 
-Even though, we're creating the `datepicker.tsx` file manually, it's still a shadcn/ui component, so it will still live in the `components/ui` folder.
-
+  Even though, we're creating the `datepicker.tsx` file manually, it's still a shadcn/ui component, so it will still live in the `components/ui` folder.
 </Aside>
 
 Add the following code to the `datepicker.tsx` file:
 
 ```tsx title="src/app/components/ui/datepicker.tsx"
-"use client";
+"use client"
 
-import * as React from "react";
-import { format } from "date-fns";
-import { Calendar as CalendarIcon } from "lucide-react";
+import * as React from "react"
+import { format } from "date-fns"
+import { Calendar as CalendarIcon } from "lucide-react"
 
-import { cn } from "@/app/lib/utils";
-import { Button } from "@/app/components/ui/button";
-import { Calendar } from "@/app/components/ui/calendar";
+import { cn } from "@/app/lib/utils"
+import { Button } from "@/app/components/ui/button"
+import { Calendar } from "@/app/components/ui/calendar"
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from "@/app/components/ui/popover";
+} from "@/app/components/ui/popover"
 
 export function DatePicker() {
-  const [date, setDate] = React.useState<Date>();
+  const [date, setDate] = React.useState<Date>()
 
   return (
     <Popover>
@@ -626,7 +643,7 @@ export function DatePicker() {
           variant={"outline"}
           className={cn(
             "w-[280px] justify-start text-left font-normal",
-            !date && "text-muted-foreground",
+            !date && "text-muted-foreground"
           )}
         >
           <CalendarIcon className="mr-2 h-4 w-4" />
@@ -642,7 +659,7 @@ export function DatePicker() {
         />
       </PopoverContent>
     </Popover>
-  );
+  )
 }
 ```
 
@@ -710,11 +727,11 @@ Now, when you visit https://localhost:5173/user/login, you should see styled but
 Perfect, now that we have our project setup, and all the frontend components installed, [let's start building the backend.](/tutorial/full-stack-app/database-setup)
 
 <Aside type="tip" title="Code on GitHub">
-  You can find the final code for this step on
-  [GitHub](https://github.com/ahaywood/applywize/tree/main/end-of-2).
+You can find the final code for this step on [GitHub](https://github.com/ahaywood/applywize/tree/main/end-of-2).
 </Aside>
 
 ## Further reading
 
 - [TailwindCSS](https://tailwindcss.com/)
 - [shadcn/ui](https://ui.shadcn.com/)
+

--- a/docs/src/content/docs/tutorial/full-stack-app/3-database-setup.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/3-database-setup.mdx
@@ -603,7 +603,7 @@ Within the `src > scripts` directory, you'll find a `seed.ts`
 This contains the basic structure for our seed file.
 
 ```ts title="src/scripts/seed.ts"
-import { defineScript } from "@redwoodjs/sdk/worker";
+import { defineScript } from "rwsdk/worker";
 import { db, setupDb } from "@/db";
 
 export default defineScript(async ({ env }) => {
@@ -637,7 +637,7 @@ If you want to start fresh with your own seed file, you could delete lines 7-17,
 You can copy and paste the following code to your project:
 
 ```ts title="src/scripts/seed.ts"
-import { defineScript } from "@redwoodjs/sdk/worker";
+import { defineScript } from "rwsdk/worker";
 import { db, setupDb } from "../db";
 
 export default defineScript(async ({ env }) => {

--- a/docs/src/content/docs/tutorial/full-stack-app/3-database-setup.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/3-database-setup.mdx
@@ -8,7 +8,7 @@ description: Setting up the database for the application
 
 {/* TODO: Claude made some recommendations for making the content better: https://claude.ai/share/e52d53ca-f49f-4f36-9bc4-30da1f345945 */}
 
-import { Aside, FileTree } from "@astrojs/starlight/components";
+import { Aside, FileTree } from '@astrojs/starlight/components';
 
 ## Setting up our Database Tables or Models
 
@@ -17,8 +17,7 @@ For this project, we'll use [Prisma](https://www.prisma.io/) as our ORM (Object 
 <Aside type="note" title="What's a migration?">
   A migration is a change to the database schema. It's a way to keep track of the changes we make to the database.
 
-One of the great things about using Prisma is that it generates the migrations and SQL code so we don't need to. We simply update the schema, and it handles the rest.
-
+  One of the great things about using Prisma is that it generates the migrations and SQL code so we don't need to. We simply update the schema, and it handles the rest.
 </Aside>
 
 I like to start by going through the [application design files]() and making a list of all the tables (models) and fields we need.
@@ -56,7 +55,6 @@ Now, that we know what our models are, we need to create the columns. What are t
 We've already alluded to the data that we'll need within the relationship diagrams, but let's take a closer look.
 
 Most tables I create include an `id`, `createdAt`, and `updatedAt` field.
-
 - `id` - We need a way to uniquely identify each record or row in the database.
 - `createdAt` - We need to know when the record was created.
 - `updatedAt` - We need to know when the record was last updated.
@@ -64,8 +62,7 @@ Most tables I create include an `id`, `createdAt`, and `updatedAt` field.
 <Aside type="tip" title="Soft Deleting">
   In the future, if you're going to "soft delete" a record, you'll probably want a `deletedAt` column for tracking when the record was deleted.
 
-"Soft deleting" a record means that instead of removing the record from the database, we'll set a column (i.e. `deleted`) to `true` to indicate that the record has been deleted. The entry won't be shown to the user, but it gives you a way to recover the data. This is also useful for auditing purposes.
-
+  "Soft deleting" a record means that instead of removing the record from the database, we'll set a column (i.e. `deleted`) to `true` to indicate that the record has been deleted. The entry won't be shown to the user, but it gives you a way to recover the data. This is also useful for auditing purposes.
 </Aside>
 
 ### Data Types
@@ -74,17 +71,17 @@ As you're making a list of all the data we need to store, you'll also need to th
 
 In Prisma, there are 9 different data types:
 
-| **Prisma Type** | **Description**                             |
-| --------------- | ------------------------------------------- |
-| `String`        | A UTF-8 encoded string                      |
-| `Boolean`       | A true or false value                       |
-| `Int`           | A 32-bit signed integer                     |
-| `BigInt`        | A 64-bit signed integer (for large numbers) |
-| `Float`         | A floating-point number                     |
-| `Decimal`       | A high-precision decimal number             |
-| `DateTime`      | An ISO 8601 timestamp                       |
-| `Json`          | Arbitrary JSON data                         |
-| `Bytes`         | Binary data (Base64-encoded)                |
+| **Prisma Type** |	**Description** |
+| --- | --- |
+| `String` | A UTF-8 encoded string |
+| `Boolean` | A true or false value |
+| `Int` | A 32-bit signed integer |
+| `BigInt` | A 64-bit signed integer (for large numbers) |
+| `Float` | A floating-point number |
+| `Decimal` | A high-precision decimal number |
+| `DateTime` | An ISO 8601 timestamp |
+| `Json` | Arbitrary JSON data |
+| `Bytes` | Binary data (Base64-encoded) |
 
 ### IDs
 
@@ -107,30 +104,28 @@ Let's start with the `Application` model.
 
 I need the following data:
 
-| **Field**        | **Type**   | **Notes**                                                   |
-| ---------------- | ---------- | ----------------------------------------------------------- |
-| `id`             | `String`   | A UUID                                                      |
-| `salaryMin`      | `String`   | _Optional._ The minimum salary for the job.                 |
-| `salaryMax`      | `String`   | _Optional._ The maximum salary for the job.                 |
-| `dateApplied`    | `DateTime` | _Optional._ The date the application was submitted.         |
-| `jobTitle`       | `String`   | _Optional._ The job title                                   |
-| `jobDescription` | `String`   | _Optional._ The job description.                            |
-| `postingUrl`     | `String`   | _Optional._ The URL to the job posting.                     |
-| `archived`       | `Boolean`  | False by default. Whether the application has been archived |
-| `createdAt`      | `DateTime` | The date the application was created.                       |
-| `updatedAt`      | `DateTime` | The date the application was last updated.                  |
+| **Field** | **Type** | **Notes** |
+| --- | --- | --- |
+| `id` | `String` | A UUID |
+| `salaryMin` | `String` | _Optional._ The minimum salary for the job. |
+| `salaryMax` | `String` | _Optional._ The maximum salary for the job. |
+| `dateApplied` | `DateTime` | _Optional._ The date the application was submitted. |
+| `jobTitle` | `String` | _Optional._ The job title |
+| `jobDescription` | `String` | _Optional._ The job description. |
+| `postingUrl` | `String` | _Optional._ The URL to the job posting. |
+| `archived` | `Boolean` | False by default. Whether the application has been archived |
+| `createdAt` | `DateTime` | The date the application was created. |
+| `updatedAt` | `DateTime` | The date the application was last updated. |
 
 <Aside type="note" title="Working with Money">
 You may have noticed that I'm using a `String` for the `salaryMin` and `salaryMax` fields. Alternatively, we could make this a number, so we can standardize the display or sort the applications by salary.
 
 However, there's a few reasons why I'm using a `String`:
-
 - Working with money is complicated. It's not just a number. There's currency symbols, commas, and decimal points.
 - Prisma doesn't have a native `Currency` data type for SQLite
 - If you are going to use a number, it's best to use a `integer` to avoid potential floating-point accuracy problems and store the values as cents.
 
 For now, I'm going to hit the easy button, and use a `String`.
-
 </Aside>
 
 Now, we need to translate all this information into a Prisma model. Prisma has it's own syntax for defining models. You'll notice that it looks similar to an object definition:
@@ -162,7 +157,7 @@ A few things worth noting:
 
 We can do the same for the remaining models.
 
-```prisma title="src/db/schema.prisma"
+```prisma  title="src/db/schema.prisma"
 ...
 
 model ApplicationStatus {
@@ -213,16 +208,14 @@ model User {
 <Aside type="note" title="@@index">
   You may have noticed that the provided `Credential` model includes the `@@index` directive. This is used to create an index on the field. This can improve performance when querying the database.
 
-All the database calls we make use the `id` field, which is already indexed.
-
+  All the database calls we make use the `id` field, which is already indexed.
 </Aside>
 
 <Aside type="tip" title="Naming Conventions">
-  When working with Prisma, there a couple of naming conventions you should
-  follow: - Use singular names for your models. For example, `Application` not
-  `Applications`. - The model name should be in PascalCase. - The field names
-  should be start with a lowercase letter, pascal case. For example, `jobTitle`
-  not `JobTitle`.
+  When working with Prisma, there a couple of naming conventions you should follow:
+  - Use singular names for your models. For example, `Application` not `Applications`.
+  - The model name should be in PascalCase.
+  - The field names should be start with a lowercase letter, pascal case. For example, `jobTitle` not `JobTitle`.
 </Aside>
 
 This looks good, but we haven't defined any of the relationships between the models (Other than the preexisting relationship between `User` and `Credential` models, defined in the starter).
@@ -232,7 +225,6 @@ This looks good, but we haven't defined any of the relationships between the mod
 There are several different types of relationships:
 
 ### **One-to-one**
-
 A one-to-one relationship is a relationship where a record in one table is associated with exactly one record in another table.
 
 ![](./images/one-to-one.png)
@@ -252,16 +244,11 @@ In order to establish this relationship, we need a **junction table**. This tabl
 ![](./images/many-to-many.png)
 
 <Aside type="note" title="Naming Conventions">
-  When creating junction tables, I name them based on the two tables they
-  connect. For example, if I have a `User` and `Application` model, I'll name
-  the junction table `ApplicationUser`. Notice the models are listed in
-  alphabetical order.
+  When creating junction tables, I name them based on the two tables they connect. For example, if I have a `User` and `Application` model, I'll name the junction table `ApplicationUser`. Notice the models are listed in alphabetical order.
 </Aside>
 
 <Aside type="note" title="IDs in Junction Tables">
-  Technically, you don't need an `id` field in the junction table, because the
-  combination of the two IDs (`contactId` and `tagId`) together will be unique.
-  However, I still like to include an `id` field for good measure.
+  Technically, you don't need an `id` field in the junction table, because the combination of the two IDs (`contactId` and `tagId`) together will be unique. However, I still like to include an `id` field for good measure.
 </Aside>
 
 ## All the Tables for our Database
@@ -273,22 +260,18 @@ Here's a diagram of all the models and their relationships for this project.
 Coincidentally, all the relationships in our project are one-to-one or one-to-many.
 
 <Aside type="note" title="Crendential Table">
-  Most of the tables in our database are self explanatory. But, let's look take
-  a second look at the `Credential` table. This model was included within the
-  standard starter kit and will hold all the details for our passkeys.
+  Most of the tables in our database are self explanatory. But, let's look take a second look at the `Credential` table. This model was included within the standard starter kit and will hold all the details for our passkeys.
 </Aside>
 
 <Aside type="tip" title="Database Diagram">
   I always find it helpful to have a visual representation of the database.
 
-I created these diagrams with [tldraw](https://tldraw.com/). But, [Whimsical](https://whimsical.com/) and [Figma](https://www.figma.com/) are also great tools.
+  I created these diagrams with [tldraw](https://tldraw.com/). But, [Whimsical](https://whimsical.com/) and [Figma](https://www.figma.com/) are also great tools.
 
-[prisma-dbml-generator](https://github.com/notiz-dev/prisma-dbml-generator) is an interesting project. It's built on top of [dbdiagram.io](https://dbdiagram.io/) and can take a Prisma Schema and generate a diagram.
-
+  [prisma-dbml-generator](https://github.com/notiz-dev/prisma-dbml-generator) is an interesting project. It's built on top of [dbdiagram.io](https://dbdiagram.io/) and can take a Prisma Schema and generate a diagram.
 </Aside>
 
 ## Relationships within Prisma
-
 When establishing a relationship within your schema, there are 3 parts.
 
 1. **Foreign Key Column** This stores the ID for the related record.
@@ -298,15 +281,13 @@ When establishing a relationship within your schema, there are 3 parts.
 <Aside type="note" title="What's a foreign key?">
   A foreign key is a column (or set of columns) in a table that refers to the primary key of another table, establishing a link between two tables in a relational database.
 
-It's called a "foreign key" because it references the primary key of the "foreign" table.
-
+  It's called a "foreign key" because it references the primary key of the "foreign" table.
 </Aside>
 
 <Aside type="note" title="What can you see within the database?">
   Within the database, the only column that you'll be able to see if the foreign key column that stores the ID of the related record.
 
-The **relationship field** and **implicit relationship field** are only used within the context of Prisma.
-
+  The **relationship field** and **implicit relationship field** are only used within the context of Prisma.
 </Aside>
 
 Let's look at this in practice. On the `Company` and `Contact` models:
@@ -338,21 +319,18 @@ model Contact {
 
 1. On the `Contact` model, we added a `companyId` field. This stores the ID of the related `Company` record. Because the `id` field on the `Company` model is a string, our `companyId` field is also a string.
 2. On the `Contact` model, we also added a `company` field. This describes the Contact↔Company relationship for Prisma.
-   - You can read this as: "A contact belongs to a company."
-   - It is connected to the `Company` model. You can also think of this as having a type of `Company`.
-   - It uses the `companyId` field on the `Contact` model to connect the two models.
-   - It references the `id` field on the `Company` model.
+    - You can read this as: "A contact belongs to a company."
+    - It is connected to the `Company` model. You can also think of this as having a type of `Company`.
+    - It uses the `companyId` field on the `Contact` model to connect the two models.
+    - It references the `id` field on the `Company` model.
 3. On the `Company` model, we added a `contacts` field. This describes the Company↔Contact relationship to Prisma.
-   - You can read this as: "A company has many contacts."
-   - The type of content will be an array `[]` of `Contact` records.
+    - You can read this as: "A company has many contacts."
+    - The type of content will be an array `[]` of `Contact` records.
 
 ![](./images/prisma-relationship-field.png)
 
 <Aside type="note" title="Relationships in Prisma">
-  When you look a the columns in your database that Prisma generates, you won't
-  find a relation or implicit relationship field, only the foreign key. However,
-  these properties are necessary for Prisma to understand the relationship
-  between the two models.
+  When you look a the columns in your database that Prisma generates, you won't find a relation or implicit relationship field, only the foreign key. However, these properties are necessary for Prisma to understand the relationship between the two models.
 </Aside>
 
 In some cases, you might need to give the relationship a name. This is particularly useful when you have multiple relationships between the same models.
@@ -459,9 +437,7 @@ model User {
 ```
 
 <Aside type="tip" title="Models in Alphabetical Order">
-  This is personal preference, but I like to put my models in alphabetical
-  order. It makes it easier to find what you're looking for, especially on
-  larger projects.
+This is personal preference, but I like to put my models in alphabetical order. It makes it easier to find what you're looking for, especially on larger projects.
 </Aside>
 
 ## Running Migrations
@@ -481,45 +457,43 @@ pnpm migrate:new "setup all database models"
 <Aside type="note" title="Troubleshooting a Migration">
   {/* TODO: Add a screenshot of this error message. */}
 
-Occasionally, you may run into an error where there are multiple sqlite files in the `.wrangler > state > v3 > d1 > miniflare-D1DatabaseObject` folder.
+  Occasionally, you may run into an error where there are multiple sqlite files in the `.wrangler > state > v3 > d1 > miniflare-D1DatabaseObject` folder.
 
-If this happens, you can delete the `.wrangler` folder and rerun `pnpm dev` to regenerate it.
+  If this happens, you can delete the `.wrangler` folder and rerun `pnpm dev` to regenerate it.
 
-Then, try running `pnpm migrate:dev` to apply the migration.
-
+  Then, try running `pnpm migrate:dev` to apply the migration.
 </Aside>
 
 Our generated `sql` file will be in the `migrations` folder.
 
 <figure>
-  ![](./images/migrations-folder.png)
-  <figcaption>
-    - `0001_init.sql` was generated the first time we ran `pnpm dev`. -
-    `0002_setup_all_database_models.sql` was generated when we ran `pnpm
-    migrate:new "setup all database models"`.
-  </figcaption>
+![](./images/migrations-folder.png)
+<figcaption>
+- `0001_init.sql` was generated the first time we ran `pnpm dev`.
+- `0002_setup_all_database_models.sql` was generated when we ran `pnpm migrate:new "setup all database models"`.
+</figcaption>
 </figure>
 
+
 <Aside type="tip" title="The Number of Migrations">
-  Worried about the number of migrations in your project? Don't. It really
-  doesn't have any effect on your project.
+  Worried about the number of migrations in your project? Don't. It really doesn't have any effect on your project.
 </Aside>
 
 <Aside type="note" title="Working with other people">
   An added benefit of migrations is that it makes it easier to work with other people.
 
-Migration files get committed to the repository and placed in version control.
+  Migration files get committed to the repository and placed in version control.
 
-Database changes can be tied to a branch and a specific feature or bug fix.
+  Database changes can be tied to a branch and a specific feature or bug fix.
 
-Keeping another team member's database in sync is as simple as running the migration: `npm migrate:dev`
-
+  Keeping another team member's database in sync is as simple as running the migration: `npm migrate:dev`
 </Aside>
 
 <Aside type="note" title="Migration Commands">
-  There are 3 different migration commands: 1. `migrate:dev`: runs the migration
-  on your local database 2. `migrate:prd`: runs the migration on your production
-  database 3. `migrate:new`: creates a new migration
+  There are 3 different migration commands:
+  1. `migrate:dev`: runs the migration on your local database
+  2. `migrate:prd`: runs the migration on your production database
+  3. `migrate:new`: creates a new migration
 </Aside>
 
 ## Previewing the Migration
@@ -559,6 +533,7 @@ Then, paste in the database path:
 
 ![](./images/database-url-full-url.png)
 
+
 Now, within the Terminal, run:
 
 ```shell
@@ -568,13 +543,12 @@ npx prisma studio
 This will open a new tab in your default browser at `http://localhost:5555`.
 
 {/* ./images/prisma-studio.png - this is a screenshot of a seeded database */}
-
 <figure>
-  ![](./images/prisma-studio-no-tables-selected.png)
-  <figcaption>
-    - Within Prisma Studio, you can see a list of all your tables/models on the
-    left. - If you click on one, it will load the table/model on the right.
-  </figcaption>
+![](./images/prisma-studio-no-tables-selected.png)
+<figcaption>
+- Within Prisma Studio, you can see a list of all your tables/models on the left.
+- If you click on one, it will load the table/model on the right.
+</figcaption>
 </figure>
 
 ![](./images/prisma-studio-application-table-selected.png)
@@ -588,8 +562,12 @@ The [VS Code extension, SQLite Viewer](https://marketplace.visualstudio.com/item
 Within the file explorer, navigate to your D1 database. You can find it in the `.wrangler > state > v3 > d1 > miniflare-D1DatabaseObject` folder.
 
 <FileTree>
-  - .wrangler - state - v3 - d1 - miniflare-D1DatabaseObject/ -
-  005cb3d3133217f352562272facf516778925ea1151d9c310bcb4e13614995c1.sqlite
+- .wrangler
+  - state
+    - v3
+      - d1
+        - miniflare-D1DatabaseObject/
+          - 005cb3d3133217f352562272facf516778925ea1151d9c310bcb4e13614995c1.sqlite
 </FileTree>
 
 The file name of your sqlite database will vary.
@@ -601,14 +579,11 @@ Click on the sqlite file and a preview should open within VSCode.
 The viewer will only let you preview the database. If you want to create, update, or delete, you'll need a pro (premium) account.
 
 <Aside type="note" title="If the Migration Didn't Run">
-  If the migration didn't run, there are a few things you can check: - How many
-  SQLlite files are in the `.wrangler > state > v3 > d1 >
-  miniflare-D1DatabaseObject` folder? There should be one. You can always delete
-  the `.wrangler` folder and rerun `pnpm dev` to regenerate it. - Try running
-  `pnpm migrate:dev`. This will apply any new migrations. - Try running `pnpm
-  dev`. This will also apply any new migrations. - Ensure that the `database_id`
-  within the `wrangler.jsonc` file matches the database id in your Cloudflare
-  account.
+If the migration didn't run, there are a few things you can check:
+- How many SQLlite files are in the `.wrangler > state > v3 > d1 > miniflare-D1DatabaseObject` folder? There should be one. You can always delete the `.wrangler` folder and rerun `pnpm dev` to regenerate it.
+- Try running `pnpm migrate:dev`. This will apply any new migrations.
+- Try running `pnpm dev`. This will also apply any new migrations.
+- Ensure that the `database_id` within the `wrangler.jsonc` file matches the database id in your Cloudflare account.
 </Aside>
 
 ## Seed the database
@@ -619,12 +594,16 @@ Instead of manually adding data to the database, we can create a **seed file** t
 
 Within the `src > scripts` directory, you'll find a `seed.ts`
 
-<FileTree>- src/ - scripts/ - seed.ts</FileTree>
+<FileTree>
+- src/
+  - scripts/
+    - seed.ts
+</FileTree>
 
 This contains the basic structure for our seed file.
 
 ```ts title="src/scripts/seed.ts"
-import { defineScript } from "rwsdk/worker";
+import { defineScript } from "@redwoodjs/sdk/worker";
 import { db, setupDb } from "@/db";
 
 export default defineScript(async ({ env }) => {
@@ -652,14 +631,13 @@ If you want to start fresh with your own seed file, you could delete lines 7-17,
 <Aside type="tip" title="Seed File Structure">
   In order for our seed file to run properly, we have to run it inside a Cloudflare worker.
 
-Why? Since we're using a Cloudflare D1 database, we need a worker in order to access it.
-
+  Why? Since we're using a Cloudflare D1 database, we need a worker in order to access it.
 </Aside>
 
 You can copy and paste the following code to your project:
 
 ```ts title="src/scripts/seed.ts"
-import { defineScript } from "rwsdk/worker";
+import { defineScript } from "@redwoodjs/sdk/worker";
 import { db, setupDb } from "../db";
 
 export default defineScript(async ({ env }) => {
@@ -690,13 +668,12 @@ export default defineScript(async ({ env }) => {
 ```
 
 Let's make sure we understand what's happening:
-
-- **On lines 1 and 2** are importing our dependencies. We need our Cloudflare worker and database connection.
-- **On line 4**, we're setting up our Cloudflare worker environment.
-- **On line 5**, we're setting up our database connection.
-- **On line 7-15**, we're using raw SQL to delete all the existing data from the database. This will allow us to start fresh when seeding the database.
-- **On line 16-25**, we're adding all the job application statuses to the database. You'll notice this is a standard Prisma `createMany` function.
-- **On line 27**, we're logging a message to the console saying the seeding is complete.
+* **On lines 1 and 2** are importing our dependencies. We need our Cloudflare worker and database connection.
+* **On line 4**, we're setting up our Cloudflare worker environment.
+* **On line 5**, we're setting up our database connection.
+* **On line 7-15**, we're using raw SQL to delete all the existing data from the database. This will allow us to start fresh when seeding the database.
+* **On line 16-25**, we're adding all the job application statuses to the database. You'll notice this is a standard Prisma `createMany` function.
+* **On line 27**, we're logging a message to the console saying the seeding is complete.
 
 <Aside type="caution" title="Troubleshooting">
 Are you getting an error that says: `"Property 'applicationStatus' does not exist on type 'PrismaClient<PrismaClientOptions, never, DefaultArgs>'"`
@@ -706,9 +683,7 @@ This means that the Prisma types haven't been generated for your model. Within t
 ```shell
 npx prisma generate
 ```
-
 Problem solved.
-
 </Aside>
 
 To seed the database, run the following command:
@@ -733,12 +708,11 @@ The seed file we just created is perfect for a brand new database, whether we're
 Typically, I'll also create seed files to test the application with various sets of data. This is much easier (and faster) than manually adding data again and again.
 
 You can also leverage libraries, like [Faker](https://fakerjs.dev/) and [Snaplet](https://snaplet-seed.netlify.app/seed/getting-started/overview), to make it easier to create realistic data sets.
-
 </Aside>
 
+
 <Aside type="tip" title="Code on GitHub">
-  You can find the final code for this step on
-  [GitHub](https://github.com/ahaywood/applywize/tree/main/end-of-3).
+You can find the final code for this step on [GitHub](https://github.com/ahaywood/applywize/tree/main/end-of-3).
 </Aside>
 
 ## Further reading

--- a/docs/src/content/docs/tutorial/full-stack-app/3-database-setup.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/3-database-setup.mdx
@@ -8,7 +8,7 @@ description: Setting up the database for the application
 
 {/* TODO: Claude made some recommendations for making the content better: https://claude.ai/share/e52d53ca-f49f-4f36-9bc4-30da1f345945 */}
 
-import { Aside, FileTree } from '@astrojs/starlight/components';
+import { Aside, FileTree } from "@astrojs/starlight/components";
 
 ## Setting up our Database Tables or Models
 
@@ -17,7 +17,8 @@ For this project, we'll use [Prisma](https://www.prisma.io/) as our ORM (Object 
 <Aside type="note" title="What's a migration?">
   A migration is a change to the database schema. It's a way to keep track of the changes we make to the database.
 
-  One of the great things about using Prisma is that it generates the migrations and SQL code so we don't need to. We simply update the schema, and it handles the rest.
+One of the great things about using Prisma is that it generates the migrations and SQL code so we don't need to. We simply update the schema, and it handles the rest.
+
 </Aside>
 
 I like to start by going through the [application design files]() and making a list of all the tables (models) and fields we need.
@@ -55,6 +56,7 @@ Now, that we know what our models are, we need to create the columns. What are t
 We've already alluded to the data that we'll need within the relationship diagrams, but let's take a closer look.
 
 Most tables I create include an `id`, `createdAt`, and `updatedAt` field.
+
 - `id` - We need a way to uniquely identify each record or row in the database.
 - `createdAt` - We need to know when the record was created.
 - `updatedAt` - We need to know when the record was last updated.
@@ -62,7 +64,8 @@ Most tables I create include an `id`, `createdAt`, and `updatedAt` field.
 <Aside type="tip" title="Soft Deleting">
   In the future, if you're going to "soft delete" a record, you'll probably want a `deletedAt` column for tracking when the record was deleted.
 
-  "Soft deleting" a record means that instead of removing the record from the database, we'll set a column (i.e. `deleted`) to `true` to indicate that the record has been deleted. The entry won't be shown to the user, but it gives you a way to recover the data. This is also useful for auditing purposes.
+"Soft deleting" a record means that instead of removing the record from the database, we'll set a column (i.e. `deleted`) to `true` to indicate that the record has been deleted. The entry won't be shown to the user, but it gives you a way to recover the data. This is also useful for auditing purposes.
+
 </Aside>
 
 ### Data Types
@@ -71,17 +74,17 @@ As you're making a list of all the data we need to store, you'll also need to th
 
 In Prisma, there are 9 different data types:
 
-| **Prisma Type** |	**Description** |
-| --- | --- |
-| `String` | A UTF-8 encoded string |
-| `Boolean` | A true or false value |
-| `Int` | A 32-bit signed integer |
-| `BigInt` | A 64-bit signed integer (for large numbers) |
-| `Float` | A floating-point number |
-| `Decimal` | A high-precision decimal number |
-| `DateTime` | An ISO 8601 timestamp |
-| `Json` | Arbitrary JSON data |
-| `Bytes` | Binary data (Base64-encoded) |
+| **Prisma Type** | **Description**                             |
+| --------------- | ------------------------------------------- |
+| `String`        | A UTF-8 encoded string                      |
+| `Boolean`       | A true or false value                       |
+| `Int`           | A 32-bit signed integer                     |
+| `BigInt`        | A 64-bit signed integer (for large numbers) |
+| `Float`         | A floating-point number                     |
+| `Decimal`       | A high-precision decimal number             |
+| `DateTime`      | An ISO 8601 timestamp                       |
+| `Json`          | Arbitrary JSON data                         |
+| `Bytes`         | Binary data (Base64-encoded)                |
 
 ### IDs
 
@@ -104,28 +107,30 @@ Let's start with the `Application` model.
 
 I need the following data:
 
-| **Field** | **Type** | **Notes** |
-| --- | --- | --- |
-| `id` | `String` | A UUID |
-| `salaryMin` | `String` | _Optional._ The minimum salary for the job. |
-| `salaryMax` | `String` | _Optional._ The maximum salary for the job. |
-| `dateApplied` | `DateTime` | _Optional._ The date the application was submitted. |
-| `jobTitle` | `String` | _Optional._ The job title |
-| `jobDescription` | `String` | _Optional._ The job description. |
-| `postingUrl` | `String` | _Optional._ The URL to the job posting. |
-| `archived` | `Boolean` | False by default. Whether the application has been archived |
-| `createdAt` | `DateTime` | The date the application was created. |
-| `updatedAt` | `DateTime` | The date the application was last updated. |
+| **Field**        | **Type**   | **Notes**                                                   |
+| ---------------- | ---------- | ----------------------------------------------------------- |
+| `id`             | `String`   | A UUID                                                      |
+| `salaryMin`      | `String`   | _Optional._ The minimum salary for the job.                 |
+| `salaryMax`      | `String`   | _Optional._ The maximum salary for the job.                 |
+| `dateApplied`    | `DateTime` | _Optional._ The date the application was submitted.         |
+| `jobTitle`       | `String`   | _Optional._ The job title                                   |
+| `jobDescription` | `String`   | _Optional._ The job description.                            |
+| `postingUrl`     | `String`   | _Optional._ The URL to the job posting.                     |
+| `archived`       | `Boolean`  | False by default. Whether the application has been archived |
+| `createdAt`      | `DateTime` | The date the application was created.                       |
+| `updatedAt`      | `DateTime` | The date the application was last updated.                  |
 
 <Aside type="note" title="Working with Money">
 You may have noticed that I'm using a `String` for the `salaryMin` and `salaryMax` fields. Alternatively, we could make this a number, so we can standardize the display or sort the applications by salary.
 
 However, there's a few reasons why I'm using a `String`:
+
 - Working with money is complicated. It's not just a number. There's currency symbols, commas, and decimal points.
 - Prisma doesn't have a native `Currency` data type for SQLite
 - If you are going to use a number, it's best to use a `integer` to avoid potential floating-point accuracy problems and store the values as cents.
 
 For now, I'm going to hit the easy button, and use a `String`.
+
 </Aside>
 
 Now, we need to translate all this information into a Prisma model. Prisma has it's own syntax for defining models. You'll notice that it looks similar to an object definition:
@@ -157,7 +162,7 @@ A few things worth noting:
 
 We can do the same for the remaining models.
 
-```prisma  title="src/db/schema.prisma"
+```prisma title="src/db/schema.prisma"
 ...
 
 model ApplicationStatus {
@@ -208,14 +213,16 @@ model User {
 <Aside type="note" title="@@index">
   You may have noticed that the provided `Credential` model includes the `@@index` directive. This is used to create an index on the field. This can improve performance when querying the database.
 
-  All the database calls we make use the `id` field, which is already indexed.
+All the database calls we make use the `id` field, which is already indexed.
+
 </Aside>
 
 <Aside type="tip" title="Naming Conventions">
-  When working with Prisma, there a couple of naming conventions you should follow:
-  - Use singular names for your models. For example, `Application` not `Applications`.
-  - The model name should be in PascalCase.
-  - The field names should be start with a lowercase letter, pascal case. For example, `jobTitle` not `JobTitle`.
+  When working with Prisma, there a couple of naming conventions you should
+  follow: - Use singular names for your models. For example, `Application` not
+  `Applications`. - The model name should be in PascalCase. - The field names
+  should be start with a lowercase letter, pascal case. For example, `jobTitle`
+  not `JobTitle`.
 </Aside>
 
 This looks good, but we haven't defined any of the relationships between the models (Other than the preexisting relationship between `User` and `Credential` models, defined in the starter).
@@ -225,6 +232,7 @@ This looks good, but we haven't defined any of the relationships between the mod
 There are several different types of relationships:
 
 ### **One-to-one**
+
 A one-to-one relationship is a relationship where a record in one table is associated with exactly one record in another table.
 
 ![](./images/one-to-one.png)
@@ -244,11 +252,16 @@ In order to establish this relationship, we need a **junction table**. This tabl
 ![](./images/many-to-many.png)
 
 <Aside type="note" title="Naming Conventions">
-  When creating junction tables, I name them based on the two tables they connect. For example, if I have a `User` and `Application` model, I'll name the junction table `ApplicationUser`. Notice the models are listed in alphabetical order.
+  When creating junction tables, I name them based on the two tables they
+  connect. For example, if I have a `User` and `Application` model, I'll name
+  the junction table `ApplicationUser`. Notice the models are listed in
+  alphabetical order.
 </Aside>
 
 <Aside type="note" title="IDs in Junction Tables">
-  Technically, you don't need an `id` field in the junction table, because the combination of the two IDs (`contactId` and `tagId`) together will be unique. However, I still like to include an `id` field for good measure.
+  Technically, you don't need an `id` field in the junction table, because the
+  combination of the two IDs (`contactId` and `tagId`) together will be unique.
+  However, I still like to include an `id` field for good measure.
 </Aside>
 
 ## All the Tables for our Database
@@ -260,18 +273,22 @@ Here's a diagram of all the models and their relationships for this project.
 Coincidentally, all the relationships in our project are one-to-one or one-to-many.
 
 <Aside type="note" title="Crendential Table">
-  Most of the tables in our database are self explanatory. But, let's look take a second look at the `Credential` table. This model was included within the standard starter kit and will hold all the details for our passkeys.
+  Most of the tables in our database are self explanatory. But, let's look take
+  a second look at the `Credential` table. This model was included within the
+  standard starter kit and will hold all the details for our passkeys.
 </Aside>
 
 <Aside type="tip" title="Database Diagram">
   I always find it helpful to have a visual representation of the database.
 
-  I created these diagrams with [tldraw](https://tldraw.com/). But, [Whimsical](https://whimsical.com/) and [Figma](https://www.figma.com/) are also great tools.
+I created these diagrams with [tldraw](https://tldraw.com/). But, [Whimsical](https://whimsical.com/) and [Figma](https://www.figma.com/) are also great tools.
 
-  [prisma-dbml-generator](https://github.com/notiz-dev/prisma-dbml-generator) is an interesting project. It's built on top of [dbdiagram.io](https://dbdiagram.io/) and can take a Prisma Schema and generate a diagram.
+[prisma-dbml-generator](https://github.com/notiz-dev/prisma-dbml-generator) is an interesting project. It's built on top of [dbdiagram.io](https://dbdiagram.io/) and can take a Prisma Schema and generate a diagram.
+
 </Aside>
 
 ## Relationships within Prisma
+
 When establishing a relationship within your schema, there are 3 parts.
 
 1. **Foreign Key Column** This stores the ID for the related record.
@@ -281,13 +298,15 @@ When establishing a relationship within your schema, there are 3 parts.
 <Aside type="note" title="What's a foreign key?">
   A foreign key is a column (or set of columns) in a table that refers to the primary key of another table, establishing a link between two tables in a relational database.
 
-  It's called a "foreign key" because it references the primary key of the "foreign" table.
+It's called a "foreign key" because it references the primary key of the "foreign" table.
+
 </Aside>
 
 <Aside type="note" title="What can you see within the database?">
   Within the database, the only column that you'll be able to see if the foreign key column that stores the ID of the related record.
 
-  The **relationship field** and **implicit relationship field** are only used within the context of Prisma.
+The **relationship field** and **implicit relationship field** are only used within the context of Prisma.
+
 </Aside>
 
 Let's look at this in practice. On the `Company` and `Contact` models:
@@ -319,18 +338,21 @@ model Contact {
 
 1. On the `Contact` model, we added a `companyId` field. This stores the ID of the related `Company` record. Because the `id` field on the `Company` model is a string, our `companyId` field is also a string.
 2. On the `Contact` model, we also added a `company` field. This describes the Contact↔Company relationship for Prisma.
-    - You can read this as: "A contact belongs to a company."
-    - It is connected to the `Company` model. You can also think of this as having a type of `Company`.
-    - It uses the `companyId` field on the `Contact` model to connect the two models.
-    - It references the `id` field on the `Company` model.
+   - You can read this as: "A contact belongs to a company."
+   - It is connected to the `Company` model. You can also think of this as having a type of `Company`.
+   - It uses the `companyId` field on the `Contact` model to connect the two models.
+   - It references the `id` field on the `Company` model.
 3. On the `Company` model, we added a `contacts` field. This describes the Company↔Contact relationship to Prisma.
-    - You can read this as: "A company has many contacts."
-    - The type of content will be an array `[]` of `Contact` records.
+   - You can read this as: "A company has many contacts."
+   - The type of content will be an array `[]` of `Contact` records.
 
 ![](./images/prisma-relationship-field.png)
 
 <Aside type="note" title="Relationships in Prisma">
-  When you look a the columns in your database that Prisma generates, you won't find a relation or implicit relationship field, only the foreign key. However, these properties are necessary for Prisma to understand the relationship between the two models.
+  When you look a the columns in your database that Prisma generates, you won't
+  find a relation or implicit relationship field, only the foreign key. However,
+  these properties are necessary for Prisma to understand the relationship
+  between the two models.
 </Aside>
 
 In some cases, you might need to give the relationship a name. This is particularly useful when you have multiple relationships between the same models.
@@ -437,7 +459,9 @@ model User {
 ```
 
 <Aside type="tip" title="Models in Alphabetical Order">
-This is personal preference, but I like to put my models in alphabetical order. It makes it easier to find what you're looking for, especially on larger projects.
+  This is personal preference, but I like to put my models in alphabetical
+  order. It makes it easier to find what you're looking for, especially on
+  larger projects.
 </Aside>
 
 ## Running Migrations
@@ -457,43 +481,45 @@ pnpm migrate:new "setup all database models"
 <Aside type="note" title="Troubleshooting a Migration">
   {/* TODO: Add a screenshot of this error message. */}
 
-  Occasionally, you may run into an error where there are multiple sqlite files in the `.wrangler > state > v3 > d1 > miniflare-D1DatabaseObject` folder.
+Occasionally, you may run into an error where there are multiple sqlite files in the `.wrangler > state > v3 > d1 > miniflare-D1DatabaseObject` folder.
 
-  If this happens, you can delete the `.wrangler` folder and rerun `pnpm dev` to regenerate it.
+If this happens, you can delete the `.wrangler` folder and rerun `pnpm dev` to regenerate it.
 
-  Then, try running `pnpm migrate:dev` to apply the migration.
+Then, try running `pnpm migrate:dev` to apply the migration.
+
 </Aside>
 
 Our generated `sql` file will be in the `migrations` folder.
 
 <figure>
-![](./images/migrations-folder.png)
-<figcaption>
-- `0001_init.sql` was generated the first time we ran `pnpm dev`.
-- `0002_setup_all_database_models.sql` was generated when we ran `pnpm migrate:new "setup all database models"`.
-</figcaption>
+  ![](./images/migrations-folder.png)
+  <figcaption>
+    - `0001_init.sql` was generated the first time we ran `pnpm dev`. -
+    `0002_setup_all_database_models.sql` was generated when we ran `pnpm
+    migrate:new "setup all database models"`.
+  </figcaption>
 </figure>
 
-
 <Aside type="tip" title="The Number of Migrations">
-  Worried about the number of migrations in your project? Don't. It really doesn't have any effect on your project.
+  Worried about the number of migrations in your project? Don't. It really
+  doesn't have any effect on your project.
 </Aside>
 
 <Aside type="note" title="Working with other people">
   An added benefit of migrations is that it makes it easier to work with other people.
 
-  Migration files get committed to the repository and placed in version control.
+Migration files get committed to the repository and placed in version control.
 
-  Database changes can be tied to a branch and a specific feature or bug fix.
+Database changes can be tied to a branch and a specific feature or bug fix.
 
-  Keeping another team member's database in sync is as simple as running the migration: `npm migrate:dev`
+Keeping another team member's database in sync is as simple as running the migration: `npm migrate:dev`
+
 </Aside>
 
 <Aside type="note" title="Migration Commands">
-  There are 3 different migration commands:
-  1. `migrate:dev`: runs the migration on your local database
-  2. `migrate:prd`: runs the migration on your production database
-  3. `migrate:new`: creates a new migration
+  There are 3 different migration commands: 1. `migrate:dev`: runs the migration
+  on your local database 2. `migrate:prd`: runs the migration on your production
+  database 3. `migrate:new`: creates a new migration
 </Aside>
 
 ## Previewing the Migration
@@ -533,7 +559,6 @@ Then, paste in the database path:
 
 ![](./images/database-url-full-url.png)
 
-
 Now, within the Terminal, run:
 
 ```shell
@@ -543,12 +568,13 @@ npx prisma studio
 This will open a new tab in your default browser at `http://localhost:5555`.
 
 {/* ./images/prisma-studio.png - this is a screenshot of a seeded database */}
+
 <figure>
-![](./images/prisma-studio-no-tables-selected.png)
-<figcaption>
-- Within Prisma Studio, you can see a list of all your tables/models on the left.
-- If you click on one, it will load the table/model on the right.
-</figcaption>
+  ![](./images/prisma-studio-no-tables-selected.png)
+  <figcaption>
+    - Within Prisma Studio, you can see a list of all your tables/models on the
+    left. - If you click on one, it will load the table/model on the right.
+  </figcaption>
 </figure>
 
 ![](./images/prisma-studio-application-table-selected.png)
@@ -562,12 +588,8 @@ The [VS Code extension, SQLite Viewer](https://marketplace.visualstudio.com/item
 Within the file explorer, navigate to your D1 database. You can find it in the `.wrangler > state > v3 > d1 > miniflare-D1DatabaseObject` folder.
 
 <FileTree>
-- .wrangler
-  - state
-    - v3
-      - d1
-        - miniflare-D1DatabaseObject/
-          - 005cb3d3133217f352562272facf516778925ea1151d9c310bcb4e13614995c1.sqlite
+  - .wrangler - state - v3 - d1 - miniflare-D1DatabaseObject/ -
+  005cb3d3133217f352562272facf516778925ea1151d9c310bcb4e13614995c1.sqlite
 </FileTree>
 
 The file name of your sqlite database will vary.
@@ -579,11 +601,14 @@ Click on the sqlite file and a preview should open within VSCode.
 The viewer will only let you preview the database. If you want to create, update, or delete, you'll need a pro (premium) account.
 
 <Aside type="note" title="If the Migration Didn't Run">
-If the migration didn't run, there are a few things you can check:
-- How many SQLlite files are in the `.wrangler > state > v3 > d1 > miniflare-D1DatabaseObject` folder? There should be one. You can always delete the `.wrangler` folder and rerun `pnpm dev` to regenerate it.
-- Try running `pnpm migrate:dev`. This will apply any new migrations.
-- Try running `pnpm dev`. This will also apply any new migrations.
-- Ensure that the `database_id` within the `wrangler.jsonc` file matches the database id in your Cloudflare account.
+  If the migration didn't run, there are a few things you can check: - How many
+  SQLlite files are in the `.wrangler > state > v3 > d1 >
+  miniflare-D1DatabaseObject` folder? There should be one. You can always delete
+  the `.wrangler` folder and rerun `pnpm dev` to regenerate it. - Try running
+  `pnpm migrate:dev`. This will apply any new migrations. - Try running `pnpm
+  dev`. This will also apply any new migrations. - Ensure that the `database_id`
+  within the `wrangler.jsonc` file matches the database id in your Cloudflare
+  account.
 </Aside>
 
 ## Seed the database
@@ -594,16 +619,12 @@ Instead of manually adding data to the database, we can create a **seed file** t
 
 Within the `src > scripts` directory, you'll find a `seed.ts`
 
-<FileTree>
-- src/
-  - scripts/
-    - seed.ts
-</FileTree>
+<FileTree>- src/ - scripts/ - seed.ts</FileTree>
 
 This contains the basic structure for our seed file.
 
 ```ts title="src/scripts/seed.ts"
-import { defineScript } from "@redwoodjs/sdk/worker";
+import { defineScript } from "rwsdk/worker";
 import { db, setupDb } from "@/db";
 
 export default defineScript(async ({ env }) => {
@@ -631,13 +652,14 @@ If you want to start fresh with your own seed file, you could delete lines 7-17,
 <Aside type="tip" title="Seed File Structure">
   In order for our seed file to run properly, we have to run it inside a Cloudflare worker.
 
-  Why? Since we're using a Cloudflare D1 database, we need a worker in order to access it.
+Why? Since we're using a Cloudflare D1 database, we need a worker in order to access it.
+
 </Aside>
 
 You can copy and paste the following code to your project:
 
 ```ts title="src/scripts/seed.ts"
-import { defineScript } from "@redwoodjs/sdk/worker";
+import { defineScript } from "rwsdk/worker";
 import { db, setupDb } from "../db";
 
 export default defineScript(async ({ env }) => {
@@ -668,12 +690,13 @@ export default defineScript(async ({ env }) => {
 ```
 
 Let's make sure we understand what's happening:
-* **On lines 1 and 2** are importing our dependencies. We need our Cloudflare worker and database connection.
-* **On line 4**, we're setting up our Cloudflare worker environment.
-* **On line 5**, we're setting up our database connection.
-* **On line 7-15**, we're using raw SQL to delete all the existing data from the database. This will allow us to start fresh when seeding the database.
-* **On line 16-25**, we're adding all the job application statuses to the database. You'll notice this is a standard Prisma `createMany` function.
-* **On line 27**, we're logging a message to the console saying the seeding is complete.
+
+- **On lines 1 and 2** are importing our dependencies. We need our Cloudflare worker and database connection.
+- **On line 4**, we're setting up our Cloudflare worker environment.
+- **On line 5**, we're setting up our database connection.
+- **On line 7-15**, we're using raw SQL to delete all the existing data from the database. This will allow us to start fresh when seeding the database.
+- **On line 16-25**, we're adding all the job application statuses to the database. You'll notice this is a standard Prisma `createMany` function.
+- **On line 27**, we're logging a message to the console saying the seeding is complete.
 
 <Aside type="caution" title="Troubleshooting">
 Are you getting an error that says: `"Property 'applicationStatus' does not exist on type 'PrismaClient<PrismaClientOptions, never, DefaultArgs>'"`
@@ -683,7 +706,9 @@ This means that the Prisma types haven't been generated for your model. Within t
 ```shell
 npx prisma generate
 ```
+
 Problem solved.
+
 </Aside>
 
 To seed the database, run the following command:
@@ -708,11 +733,12 @@ The seed file we just created is perfect for a brand new database, whether we're
 Typically, I'll also create seed files to test the application with various sets of data. This is much easier (and faster) than manually adding data again and again.
 
 You can also leverage libraries, like [Faker](https://fakerjs.dev/) and [Snaplet](https://snaplet-seed.netlify.app/seed/getting-started/overview), to make it easier to create realistic data sets.
+
 </Aside>
 
-
 <Aside type="tip" title="Code on GitHub">
-You can find the final code for this step on [GitHub](https://github.com/ahaywood/applywize/tree/main/end-of-3).
+  You can find the final code for this step on
+  [GitHub](https://github.com/ahaywood/applywize/tree/main/end-of-3).
 </Aside>
 
 ## Further reading

--- a/docs/src/content/docs/tutorial/full-stack-app/4-auth.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/4-auth.mdx
@@ -6,10 +6,9 @@ sidebar:
 description: A guide in my new Starlight docs site.
 ---
 
-import { Aside, FileTree } from "@astrojs/starlight/components";
+import { Aside, FileTree } from '@astrojs/starlight/components';
 
 ## Existing Authentication Code
-
 Since we're using the [standard starter kit](https://github.com/redwoodjs/sdk/tree/main/starters/standard), it already has passkey authentication set up.
 
 <Aside type="note" title="Passkey Authentication">
@@ -17,7 +16,6 @@ Since we're using the [standard starter kit](https://github.com/redwoodjs/sdk/tr
 Passkey authentication is a passwordless authentication method that uses a biometric or device authentication to verify the user's identity.
 
 **How it Works**:
-
 1. A user creates a passkey during the registration process.
 2. A unique public-private key pair is generated.
 3. The private key remains securely stored on the user's device or [in a password manager](https://developer.apple.com/passkeys/).
@@ -26,19 +24,18 @@ Passkey authentication is a passwordless authentication method that uses a biome
 6. The service verifies the user's identity using the public key.
 
 ### Why Passkey Authentication?
-
 Passkey authentication offers several key advantages:
 
 - **Enhanced Security**: Passkeys are unique, resistant to guessing, and eliminate vulnerabilities associated with traditional passwords. They use biometric authentication like fingerprints, making them much harder to compromise.
 - **User-Friendly**: Users can log in quickly using biometric data or device authentication, removing the need to remember complex passwords. This creates a frictionless access experience across different platforms.
 - **Phishing Resistance**: Passkeys are tied to specific websites, making them immune to phishing attacks that typically trick users into entering credentials on fake sites.
-  </Aside>
+</Aside>
 
 Let's start by taking a look at the `worker.tsx` file. This file sets up our Cloudflare worker, but it also handles all the routing, middleware, and interrupters.
 
 ```tsx title="src/worker.tsx" collapse={1-12}
-import { defineApp, ErrorResponse } from "rwsdk/worker";
-import { route, render, prefix } from "rwsdk/router";
+import { defineApp, ErrorResponse } from "@redwoodjs/sdk/worker";
+import { route, render, prefix } from "@redwoodjs/sdk/router";
 import { Document } from "@/app/Document";
 import { Home } from "@/app/pages/Home";
 import { setCommonHeaders } from "@/app/headers";
@@ -111,7 +108,6 @@ export type AppContext = {
   user: User | null;
 };
 ```
-
 - On **lines 14-17**, we're setting up the types for our application's context object. Specifically, we're defining the `session` and `user` properties.
   - The `Session` type is defined in `src/session/durableObject.ts`. (Imported on line 8.) It contains a `userId`, `challenge`, and `createdAt`.
   - The `User` type comes from our `@prisma/client`. (Imported on line 10.) That's right! When Prisma generates our migration files, it also generates types.
@@ -119,7 +115,6 @@ export type AppContext = {
 ```tsx title="src/worker.tsx" startLineNumber=20
 setCommonHeaders(),
 ```
-
 - On **line 20** we're setting up our common headers. This is a function inside of `app/src/headers.ts`. (Imported on line 5.) It creates the Security Policies, Transport Policy, Referrer Policy, and Permissions Policy. [You can find additional documentation here.](/core/security/#-security-headers)
 
 ```tsx title="src/worker.tsx" startLineNumber=21
@@ -152,7 +147,6 @@ async ({ ctx, request, headers }) => {
   }
 },
 ```
-
 - On **lines 21-48**, we're setting up our middleware. This will run between every request and response cycle.
   - First, we're setting up the database `setupDb(env);` We'll use this later, on line 42, to find the logged in user.
   - Then, we're setting up the session store `setupSessionStore(env);`. We're using Cloudflare's Durable Objects to store our session data and loading it. `sessions.load(request)`
@@ -162,7 +156,6 @@ async ({ ctx, request, headers }) => {
 ```tsx title="src/worker.tsx" startLineNumber=49
 render(Document, [
 ```
-
 - On **line 49**, we're setting up our document. This document is referencing our `src/app/Document.tsx` file. It contains our `html`, `head`, and `body` tags and wraps _all_ of our pages.
   - One of the powerful yet simple features of RedwoodSDK is that it supports per-route documents. Read more about this [on our blog](https://rwsdk.com/blog/redwoodsdk-multiple-documents).
 
@@ -170,7 +163,6 @@ render(Document, [
 render(Document, [
   route("/", () => new Response("Hello, World!")),
 ```
-
 - On **line 50**, we're setting up our home page route. Here, we're just returning a standard response.
 
 The router highlights the request-response lifecycle. The first parameter is the route we're requesting and the second parameter is the response. This can be a standard response, or it can be a React component. On line 50, we're returning a standard response that says `Hello World!`.
@@ -184,7 +176,7 @@ route("/", Home),
 We can also change the home page route to use the `index` method:
 
 ```tsx title="src/worker.tsx" showLineNumbers={false}
-import { index, route, render, prefix } from "rwsdk/router";
+import { index, route, render, prefix } from "@redwoodjs/sdk/router";
 ...
 index([Home]);
 ```
@@ -230,14 +222,12 @@ Interrupters will _interrupt_ the flow. Before, the server returns a response, t
 - Middleware will run before _every single route_.
 - Interrupters will only run _on specific routes._
 
-In our code, we're using middleware to attach the user session to our context object _on every request_. But, we're only checking to see if the user is logged in _on the home page_.
-
+In our code, we're using middleware to attach the user session to our context object *on every request*. But, we're only checking to see if the user is logged in *on the home page*.
 </Aside>
 
 ```tsx title="src/worker.tsx" startLineNumber=62
 prefix("/user", userRoutes),
 ```
-
 - On **line 62**, we're prefixing all of our auth routes with `/user`. Meaning, our `login` route will be `/user/login` and our `logout` route will be `/user/logout`.
   - `login` and `logout` are defined within the `userRoutes` file, imported on line 6. One of the cool things about the RedwoodSDK router is that the response parameter can be an array. This means we can define our route information in a separate file and then import it into our `worker.tsx` file.
 
@@ -246,7 +236,7 @@ We're co-locating the file that defines our auth routes with our auth pages.
 Let's take a look at `userRoutes`. This is coming from `src/app/pages/user/routes.tsx`.
 
 ```tsx title="src/app/pages/user/routes.tsx"
-import { route } from "rwsdk/router";
+import { route } from "@redwoodjs/sdk/router";
 import { Login } from "./Login";
 import { sessions } from "@/session/store";
 
@@ -266,18 +256,14 @@ export const userRoutes = [
 ```
 
 We're defining 2 routes:
-
 - `/login` - This is displaying our login page (on line 6).
 - `/logout` - This is our logout route (on line 7), but instead of returning JSX, we're removing the session (line 9) and redirecting the user to the home page (line 10). Then, we return the response (line 12-15). The [302 status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/302) means we're redirecting to the `Location` header.
 
 <Aside type="note" title="Prefixed Routes">
-  Remember, even though these routes are defined as `/login` and `/logout`,
-  we've prefixed them in our `worker.tsx` file with `/user` So, in order to
-  access them, you'll go to `/user/login` and `/user/logout`.
+Remember, even though these routes are defined as `/login` and `/logout`, we've prefixed them in our `worker.tsx` file with `/user` So, in order to access them, you'll go to `/user/login` and `/user/logout`.
 </Aside>
 
 ## Setting up the Signup Page
-
 Let's create a third route for registering a new user, giving sign up a dedicated page.
 
 Inside, our `src/app/pages/user` directory, create a new file called `Signup.tsx`. Let's stub out a simple function, just to make sure it's working:
@@ -285,13 +271,13 @@ Inside, our `src/app/pages/user` directory, create a new file called `Signup.tsx
 ```tsx title="src/app/pages/user/Signup.tsx"
 export const Signup = () => {
   return <div>Signup</div>;
-};
+}
 ```
 
 Now, we need to add this route to our `userRoutes` array (inside of `src/app/pages/user/routes.ts`):
 
 ```tsx title="src/app/pages/user/routes.ts" {3,8}
-import { route } from "rwsdk/router";
+import { route } from "@redwoodjs/sdk/router";
 import { Login } from "./Login";
 import { Signup } from "./Signup";
 import { sessions } from "@/session/store";
@@ -335,7 +321,7 @@ import {
   startPasskeyLogin,
   startPasskeyRegistration,
 } from "./functions";
-import { useTurnstile } from "rwsdk/turnstile";
+import { useTurnstile } from "@redwoodjs/sdk/turnstile";
 import { Button } from "@/app/components/ui/button";
 // >>> Replace this with your own Cloudflare Turnstile site key
 const TURNSTILE_SITE_KEY = "0x4AAAAAABBM92GLK3VnyFAr";
@@ -415,7 +401,6 @@ export function Login() {
   );
 }
 ```
-
 </details>
 
 Let's break it down, chunk by chunk:
@@ -546,9 +531,7 @@ const handlePerformPasskeyRegister = () => {
 ```
 
 <Aside type="note" title="Usernames vs Email Addresses">
-  We're intentionally using usernames instead of emails. This decision prevents
-  enumeration attacks and avoids requiring valid email addresses for
-  registration.
+We're intentionally using usernames instead of emails. This decision prevents enumeration attacks and avoids requiring valid email addresses for registration.
 </Aside>
 
 ```tsx title="src/app/pages/user/Login.tsx" startLineNumber=74
@@ -579,7 +562,6 @@ export function Signup() {
 ```
 
 Let's remove all the pieces that aren't related to registering.
-
 - We don't need the `passkeyLogin` function (lines 26-36)
 - You can delete the `handlePerformPasskeyLogin` function (originally lines 56-58)
 - Let's also remove the "Login with passkey" button (originally lines 74-76)
@@ -595,12 +577,14 @@ Now, we need to clean up our unused imports. Within our IDE, these should be gra
 "use client";
 
 import { useState, useTransition } from "react";
-import { startRegistration } from "@simplewebauthn/browser";
+import {
+  startRegistration,
+} from "@simplewebauthn/browser";
 import {
   finishPasskeyRegistration,
   startPasskeyRegistration,
 } from "./functions";
-import { useTurnstile } from "rwsdk/turnstile";
+import { useTurnstile } from "@redwoodjs/sdk/turnstile";
 import { Button } from "@/app/components/ui/button";
 
 // >>> Replace this with your own Cloudflare Turnstile site key
@@ -654,6 +638,7 @@ export function Signup() {
 ```
 
 </details>
+
 
 Now, let's do the opposite for our `Login.tsx`.
 
@@ -718,7 +703,6 @@ export function LoginPage() {
   );
 }
 ```
-
 </details>
 
 Now, let's test our code:
@@ -760,7 +744,6 @@ Now, navigate to http://localhost:2332/. You should see a message that you're lo
 ![](./images/home-page-logged-in-as.png)
 
 Did you realize we haven't been able to access the home page before because it was protected by an interruptor?
-
 <details>
 <summary>Interruptor code (`worker.tsx`, lines 35-42)</summary>
 
@@ -777,7 +760,6 @@ index([
   Home,
 ]),
 ```
-
 </details>
 
 Try logging out, by going to http://localhost:2332/user/logout. You should be redirected to the login page.
@@ -789,7 +771,6 @@ Login and then you can visit the home page again.
 😎 Cool, right?
 
 ## Styling the Login Page
-
 Now that we know our authentication code is working, let's add some styles and make it look good.
 
 If we take a look at [the final design within Figma](https://www.figma.com/design/nqBPIIfe0MO4W8zOfW4oae/RedwoodSDK-%2F-Applywize?node-id=239-604&t=AzaW01lRe7c80zl2-1), this is what we're aiming for:
@@ -808,8 +789,8 @@ When we installed shadcn/ui, it added a lot of variables to the bottom of our `s
 <summary>Updated `styles.css` file</summary>
 
 ```css title="src/app/styles.css"
-@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@500;700&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap");
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@500;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
 
 @import "tailwindcss";
 
@@ -955,7 +936,6 @@ body {
   --color-tag-offer: #aae198;
 }
 ```
-
 </details>
 
 If you take a look in the browser, by changing the position of the `@theme` block, it also changed the button's background color to yellow, our primary color. Perfect.
@@ -964,7 +944,12 @@ If you take a look in the browser, by changing the position of the `@theme` bloc
 
 Now, let's start on our layout component. Inside our `app` directory, create a new folder called `layouts`. Then, a new file called `AuthLayout.tsx`:
 
-<FileTree>- src - app - layouts - AuthLayout.tsx</FileTree>
+<FileTree>
+- src
+  - app
+    - layouts
+      - AuthLayout.tsx
+</FileTree>
 
 Let's start by stubbing out our component:
 
@@ -993,7 +978,7 @@ Inside our `Login` component let's replace our `main` tag with our `AuthLayout` 
 ```tsx title="src/app/pages/user/Login.tsx" {2,15} startLineNumber=37
 return (
   <AuthLayout>
-    <h1 className="text-4xl font-bold text-red-500">YOLO</h1>
+  <h1 className="text-4xl font-bold text-red-500">YOLO</h1>
     <div ref={turnstile.ref} />
     <input
       type="text"
@@ -1006,7 +991,7 @@ return (
     </Button>
     {result && <div>{result}</div>}
   </AuthLayout>
-);
+)
 ```
 
 If we head over to the browser, we should see something like this:
@@ -1041,7 +1026,13 @@ For the column on the left, we have a repeating background image. You can export
 
 Inside the root of our project, create a new folder called `public`. Inside, I'm going to create another folder called `images` and drop the image inside.
 
-<FileTree>- public/ - images/ - bg.png - logo.svg - src/</FileTree>
+<FileTree>
+- public/
+  - images/
+    - bg.png
+    - logo.svg
+- src/
+</FileTree>
 
 While we're here, let's also grab the logo. I'm only going to grab the owl. We can use "Apply Wize" text and style it with CSS. This will give us a little more control over the display (horizontal or stacked) without having to use two separate images. You can export the owl as an SVG (or [download it directly](https://github.com/ahaywood/applywize/tree/main/assets)).
 
@@ -1095,9 +1086,13 @@ Now, we can use this on both of our columns:
   <div className="grid grid-cols-2 min-h-[calc(100vh-96px)] rounded-xl border-2 border-[#D6D5C5]">
     <div className="center bg-[url('/images/bg.png')] bg-repeat rounded-l-xl">
       <img src="/images/logo.svg" alt="Apply Wize" />
-      <div>Apply Wize</div>
+      <div>
+        Apply Wize
+      </div>
     </div>
-    <div className="center">{children}</div>
+    <div className="center">
+      {children}
+    </div>
   </div>
 </div>
 ```
@@ -1113,7 +1108,9 @@ It's centering our content, but it's also horizontally aligning everything. Let'
       <div className="center">
         <div>
           <img src="/images/logo.svg" alt="Apply Wize" />
-          <div className="text-5xl text-white font-bold">Apply Wize</div>
+          <div className="text-5xl text-white font-bold">
+            Apply Wize
+          </div>
         </div>
       </div>
     </div>
@@ -1157,7 +1154,9 @@ We want this to be fixed to the bottom of the left column. So, this needs to be 
 <div className="center bg-[url('/images/bg.png')] bg-repeat rounded-l-xl">
   <div>
     <img src="/images/logo.svg" alt="Apply Wize" className="mx-auto" />
-    <div className="text-5xl text-white font-bold">Apply Wize</div>
+    <div className="text-5xl text-white font-bold">
+      Apply Wize
+    </div>
   </div>
   <div>“Transform the job hunt from a maze into a map.”</div>
 </div>
@@ -1229,6 +1228,9 @@ Now, let's style the right side. This is easy!
 ---
 ```
 
+
+
+
 ![](./images/authlayout-styling-complete.png)
 
 The styling for auth layout component is complete, but there's still one thing bothering me. (And maybe it's been bothering you too.)
@@ -1251,7 +1253,6 @@ When setting the type for `children` within React, you'll see `React.ReactNode`,
 > - `JSX.Element` and `React.ReactElement` are functionally the same type. They can be used interchangeably. They represent the thing that a JSX expression creates.
 > - They can't be used to represent all the things that React can render, like strings and numbers. For that, use `React.ReactNode.`
 > - In everyday use, you should use `React.ReactNode`. You rarely need to use the more specific type of `JSX.Element`.
-
 </Aside>
 
 <details>
@@ -1265,7 +1266,9 @@ const AuthLayout = ({ children }: { children: React.ReactNode }) => {
         <div className="relative center bg-[url('/images/bg.png')] bg-repeat rounded-l-xl">
           <div className="-top-[100px] relative">
             <img src="/images/logo.svg" alt="Apply Wize" className="mx-auto" />
-            <div className="text-5xl text-white font-bold">Apply Wize</div>
+            <div className="text-5xl text-white font-bold">
+              Apply Wize
+            </div>
           </div>
           <div className="text-white text-sm absolute bottom-0 left-0 right-0 p-10">
             “Transform the job hunt from a maze into a map.”
@@ -1281,7 +1284,6 @@ const AuthLayout = ({ children }: { children: React.ReactNode }) => {
 
 export { AuthLayout };
 ```
-
 </details>
 
 ### Styling the Login Content
@@ -1349,20 +1351,11 @@ Next up, let's wrap all of our form content with a `div` and add the text at the
 Let's also add some text below our form:
 
 ```tsx title="src/app/pages/user/Login.tsx" startLineNumber=68 {5}
-<Button
-  onClick={handlePerformPasskeyLogin}
-  disabled={isPending}
-  className="font-display w-full mb-6"
->
-  {isPending ? <>...</> : "Login with passkey"}
-</Button>;
-{
-  result && <div>{result}</div>;
-}
-<p>
-  By clicking continue, you agree to our <a href="#">Terms of Service</a> and{" "}
-  <a href="#">Privacy Policy</a>.
-</p>;
+<Button onClick={handlePerformPasskeyLogin} disabled={isPending} className="font-display w-full mb-6">
+    {isPending ? <>...</> : "Login with passkey"}
+  </Button>
+  {result && <div>{result}</div>}
+  <p>By clicking continue, you agree to our <a href="#">Terms of Service</a> and <a href="#">Privacy Policy</a>.</p>
 ```
 
 I want to add some more styling, but I want to be able to reuse these styles on our Signup page, so let's stick these updates inside our `styles.css` file.
@@ -1370,7 +1363,6 @@ I want to add some more styling, but I want to be able to reuse these styles on 
 In CSS order matters. The [`@layer` CSS at-rule](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer) makes it easy to declare a _layer_ and set the order of preference.
 
 I like to order my CSS:
-
 1. **Base styles** are at the top. These are for styling generic HTML elements. No classes, just tags.
 2. **Component styles.** These are for styling classes that get used across multiple components and pages.
 3. **Page specific styles.** These are for styling elements on a specific page.
@@ -1382,45 +1374,34 @@ At the very bottom of our `styles.css` file, let's start by setting up `@layer` 
 ```css title="src/styles.css" startLineNumber=238
 @layer base, components, page;
 
-@layer base {
-}
+@layer base {}
 
-@layer components {
-}
+@layer components {}
 
-@layer page {
-}
+@layer page {}
 ```
 
 <Aside type="tip" title="CSS Layers">
 Do these `@layer` names give you déjà vu? Feels similar to Tailwind v3? It's the exact same concept! Since these layers [are no longer established in Tailwind v4](https://tailwindcss.com/docs/upgrade-guide#removed-tailwind-directives), we have to define the order ourselves: `@layer base, components, page;`
 
 Technically, we could list our layers in any order we want:
-
 ```css showLineNumbers=false
-@layer page {
-}
-@layer components {
-}
-@layer base {
-}
+@layer page {}
+@layer components {}
+@layer base {}
 ```
 
 It will still be applied in the correct order, because we explicitly defined the order:
-
 ```css showLineNumbers=false
 @layer base, components, page;
 ```
-
 </Aside>
 
 For all our headings (`h1, h2, h3, etc.`), we want to use the font Poppins, `font-display`, and make it bold `font-bold`. Let's stick this inside our base layer:
 
 ```css title="src/styles.css" showLineNumbers=false
 @layer base {
-  h1,
-  h2,
-  h3 {
+  h1, h2, h3 {
     @apply font-display font-bold;
   }
 }
@@ -1597,19 +1578,11 @@ But, there's one more thing. Let's move the `result` message above the form and 
     onChange={(e) => setUsername(e.target.value)}
     placeholder="Username"
   />
-  <Button
-    onClick={handlePerformPasskeyLogin}
-    disabled={isPending}
-    className="font-display w-full mb-6"
-  >
+  <Button onClick={handlePerformPasskeyLogin} disabled={isPending} className="font-display w-full mb-6">
     {isPending ? <>...</> : "Login with Passkey"}
   </Button>
 
-  <p>
-    By clicking continue, you agree to our 
-    <a href={link("/legal/terms")}>Terms of Service</a> and 
-    <a href={link("/legal/privacy")}>Privacy Policy</a>.
-  </p>
+  <p>By clicking continue, you agree to our <a href={link('/legal/terms')}>Terms of Service</a> and <a href={link('/legal/privacy')}>Privacy Policy</a>.</p>
 </div>
 ```
 
@@ -1722,11 +1695,7 @@ As you type, you should see VS Code make recommendations based on the contents o
 We can make similar changes to our **Terms of Service** and **Privacy Policy** links:
 
 ```tsx title="src/app/pages/user/Login.tsx" "{link("/legal/terms")}" "link("/legal/privacy")" startLineNumber=70
-<p>
-  By clicking continue, you agree to our{" "}
-  <a href={link("/legal/terms")}>Terms of Service</a> and{" "}
-  <a href={link("/legal/privacy")}>Privacy Policy</a>.
-</p>
+<p>By clicking continue, you agree to our <a href={link("/legal/terms")}>Terms of Service</a> and <a href={link("/legal/privacy")}>Privacy Policy</a>.</p>
 ```
 
 If you check your work in the browser, the register link works great, but our Terms of Service and Privacy Policy links go to a Not Found page. Let's fix that.
@@ -1801,14 +1770,18 @@ Now, if you check your work in the browser, you should see the Terms of Service 
 ![](./images/working-terms-page.png)
 
 <Aside type="note" title="Alternate way of displaying our legal routes">
-  When we listed our legal routes, we listed them individually: ```tsx
-  title="src/worker.tsx" startLineNumber=18 {46}
-  route("/legal/privacy", () => <h1>Privacy Policy</h1>), route("/legal/terms",
-  () => <h1>Terms of Service</h1>), ``` But, we could also group them together,
-  with a `prefix` (similar to our `/user` routes, but a little different):
-  ```tsx title="src/worker.tsx" startLineNumber=18 prefix("/legal", [
-  route("/privacy", () => <h1>Privacy Policy</h1>), route("/terms", () =>{" "}
-  <h1>Terms of Service</h1>), ]), ```
+  When we listed our legal routes, we listed them individually:
+  ```tsx title="src/worker.tsx" startLineNumber=18 {46}
+  route("/legal/privacy", () => <h1>Privacy Policy</h1>),
+  route("/legal/terms", () => <h1>Terms of Service</h1>),
+  ```
+  But, we could also group them together, with a `prefix` (similar to our `/user` routes, but a little different):
+  ```tsx title="src/worker.tsx" startLineNumber=18
+  prefix("/legal", [
+    route("/privacy", () => <h1>Privacy Policy</h1>),
+    route("/terms", () => <h1>Terms of Service</h1>),
+  ]),
+  ```
 </Aside>
 
 We've touched a few files, if you want to see the full code for each:
@@ -1831,7 +1804,7 @@ import {
   startPasskeyLogin,
   startPasskeyRegistration,
 } from "./functions";
-import { useTurnstile } from "rwsdk/turnstile";
+import { useTurnstile } from "@redwoodjs/sdk/turnstile";
 import { AuthLayout } from "@/app/layouts/AuthLayout";
 import { Button } from "@/app/components/ui/button";
 import { Alert, AlertTitle } from "@/app/components/ui/alert";
@@ -1874,17 +1847,14 @@ export function Login() {
         <p className="py-6">Enter your username below to sign-in.</p>
 
         {result && (
-          <Alert variant="destructive" className="mb-5">
-            <AlertCircle className="h-4 w-4" />
-            <AlertTitle>{result}</AlertTitle>
-          </Alert>
+        <Alert variant="destructive" className="mb-5">
+          <AlertCircle className="h-4 w-4"/>
+          <AlertTitle>{result}</AlertTitle>
+        </Alert>
         )}
 
         <div className="absolute top-0 right-0 p-10">
-          <a
-            href={link("/user/signup")}
-            className="font-display font-bold text-black text-sm underline underline-offset-8 hover:decoration-primary"
-          >
+          <a href={link("/user/signup")} className="font-display font-bold text-black text-sm underline underline-offset-8 hover:decoration-primary">
             Register
           </a>
         </div>
@@ -1895,19 +1865,11 @@ export function Login() {
           onChange={(e) => setUsername(e.target.value)}
           placeholder="Username"
         />
-        <Button
-          onClick={handlePerformPasskeyLogin}
-          disabled={isPending}
-          className="font-display w-full mb-6"
-        >
+        <Button onClick={handlePerformPasskeyLogin} disabled={isPending} className="font-display w-full mb-6">
           {isPending ? <>...</> : "Login with passkey"}
         </Button>
 
-        <p>
-          By clicking continue, you agree to our{" "}
-          <a href={link("/legal/terms")}>Terms of Service</a> and{" "}
-          <a href={link("/legal/privacy")}>Privacy Policy</a>.
-        </p>
+        <p>By clicking continue, you agree to our <a href={link("/legal/terms")}>Terms of Service</a> and <a href={link("/legal/privacy")}>Privacy Policy</a>.</p>
       </div>
     </AuthLayout>
   );
@@ -1920,36 +1882,39 @@ export function Login() {
 <summary>Final code for our `AuthLayout.tsx`</summary>
 
 ```tsx title="src/app/layouts/AuthLayout.tsx"
-const AuthLayout = ({ children }: { children: React.ReactNode }) => {
+const AuthLayout = ({ children }: { children: React.ReactNode}) => {
   return (
     <div className="bg-bg min-h-screen min-w-screen p-12">
       <div className="grid grid-cols-2 min-h-[calc(100vh-96px)] rounded-xl border-2 border-[#D6D5C5]">
         <div className="relative center bg-[url('/images/bg.png')] bg-repeat rounded-l-xl">
           <div className="-top-[100px] relative">
             <img src="/images/logo.svg" alt="Apply Wize" className="mx-auto" />
-            <div className="text-5xl text-white font-bold">Apply Wize</div>
+            <div className="text-5xl text-white font-bold">
+              Apply Wize
+            </div>
           </div>
           <div className="text-white text-sm absolute bottom-0 left-0 right-0 p-10">
             “Transform the job hunt from a maze into a map.”
           </div>
         </div>
-        <div className="center bg-white rounded-r-xl relative">{children}</div>
+        <div className="center bg-white rounded-r-xl relative">
+          {children}
+        </div>
       </div>
     </div>
-  );
-};
+  )
+}
 
-export { AuthLayout };
+export { AuthLayout }
 ```
-
 </details>
 
 <details>
 <summary>Final code for our `styles.css`</summary>
 
 ```css title="src/styles.css"
-@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@500;700&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap");
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@500;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
 
 @import "tailwindcss";
 @import "tw-animate-css";
@@ -1961,6 +1926,7 @@ body {
 }
 
 @theme inline {
+
   --radius-sm: calc(var(--radius) - 4px);
 
   --radius-md: calc(var(--radius) - 2px);
@@ -2033,6 +1999,7 @@ body {
 }
 
 :root {
+
   --radius: 0.625rem;
 
   --background: oklch(1 0 0);
@@ -2099,6 +2066,7 @@ body {
 }
 
 .dark {
+
   --background: oklch(0.145 0 0);
 
   --foreground: oklch(0.985 0 0);
@@ -2185,6 +2153,7 @@ body {
 @layer base, components, page;
 
 @layer base {
+
   h1,
   h2,
   h3 {
@@ -2194,11 +2163,12 @@ body {
 
 @layer components {
   .page-title {
-    @apply text-3xl;
+    @apply text-3xl
   }
 }
 
 @layer page {
+
   /* login page */
   .auth-form {
     p {
@@ -2230,7 +2200,6 @@ body {
   }
 }
 ```
-
 </details>
 
 <details>
@@ -2239,11 +2208,11 @@ body {
 ```tsx title="src/components/ui/button.tsx"
 "use client";
 
-import * as React from "react";
-import { Slot } from "@radix-ui/react-slot";
-import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from "@/lib/utils";
+import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
   "font-bold inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
@@ -2273,8 +2242,8 @@ const buttonVariants = cva(
       variant: "default",
       size: "default",
     },
-  },
-);
+  }
+)
 
 function Button({
   className,
@@ -2284,9 +2253,9 @@ function Button({
   ...props
 }: React.ComponentProps<"button"> &
   VariantProps<typeof buttonVariants> & {
-    asChild?: boolean;
+    asChild?: boolean
   }) {
-  const Comp = asChild ? Slot : "button";
+  const Comp = asChild ? Slot : "button"
 
   return (
     <Comp
@@ -2294,12 +2263,11 @@ function Button({
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
-  );
+  )
 }
 
-export { Button, buttonVariants };
+export { Button, buttonVariants }
 ```
-
 </details>
 
 <details>
@@ -2316,15 +2284,14 @@ export const link = defineLinks([
   "/legal/terms",
 ]);
 ```
-
 </details>
 
 <details>
 <summary>Final code for our `worker.tsx`</summary>
 
 ```tsx title="src/worker.tsx"
-import { defineApp, ErrorResponse } from "rwsdk/worker";
-import { route, render, prefix } from "rwsdk/router";
+import { defineApp, ErrorResponse } from "@redwoodjs/sdk/worker";
+import { route, render, prefix } from "@redwoodjs/sdk/router";
 import { Document } from "@/app/Document";
 import { Home } from "@/app/pages/Home";
 import { setCommonHeaders } from "@/app/headers";
@@ -2390,8 +2357,8 @@ export default defineApp([
   ]),
 ]);
 ```
-
 </details>
+
 
 ## Styling the Signup Page
 
@@ -2453,7 +2420,6 @@ Next, let's wrap all of our form content with a `div`:
 ```
 
 We can get rid of our red YOLO heading at the top and replace it with:
-
 ```tsx title="src/app/pages/user/Signup.tsx" startLineNumber=63
 <h1 className="page-title text-center">Create an Account</h1>
 <p className="py-6">Enter a username to setup an account.</p>
@@ -2492,11 +2458,7 @@ Jumping down a little bit, on our `Button` component, let's add a few classes to
 Then, right below the button, we can add our legal statement:
 
 ```tsx title="src/app/pages/user/Signup.tsx" startLineNumber=87
-<p>
-  By clicking continue, you agree to our 
-  <a href={link("/legal/terms")}>Terms of Service</a> and 
-  <a href={link("/legal/privacy")}>Privacy Policy</a>.
-</p>
+<p>By clicking continue, you agree to our <a href={link('/legal/terms')}>Terms of Service</a> and <a href={link('/legal/privacy')}>Privacy Policy</a>.</p>
 ```
 
 ![](./images/final-signup-page.png)
@@ -2510,7 +2472,9 @@ See, I told you! Easy peasy. 🍋
 "use client";
 
 import { useState, useTransition } from "react";
-import { startRegistration } from "@simplewebauthn/browser";
+import {
+  startRegistration,
+} from "@simplewebauthn/browser";
 import {
   finishPasskeyRegistration,
   startPasskeyRegistration,
@@ -2556,10 +2520,7 @@ export function SignupPage() {
   return (
     <AuthLayout>
       <div className="absolute top-0 right-0 p-10">
-        <a
-          href={link("/user/login")}
-          className="font-display font-bold text-black text-sm underline underline-offset-8 hover:decoration-primary"
-        >
+        <a href={link('/user/login')} className="font-display font-bold text-black text-sm underline underline-offset-8 hover:decoration-primary">
           Login
         </a>
       </div>
@@ -2570,7 +2531,7 @@ export function SignupPage() {
 
         {result && (
           <Alert variant="destructive" className="mb-5">
-            <AlertCircle className="h-4 w-4" />
+            <AlertCircle className="h-4 w-4"/>
             <AlertTitle>{result}</AlertTitle>
           </Alert>
         )}
@@ -2582,32 +2543,23 @@ export function SignupPage() {
           onChange={(e) => setUsername(e.target.value)}
           placeholder="Username"
         />
-        <Button
-          onClick={handlePerformPasskeyRegister}
-          disabled={isPending}
-          className="font-display w-full mb-6"
-        >
+        <Button onClick={handlePerformPasskeyRegister} disabled={isPending} className="font-display w-full mb-6">
           {isPending ? <>...</> : "Register with Passkey"}
         </Button>
 
-        <p>
-          By clicking continue, you agree to our 
-          <a href={link("/legal/terms")}>Terms of Service</a> and 
-          <a href={link("/legal/privacy")}>Privacy Policy</a>.
-        </p>
+        <p>By clicking continue, you agree to our <a href={link('/legal/terms')}>Terms of Service</a> and <a href={link('/legal/privacy')}>Privacy Policy</a>.</p>
       </div>
     </AuthLayout>
   );
 }
 ```
-
 </details>
 
 <Aside type="tip" title="Code on GitHub">
-  You can find the final code for this step on
-  [GitHub](https://github.com/ahaywood/applywize/tree/main/end-of-4).
+You can find the final code for this step on [GitHub](https://github.com/ahaywood/applywize/tree/main/end-of-4).
 </Aside>
 
 ## Further reading
 
 - An even more [detailed guide to how Authentication works and the reasoning behind some of the decisions we made](/core/authentication)
+

--- a/docs/src/content/docs/tutorial/full-stack-app/4-auth.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/4-auth.mdx
@@ -6,9 +6,10 @@ sidebar:
 description: A guide in my new Starlight docs site.
 ---
 
-import { Aside, FileTree } from '@astrojs/starlight/components';
+import { Aside, FileTree } from "@astrojs/starlight/components";
 
 ## Existing Authentication Code
+
 Since we're using the [standard starter kit](https://github.com/redwoodjs/sdk/tree/main/starters/standard), it already has passkey authentication set up.
 
 <Aside type="note" title="Passkey Authentication">
@@ -16,6 +17,7 @@ Since we're using the [standard starter kit](https://github.com/redwoodjs/sdk/tr
 Passkey authentication is a passwordless authentication method that uses a biometric or device authentication to verify the user's identity.
 
 **How it Works**:
+
 1. A user creates a passkey during the registration process.
 2. A unique public-private key pair is generated.
 3. The private key remains securely stored on the user's device or [in a password manager](https://developer.apple.com/passkeys/).
@@ -24,18 +26,19 @@ Passkey authentication is a passwordless authentication method that uses a biome
 6. The service verifies the user's identity using the public key.
 
 ### Why Passkey Authentication?
+
 Passkey authentication offers several key advantages:
 
 - **Enhanced Security**: Passkeys are unique, resistant to guessing, and eliminate vulnerabilities associated with traditional passwords. They use biometric authentication like fingerprints, making them much harder to compromise.
 - **User-Friendly**: Users can log in quickly using biometric data or device authentication, removing the need to remember complex passwords. This creates a frictionless access experience across different platforms.
 - **Phishing Resistance**: Passkeys are tied to specific websites, making them immune to phishing attacks that typically trick users into entering credentials on fake sites.
-</Aside>
+  </Aside>
 
 Let's start by taking a look at the `worker.tsx` file. This file sets up our Cloudflare worker, but it also handles all the routing, middleware, and interrupters.
 
 ```tsx title="src/worker.tsx" collapse={1-12}
-import { defineApp, ErrorResponse } from "@redwoodjs/sdk/worker";
-import { route, render, prefix } from "@redwoodjs/sdk/router";
+import { defineApp, ErrorResponse } from "rwsdk/worker";
+import { route, render, prefix } from "rwsdk/router";
 import { Document } from "@/app/Document";
 import { Home } from "@/app/pages/Home";
 import { setCommonHeaders } from "@/app/headers";
@@ -108,6 +111,7 @@ export type AppContext = {
   user: User | null;
 };
 ```
+
 - On **lines 14-17**, we're setting up the types for our application's context object. Specifically, we're defining the `session` and `user` properties.
   - The `Session` type is defined in `src/session/durableObject.ts`. (Imported on line 8.) It contains a `userId`, `challenge`, and `createdAt`.
   - The `User` type comes from our `@prisma/client`. (Imported on line 10.) That's right! When Prisma generates our migration files, it also generates types.
@@ -115,6 +119,7 @@ export type AppContext = {
 ```tsx title="src/worker.tsx" startLineNumber=20
 setCommonHeaders(),
 ```
+
 - On **line 20** we're setting up our common headers. This is a function inside of `app/src/headers.ts`. (Imported on line 5.) It creates the Security Policies, Transport Policy, Referrer Policy, and Permissions Policy. [You can find additional documentation here.](/core/security/#-security-headers)
 
 ```tsx title="src/worker.tsx" startLineNumber=21
@@ -147,6 +152,7 @@ async ({ ctx, request, headers }) => {
   }
 },
 ```
+
 - On **lines 21-48**, we're setting up our middleware. This will run between every request and response cycle.
   - First, we're setting up the database `setupDb(env);` We'll use this later, on line 42, to find the logged in user.
   - Then, we're setting up the session store `setupSessionStore(env);`. We're using Cloudflare's Durable Objects to store our session data and loading it. `sessions.load(request)`
@@ -156,6 +162,7 @@ async ({ ctx, request, headers }) => {
 ```tsx title="src/worker.tsx" startLineNumber=49
 render(Document, [
 ```
+
 - On **line 49**, we're setting up our document. This document is referencing our `src/app/Document.tsx` file. It contains our `html`, `head`, and `body` tags and wraps _all_ of our pages.
   - One of the powerful yet simple features of RedwoodSDK is that it supports per-route documents. Read more about this [on our blog](https://rwsdk.com/blog/redwoodsdk-multiple-documents).
 
@@ -163,6 +170,7 @@ render(Document, [
 render(Document, [
   route("/", () => new Response("Hello, World!")),
 ```
+
 - On **line 50**, we're setting up our home page route. Here, we're just returning a standard response.
 
 The router highlights the request-response lifecycle. The first parameter is the route we're requesting and the second parameter is the response. This can be a standard response, or it can be a React component. On line 50, we're returning a standard response that says `Hello World!`.
@@ -176,7 +184,7 @@ route("/", Home),
 We can also change the home page route to use the `index` method:
 
 ```tsx title="src/worker.tsx" showLineNumbers={false}
-import { index, route, render, prefix } from "@redwoodjs/sdk/router";
+import { index, route, render, prefix } from "rwsdk/router";
 ...
 index([Home]);
 ```
@@ -222,12 +230,14 @@ Interrupters will _interrupt_ the flow. Before, the server returns a response, t
 - Middleware will run before _every single route_.
 - Interrupters will only run _on specific routes._
 
-In our code, we're using middleware to attach the user session to our context object *on every request*. But, we're only checking to see if the user is logged in *on the home page*.
+In our code, we're using middleware to attach the user session to our context object _on every request_. But, we're only checking to see if the user is logged in _on the home page_.
+
 </Aside>
 
 ```tsx title="src/worker.tsx" startLineNumber=62
 prefix("/user", userRoutes),
 ```
+
 - On **line 62**, we're prefixing all of our auth routes with `/user`. Meaning, our `login` route will be `/user/login` and our `logout` route will be `/user/logout`.
   - `login` and `logout` are defined within the `userRoutes` file, imported on line 6. One of the cool things about the RedwoodSDK router is that the response parameter can be an array. This means we can define our route information in a separate file and then import it into our `worker.tsx` file.
 
@@ -236,7 +246,7 @@ We're co-locating the file that defines our auth routes with our auth pages.
 Let's take a look at `userRoutes`. This is coming from `src/app/pages/user/routes.tsx`.
 
 ```tsx title="src/app/pages/user/routes.tsx"
-import { route } from "@redwoodjs/sdk/router";
+import { route } from "rwsdk/router";
 import { Login } from "./Login";
 import { sessions } from "@/session/store";
 
@@ -256,14 +266,18 @@ export const userRoutes = [
 ```
 
 We're defining 2 routes:
+
 - `/login` - This is displaying our login page (on line 6).
 - `/logout` - This is our logout route (on line 7), but instead of returning JSX, we're removing the session (line 9) and redirecting the user to the home page (line 10). Then, we return the response (line 12-15). The [302 status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/302) means we're redirecting to the `Location` header.
 
 <Aside type="note" title="Prefixed Routes">
-Remember, even though these routes are defined as `/login` and `/logout`, we've prefixed them in our `worker.tsx` file with `/user` So, in order to access them, you'll go to `/user/login` and `/user/logout`.
+  Remember, even though these routes are defined as `/login` and `/logout`,
+  we've prefixed them in our `worker.tsx` file with `/user` So, in order to
+  access them, you'll go to `/user/login` and `/user/logout`.
 </Aside>
 
 ## Setting up the Signup Page
+
 Let's create a third route for registering a new user, giving sign up a dedicated page.
 
 Inside, our `src/app/pages/user` directory, create a new file called `Signup.tsx`. Let's stub out a simple function, just to make sure it's working:
@@ -271,13 +285,13 @@ Inside, our `src/app/pages/user` directory, create a new file called `Signup.tsx
 ```tsx title="src/app/pages/user/Signup.tsx"
 export const Signup = () => {
   return <div>Signup</div>;
-}
+};
 ```
 
 Now, we need to add this route to our `userRoutes` array (inside of `src/app/pages/user/routes.ts`):
 
 ```tsx title="src/app/pages/user/routes.ts" {3,8}
-import { route } from "@redwoodjs/sdk/router";
+import { route } from "rwsdk/router";
 import { Login } from "./Login";
 import { Signup } from "./Signup";
 import { sessions } from "@/session/store";
@@ -321,7 +335,7 @@ import {
   startPasskeyLogin,
   startPasskeyRegistration,
 } from "./functions";
-import { useTurnstile } from "@redwoodjs/sdk/turnstile";
+import { useTurnstile } from "rwsdk/turnstile";
 import { Button } from "@/app/components/ui/button";
 // >>> Replace this with your own Cloudflare Turnstile site key
 const TURNSTILE_SITE_KEY = "0x4AAAAAABBM92GLK3VnyFAr";
@@ -401,6 +415,7 @@ export function Login() {
   );
 }
 ```
+
 </details>
 
 Let's break it down, chunk by chunk:
@@ -531,7 +546,9 @@ const handlePerformPasskeyRegister = () => {
 ```
 
 <Aside type="note" title="Usernames vs Email Addresses">
-We're intentionally using usernames instead of emails. This decision prevents enumeration attacks and avoids requiring valid email addresses for registration.
+  We're intentionally using usernames instead of emails. This decision prevents
+  enumeration attacks and avoids requiring valid email addresses for
+  registration.
 </Aside>
 
 ```tsx title="src/app/pages/user/Login.tsx" startLineNumber=74
@@ -562,6 +579,7 @@ export function Signup() {
 ```
 
 Let's remove all the pieces that aren't related to registering.
+
 - We don't need the `passkeyLogin` function (lines 26-36)
 - You can delete the `handlePerformPasskeyLogin` function (originally lines 56-58)
 - Let's also remove the "Login with passkey" button (originally lines 74-76)
@@ -577,14 +595,12 @@ Now, we need to clean up our unused imports. Within our IDE, these should be gra
 "use client";
 
 import { useState, useTransition } from "react";
-import {
-  startRegistration,
-} from "@simplewebauthn/browser";
+import { startRegistration } from "@simplewebauthn/browser";
 import {
   finishPasskeyRegistration,
   startPasskeyRegistration,
 } from "./functions";
-import { useTurnstile } from "@redwoodjs/sdk/turnstile";
+import { useTurnstile } from "rwsdk/turnstile";
 import { Button } from "@/app/components/ui/button";
 
 // >>> Replace this with your own Cloudflare Turnstile site key
@@ -638,7 +654,6 @@ export function Signup() {
 ```
 
 </details>
-
 
 Now, let's do the opposite for our `Login.tsx`.
 
@@ -703,6 +718,7 @@ export function LoginPage() {
   );
 }
 ```
+
 </details>
 
 Now, let's test our code:
@@ -744,6 +760,7 @@ Now, navigate to http://localhost:2332/. You should see a message that you're lo
 ![](./images/home-page-logged-in-as.png)
 
 Did you realize we haven't been able to access the home page before because it was protected by an interruptor?
+
 <details>
 <summary>Interruptor code (`worker.tsx`, lines 35-42)</summary>
 
@@ -760,6 +777,7 @@ index([
   Home,
 ]),
 ```
+
 </details>
 
 Try logging out, by going to http://localhost:2332/user/logout. You should be redirected to the login page.
@@ -771,6 +789,7 @@ Login and then you can visit the home page again.
 😎 Cool, right?
 
 ## Styling the Login Page
+
 Now that we know our authentication code is working, let's add some styles and make it look good.
 
 If we take a look at [the final design within Figma](https://www.figma.com/design/nqBPIIfe0MO4W8zOfW4oae/RedwoodSDK-%2F-Applywize?node-id=239-604&t=AzaW01lRe7c80zl2-1), this is what we're aiming for:
@@ -789,8 +808,8 @@ When we installed shadcn/ui, it added a lot of variables to the bottom of our `s
 <summary>Updated `styles.css` file</summary>
 
 ```css title="src/app/styles.css"
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@500;700&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@500;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap");
 
 @import "tailwindcss";
 
@@ -936,6 +955,7 @@ body {
   --color-tag-offer: #aae198;
 }
 ```
+
 </details>
 
 If you take a look in the browser, by changing the position of the `@theme` block, it also changed the button's background color to yellow, our primary color. Perfect.
@@ -944,12 +964,7 @@ If you take a look in the browser, by changing the position of the `@theme` bloc
 
 Now, let's start on our layout component. Inside our `app` directory, create a new folder called `layouts`. Then, a new file called `AuthLayout.tsx`:
 
-<FileTree>
-- src
-  - app
-    - layouts
-      - AuthLayout.tsx
-</FileTree>
+<FileTree>- src - app - layouts - AuthLayout.tsx</FileTree>
 
 Let's start by stubbing out our component:
 
@@ -978,7 +993,7 @@ Inside our `Login` component let's replace our `main` tag with our `AuthLayout` 
 ```tsx title="src/app/pages/user/Login.tsx" {2,15} startLineNumber=37
 return (
   <AuthLayout>
-  <h1 className="text-4xl font-bold text-red-500">YOLO</h1>
+    <h1 className="text-4xl font-bold text-red-500">YOLO</h1>
     <div ref={turnstile.ref} />
     <input
       type="text"
@@ -991,7 +1006,7 @@ return (
     </Button>
     {result && <div>{result}</div>}
   </AuthLayout>
-)
+);
 ```
 
 If we head over to the browser, we should see something like this:
@@ -1026,13 +1041,7 @@ For the column on the left, we have a repeating background image. You can export
 
 Inside the root of our project, create a new folder called `public`. Inside, I'm going to create another folder called `images` and drop the image inside.
 
-<FileTree>
-- public/
-  - images/
-    - bg.png
-    - logo.svg
-- src/
-</FileTree>
+<FileTree>- public/ - images/ - bg.png - logo.svg - src/</FileTree>
 
 While we're here, let's also grab the logo. I'm only going to grab the owl. We can use "Apply Wize" text and style it with CSS. This will give us a little more control over the display (horizontal or stacked) without having to use two separate images. You can export the owl as an SVG (or [download it directly](https://github.com/ahaywood/applywize/tree/main/assets)).
 
@@ -1086,13 +1095,9 @@ Now, we can use this on both of our columns:
   <div className="grid grid-cols-2 min-h-[calc(100vh-96px)] rounded-xl border-2 border-[#D6D5C5]">
     <div className="center bg-[url('/images/bg.png')] bg-repeat rounded-l-xl">
       <img src="/images/logo.svg" alt="Apply Wize" />
-      <div>
-        Apply Wize
-      </div>
+      <div>Apply Wize</div>
     </div>
-    <div className="center">
-      {children}
-    </div>
+    <div className="center">{children}</div>
   </div>
 </div>
 ```
@@ -1108,9 +1113,7 @@ It's centering our content, but it's also horizontally aligning everything. Let'
       <div className="center">
         <div>
           <img src="/images/logo.svg" alt="Apply Wize" />
-          <div className="text-5xl text-white font-bold">
-            Apply Wize
-          </div>
+          <div className="text-5xl text-white font-bold">Apply Wize</div>
         </div>
       </div>
     </div>
@@ -1154,9 +1157,7 @@ We want this to be fixed to the bottom of the left column. So, this needs to be 
 <div className="center bg-[url('/images/bg.png')] bg-repeat rounded-l-xl">
   <div>
     <img src="/images/logo.svg" alt="Apply Wize" className="mx-auto" />
-    <div className="text-5xl text-white font-bold">
-      Apply Wize
-    </div>
+    <div className="text-5xl text-white font-bold">Apply Wize</div>
   </div>
   <div>“Transform the job hunt from a maze into a map.”</div>
 </div>
@@ -1228,9 +1229,6 @@ Now, let's style the right side. This is easy!
 ---
 ```
 
-
-
-
 ![](./images/authlayout-styling-complete.png)
 
 The styling for auth layout component is complete, but there's still one thing bothering me. (And maybe it's been bothering you too.)
@@ -1253,6 +1251,7 @@ When setting the type for `children` within React, you'll see `React.ReactNode`,
 > - `JSX.Element` and `React.ReactElement` are functionally the same type. They can be used interchangeably. They represent the thing that a JSX expression creates.
 > - They can't be used to represent all the things that React can render, like strings and numbers. For that, use `React.ReactNode.`
 > - In everyday use, you should use `React.ReactNode`. You rarely need to use the more specific type of `JSX.Element`.
+
 </Aside>
 
 <details>
@@ -1266,9 +1265,7 @@ const AuthLayout = ({ children }: { children: React.ReactNode }) => {
         <div className="relative center bg-[url('/images/bg.png')] bg-repeat rounded-l-xl">
           <div className="-top-[100px] relative">
             <img src="/images/logo.svg" alt="Apply Wize" className="mx-auto" />
-            <div className="text-5xl text-white font-bold">
-              Apply Wize
-            </div>
+            <div className="text-5xl text-white font-bold">Apply Wize</div>
           </div>
           <div className="text-white text-sm absolute bottom-0 left-0 right-0 p-10">
             “Transform the job hunt from a maze into a map.”
@@ -1284,6 +1281,7 @@ const AuthLayout = ({ children }: { children: React.ReactNode }) => {
 
 export { AuthLayout };
 ```
+
 </details>
 
 ### Styling the Login Content
@@ -1351,11 +1349,20 @@ Next up, let's wrap all of our form content with a `div` and add the text at the
 Let's also add some text below our form:
 
 ```tsx title="src/app/pages/user/Login.tsx" startLineNumber=68 {5}
-<Button onClick={handlePerformPasskeyLogin} disabled={isPending} className="font-display w-full mb-6">
-    {isPending ? <>...</> : "Login with passkey"}
-  </Button>
-  {result && <div>{result}</div>}
-  <p>By clicking continue, you agree to our <a href="#">Terms of Service</a> and <a href="#">Privacy Policy</a>.</p>
+<Button
+  onClick={handlePerformPasskeyLogin}
+  disabled={isPending}
+  className="font-display w-full mb-6"
+>
+  {isPending ? <>...</> : "Login with passkey"}
+</Button>;
+{
+  result && <div>{result}</div>;
+}
+<p>
+  By clicking continue, you agree to our <a href="#">Terms of Service</a> and{" "}
+  <a href="#">Privacy Policy</a>.
+</p>;
 ```
 
 I want to add some more styling, but I want to be able to reuse these styles on our Signup page, so let's stick these updates inside our `styles.css` file.
@@ -1363,6 +1370,7 @@ I want to add some more styling, but I want to be able to reuse these styles on 
 In CSS order matters. The [`@layer` CSS at-rule](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer) makes it easy to declare a _layer_ and set the order of preference.
 
 I like to order my CSS:
+
 1. **Base styles** are at the top. These are for styling generic HTML elements. No classes, just tags.
 2. **Component styles.** These are for styling classes that get used across multiple components and pages.
 3. **Page specific styles.** These are for styling elements on a specific page.
@@ -1374,34 +1382,45 @@ At the very bottom of our `styles.css` file, let's start by setting up `@layer` 
 ```css title="src/styles.css" startLineNumber=238
 @layer base, components, page;
 
-@layer base {}
+@layer base {
+}
 
-@layer components {}
+@layer components {
+}
 
-@layer page {}
+@layer page {
+}
 ```
 
 <Aside type="tip" title="CSS Layers">
 Do these `@layer` names give you déjà vu? Feels similar to Tailwind v3? It's the exact same concept! Since these layers [are no longer established in Tailwind v4](https://tailwindcss.com/docs/upgrade-guide#removed-tailwind-directives), we have to define the order ourselves: `@layer base, components, page;`
 
 Technically, we could list our layers in any order we want:
+
 ```css showLineNumbers=false
-@layer page {}
-@layer components {}
-@layer base {}
+@layer page {
+}
+@layer components {
+}
+@layer base {
+}
 ```
 
 It will still be applied in the correct order, because we explicitly defined the order:
+
 ```css showLineNumbers=false
 @layer base, components, page;
 ```
+
 </Aside>
 
 For all our headings (`h1, h2, h3, etc.`), we want to use the font Poppins, `font-display`, and make it bold `font-bold`. Let's stick this inside our base layer:
 
 ```css title="src/styles.css" showLineNumbers=false
 @layer base {
-  h1, h2, h3 {
+  h1,
+  h2,
+  h3 {
     @apply font-display font-bold;
   }
 }
@@ -1578,11 +1597,19 @@ But, there's one more thing. Let's move the `result` message above the form and 
     onChange={(e) => setUsername(e.target.value)}
     placeholder="Username"
   />
-  <Button onClick={handlePerformPasskeyLogin} disabled={isPending} className="font-display w-full mb-6">
+  <Button
+    onClick={handlePerformPasskeyLogin}
+    disabled={isPending}
+    className="font-display w-full mb-6"
+  >
     {isPending ? <>...</> : "Login with Passkey"}
   </Button>
 
-  <p>By clicking continue, you agree to our <a href={link('/legal/terms')}>Terms of Service</a> and <a href={link('/legal/privacy')}>Privacy Policy</a>.</p>
+  <p>
+    By clicking continue, you agree to our 
+    <a href={link("/legal/terms")}>Terms of Service</a> and 
+    <a href={link("/legal/privacy")}>Privacy Policy</a>.
+  </p>
 </div>
 ```
 
@@ -1695,7 +1722,11 @@ As you type, you should see VS Code make recommendations based on the contents o
 We can make similar changes to our **Terms of Service** and **Privacy Policy** links:
 
 ```tsx title="src/app/pages/user/Login.tsx" "{link("/legal/terms")}" "link("/legal/privacy")" startLineNumber=70
-<p>By clicking continue, you agree to our <a href={link("/legal/terms")}>Terms of Service</a> and <a href={link("/legal/privacy")}>Privacy Policy</a>.</p>
+<p>
+  By clicking continue, you agree to our{" "}
+  <a href={link("/legal/terms")}>Terms of Service</a> and{" "}
+  <a href={link("/legal/privacy")}>Privacy Policy</a>.
+</p>
 ```
 
 If you check your work in the browser, the register link works great, but our Terms of Service and Privacy Policy links go to a Not Found page. Let's fix that.
@@ -1770,18 +1801,14 @@ Now, if you check your work in the browser, you should see the Terms of Service 
 ![](./images/working-terms-page.png)
 
 <Aside type="note" title="Alternate way of displaying our legal routes">
-  When we listed our legal routes, we listed them individually:
-  ```tsx title="src/worker.tsx" startLineNumber=18 {46}
-  route("/legal/privacy", () => <h1>Privacy Policy</h1>),
-  route("/legal/terms", () => <h1>Terms of Service</h1>),
-  ```
-  But, we could also group them together, with a `prefix` (similar to our `/user` routes, but a little different):
-  ```tsx title="src/worker.tsx" startLineNumber=18
-  prefix("/legal", [
-    route("/privacy", () => <h1>Privacy Policy</h1>),
-    route("/terms", () => <h1>Terms of Service</h1>),
-  ]),
-  ```
+  When we listed our legal routes, we listed them individually: ```tsx
+  title="src/worker.tsx" startLineNumber=18 {46}
+  route("/legal/privacy", () => <h1>Privacy Policy</h1>), route("/legal/terms",
+  () => <h1>Terms of Service</h1>), ``` But, we could also group them together,
+  with a `prefix` (similar to our `/user` routes, but a little different):
+  ```tsx title="src/worker.tsx" startLineNumber=18 prefix("/legal", [
+  route("/privacy", () => <h1>Privacy Policy</h1>), route("/terms", () =>{" "}
+  <h1>Terms of Service</h1>), ]), ```
 </Aside>
 
 We've touched a few files, if you want to see the full code for each:
@@ -1804,7 +1831,7 @@ import {
   startPasskeyLogin,
   startPasskeyRegistration,
 } from "./functions";
-import { useTurnstile } from "@redwoodjs/sdk/turnstile";
+import { useTurnstile } from "rwsdk/turnstile";
 import { AuthLayout } from "@/app/layouts/AuthLayout";
 import { Button } from "@/app/components/ui/button";
 import { Alert, AlertTitle } from "@/app/components/ui/alert";
@@ -1847,14 +1874,17 @@ export function Login() {
         <p className="py-6">Enter your username below to sign-in.</p>
 
         {result && (
-        <Alert variant="destructive" className="mb-5">
-          <AlertCircle className="h-4 w-4"/>
-          <AlertTitle>{result}</AlertTitle>
-        </Alert>
+          <Alert variant="destructive" className="mb-5">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>{result}</AlertTitle>
+          </Alert>
         )}
 
         <div className="absolute top-0 right-0 p-10">
-          <a href={link("/user/signup")} className="font-display font-bold text-black text-sm underline underline-offset-8 hover:decoration-primary">
+          <a
+            href={link("/user/signup")}
+            className="font-display font-bold text-black text-sm underline underline-offset-8 hover:decoration-primary"
+          >
             Register
           </a>
         </div>
@@ -1865,11 +1895,19 @@ export function Login() {
           onChange={(e) => setUsername(e.target.value)}
           placeholder="Username"
         />
-        <Button onClick={handlePerformPasskeyLogin} disabled={isPending} className="font-display w-full mb-6">
+        <Button
+          onClick={handlePerformPasskeyLogin}
+          disabled={isPending}
+          className="font-display w-full mb-6"
+        >
           {isPending ? <>...</> : "Login with passkey"}
         </Button>
 
-        <p>By clicking continue, you agree to our <a href={link("/legal/terms")}>Terms of Service</a> and <a href={link("/legal/privacy")}>Privacy Policy</a>.</p>
+        <p>
+          By clicking continue, you agree to our{" "}
+          <a href={link("/legal/terms")}>Terms of Service</a> and{" "}
+          <a href={link("/legal/privacy")}>Privacy Policy</a>.
+        </p>
       </div>
     </AuthLayout>
   );
@@ -1882,39 +1920,36 @@ export function Login() {
 <summary>Final code for our `AuthLayout.tsx`</summary>
 
 ```tsx title="src/app/layouts/AuthLayout.tsx"
-const AuthLayout = ({ children }: { children: React.ReactNode}) => {
+const AuthLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <div className="bg-bg min-h-screen min-w-screen p-12">
       <div className="grid grid-cols-2 min-h-[calc(100vh-96px)] rounded-xl border-2 border-[#D6D5C5]">
         <div className="relative center bg-[url('/images/bg.png')] bg-repeat rounded-l-xl">
           <div className="-top-[100px] relative">
             <img src="/images/logo.svg" alt="Apply Wize" className="mx-auto" />
-            <div className="text-5xl text-white font-bold">
-              Apply Wize
-            </div>
+            <div className="text-5xl text-white font-bold">Apply Wize</div>
           </div>
           <div className="text-white text-sm absolute bottom-0 left-0 right-0 p-10">
             “Transform the job hunt from a maze into a map.”
           </div>
         </div>
-        <div className="center bg-white rounded-r-xl relative">
-          {children}
-        </div>
+        <div className="center bg-white rounded-r-xl relative">{children}</div>
       </div>
     </div>
-  )
-}
+  );
+};
 
-export { AuthLayout }
+export { AuthLayout };
 ```
+
 </details>
 
 <details>
 <summary>Final code for our `styles.css`</summary>
 
 ```css title="src/styles.css"
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@500;700&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@500;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap");
 
 @import "tailwindcss";
 @import "tw-animate-css";
@@ -1926,7 +1961,6 @@ body {
 }
 
 @theme inline {
-
   --radius-sm: calc(var(--radius) - 4px);
 
   --radius-md: calc(var(--radius) - 2px);
@@ -1999,7 +2033,6 @@ body {
 }
 
 :root {
-
   --radius: 0.625rem;
 
   --background: oklch(1 0 0);
@@ -2066,7 +2099,6 @@ body {
 }
 
 .dark {
-
   --background: oklch(0.145 0 0);
 
   --foreground: oklch(0.985 0 0);
@@ -2153,7 +2185,6 @@ body {
 @layer base, components, page;
 
 @layer base {
-
   h1,
   h2,
   h3 {
@@ -2163,12 +2194,11 @@ body {
 
 @layer components {
   .page-title {
-    @apply text-3xl
+    @apply text-3xl;
   }
 }
 
 @layer page {
-
   /* login page */
   .auth-form {
     p {
@@ -2200,6 +2230,7 @@ body {
   }
 }
 ```
+
 </details>
 
 <details>
@@ -2208,11 +2239,11 @@ body {
 ```tsx title="src/components/ui/button.tsx"
 "use client";
 
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
   "font-bold inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
@@ -2242,8 +2273,8 @@ const buttonVariants = cva(
       variant: "default",
       size: "default",
     },
-  }
-)
+  },
+);
 
 function Button({
   className,
@@ -2253,9 +2284,9 @@ function Button({
   ...props
 }: React.ComponentProps<"button"> &
   VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
+    asChild?: boolean;
   }) {
-  const Comp = asChild ? Slot : "button"
+  const Comp = asChild ? Slot : "button";
 
   return (
     <Comp
@@ -2263,11 +2294,12 @@ function Button({
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
-  )
+  );
 }
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };
 ```
+
 </details>
 
 <details>
@@ -2284,14 +2316,15 @@ export const link = defineLinks([
   "/legal/terms",
 ]);
 ```
+
 </details>
 
 <details>
 <summary>Final code for our `worker.tsx`</summary>
 
 ```tsx title="src/worker.tsx"
-import { defineApp, ErrorResponse } from "@redwoodjs/sdk/worker";
-import { route, render, prefix } from "@redwoodjs/sdk/router";
+import { defineApp, ErrorResponse } from "rwsdk/worker";
+import { route, render, prefix } from "rwsdk/router";
 import { Document } from "@/app/Document";
 import { Home } from "@/app/pages/Home";
 import { setCommonHeaders } from "@/app/headers";
@@ -2357,8 +2390,8 @@ export default defineApp([
   ]),
 ]);
 ```
-</details>
 
+</details>
 
 ## Styling the Signup Page
 
@@ -2420,6 +2453,7 @@ Next, let's wrap all of our form content with a `div`:
 ```
 
 We can get rid of our red YOLO heading at the top and replace it with:
+
 ```tsx title="src/app/pages/user/Signup.tsx" startLineNumber=63
 <h1 className="page-title text-center">Create an Account</h1>
 <p className="py-6">Enter a username to setup an account.</p>
@@ -2458,7 +2492,11 @@ Jumping down a little bit, on our `Button` component, let's add a few classes to
 Then, right below the button, we can add our legal statement:
 
 ```tsx title="src/app/pages/user/Signup.tsx" startLineNumber=87
-<p>By clicking continue, you agree to our <a href={link('/legal/terms')}>Terms of Service</a> and <a href={link('/legal/privacy')}>Privacy Policy</a>.</p>
+<p>
+  By clicking continue, you agree to our 
+  <a href={link("/legal/terms")}>Terms of Service</a> and 
+  <a href={link("/legal/privacy")}>Privacy Policy</a>.
+</p>
 ```
 
 ![](./images/final-signup-page.png)
@@ -2472,9 +2510,7 @@ See, I told you! Easy peasy. 🍋
 "use client";
 
 import { useState, useTransition } from "react";
-import {
-  startRegistration,
-} from "@simplewebauthn/browser";
+import { startRegistration } from "@simplewebauthn/browser";
 import {
   finishPasskeyRegistration,
   startPasskeyRegistration,
@@ -2520,7 +2556,10 @@ export function SignupPage() {
   return (
     <AuthLayout>
       <div className="absolute top-0 right-0 p-10">
-        <a href={link('/user/login')} className="font-display font-bold text-black text-sm underline underline-offset-8 hover:decoration-primary">
+        <a
+          href={link("/user/login")}
+          className="font-display font-bold text-black text-sm underline underline-offset-8 hover:decoration-primary"
+        >
           Login
         </a>
       </div>
@@ -2531,7 +2570,7 @@ export function SignupPage() {
 
         {result && (
           <Alert variant="destructive" className="mb-5">
-            <AlertCircle className="h-4 w-4"/>
+            <AlertCircle className="h-4 w-4" />
             <AlertTitle>{result}</AlertTitle>
           </Alert>
         )}
@@ -2543,23 +2582,32 @@ export function SignupPage() {
           onChange={(e) => setUsername(e.target.value)}
           placeholder="Username"
         />
-        <Button onClick={handlePerformPasskeyRegister} disabled={isPending} className="font-display w-full mb-6">
+        <Button
+          onClick={handlePerformPasskeyRegister}
+          disabled={isPending}
+          className="font-display w-full mb-6"
+        >
           {isPending ? <>...</> : "Register with Passkey"}
         </Button>
 
-        <p>By clicking continue, you agree to our <a href={link('/legal/terms')}>Terms of Service</a> and <a href={link('/legal/privacy')}>Privacy Policy</a>.</p>
+        <p>
+          By clicking continue, you agree to our 
+          <a href={link("/legal/terms")}>Terms of Service</a> and 
+          <a href={link("/legal/privacy")}>Privacy Policy</a>.
+        </p>
       </div>
     </AuthLayout>
   );
 }
 ```
+
 </details>
 
 <Aside type="tip" title="Code on GitHub">
-You can find the final code for this step on [GitHub](https://github.com/ahaywood/applywize/tree/main/end-of-4).
+  You can find the final code for this step on
+  [GitHub](https://github.com/ahaywood/applywize/tree/main/end-of-4).
 </Aside>
 
 ## Further reading
 
 - An even more [detailed guide to how Authentication works and the reasoning behind some of the decisions we made](/core/authentication)
-

--- a/docs/src/content/docs/tutorial/full-stack-app/4-auth.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/4-auth.mdx
@@ -34,8 +34,8 @@ Passkey authentication offers several key advantages:
 Let's start by taking a look at the `worker.tsx` file. This file sets up our Cloudflare worker, but it also handles all the routing, middleware, and interrupters.
 
 ```tsx title="src/worker.tsx" collapse={1-12}
-import { defineApp, ErrorResponse } from "@redwoodjs/sdk/worker";
-import { route, render, prefix } from "@redwoodjs/sdk/router";
+import { defineApp, ErrorResponse } from "rwsdk/worker";
+import { route, render, prefix } from "rwsdk/router";
 import { Document } from "@/app/Document";
 import { Home } from "@/app/pages/Home";
 import { setCommonHeaders } from "@/app/headers";
@@ -176,7 +176,7 @@ route("/", Home),
 We can also change the home page route to use the `index` method:
 
 ```tsx title="src/worker.tsx" showLineNumbers={false}
-import { index, route, render, prefix } from "@redwoodjs/sdk/router";
+import { index, route, render, prefix } from "rwsdk/router";
 ...
 index([Home]);
 ```
@@ -236,7 +236,7 @@ We're co-locating the file that defines our auth routes with our auth pages.
 Let's take a look at `userRoutes`. This is coming from `src/app/pages/user/routes.tsx`.
 
 ```tsx title="src/app/pages/user/routes.tsx"
-import { route } from "@redwoodjs/sdk/router";
+import { route } from "rwsdk/router";
 import { Login } from "./Login";
 import { sessions } from "@/session/store";
 
@@ -277,7 +277,7 @@ export const Signup = () => {
 Now, we need to add this route to our `userRoutes` array (inside of `src/app/pages/user/routes.ts`):
 
 ```tsx title="src/app/pages/user/routes.ts" {3,8}
-import { route } from "@redwoodjs/sdk/router";
+import { route } from "rwsdk/router";
 import { Login } from "./Login";
 import { Signup } from "./Signup";
 import { sessions } from "@/session/store";
@@ -321,7 +321,7 @@ import {
   startPasskeyLogin,
   startPasskeyRegistration,
 } from "./functions";
-import { useTurnstile } from "@redwoodjs/sdk/turnstile";
+import { useTurnstile } from "rwsdk/turnstile";
 import { Button } from "@/app/components/ui/button";
 // >>> Replace this with your own Cloudflare Turnstile site key
 const TURNSTILE_SITE_KEY = "0x4AAAAAABBM92GLK3VnyFAr";
@@ -584,7 +584,7 @@ import {
   finishPasskeyRegistration,
   startPasskeyRegistration,
 } from "./functions";
-import { useTurnstile } from "@redwoodjs/sdk/turnstile";
+import { useTurnstile } from "rwsdk/turnstile";
 import { Button } from "@/app/components/ui/button";
 
 // >>> Replace this with your own Cloudflare Turnstile site key
@@ -1804,7 +1804,7 @@ import {
   startPasskeyLogin,
   startPasskeyRegistration,
 } from "./functions";
-import { useTurnstile } from "@redwoodjs/sdk/turnstile";
+import { useTurnstile } from "rwsdk/turnstile";
 import { AuthLayout } from "@/app/layouts/AuthLayout";
 import { Button } from "@/app/components/ui/button";
 import { Alert, AlertTitle } from "@/app/components/ui/alert";
@@ -2290,8 +2290,8 @@ export const link = defineLinks([
 <summary>Final code for our `worker.tsx`</summary>
 
 ```tsx title="src/worker.tsx"
-import { defineApp, ErrorResponse } from "@redwoodjs/sdk/worker";
-import { route, render, prefix } from "@redwoodjs/sdk/router";
+import { defineApp, ErrorResponse } from "rwsdk/worker";
+import { route, render, prefix } from "rwsdk/router";
 import { Document } from "@/app/Document";
 import { Home } from "@/app/pages/Home";
 import { setCommonHeaders } from "@/app/headers";

--- a/docs/src/content/docs/tutorial/full-stack-app/5-jobs-list.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/5-jobs-list.mdx
@@ -6,7 +6,7 @@ sidebar:
 description: A guide in my new Starlight docs site.
 ---
 
-import { Aside, FileTree } from '@astrojs/starlight/components';
+import { Aside, FileTree } from "@astrojs/starlight/components";
 
 The jobs application list page lists all the jobs that we've applied for. For this tutorial, it will also serve as the Dashboard.
 
@@ -21,25 +21,17 @@ But, first, we need a page and a route.
 In the `src > app > pages` directory, create a new folder called `applications`. Inside, create a file called `List.tsx`.
 
 <FileTree>
-- src/
-  - app/
-    - pages/
-      - applications/
-        - List.tsx
-      - auth/
-      - Home.tsx
+  - src/ - app/ - pages/ - applications/ - List.tsx - auth/ - Home.tsx
 </FileTree>
 
 We can stub out a basic page, just to make sure it's loading correctly.
 
 ```tsx title="src/app/pages/applications/List.tsx"
 const List = () => {
-  return (
-    <div>List</div>
-  )
-}
+  return <div>List</div>;
+};
 
-export { List }
+export { List };
 ```
 
 Now, within our `worker.tsx` file, we can add a route for our new page.
@@ -72,8 +64,10 @@ prefix("/applications", [
           headers: { Location: "/user/login" },
         });
       }
-    }, List]),
-])
+    },
+    List,
+  ]),
+]);
 ```
 
 This would get cumbersome (and annoying) if we have to do this for every.single.route we wanted to protect. Let's abstract this code into a reusable function.
@@ -95,9 +89,7 @@ We're passing in the `ctx` that we get with each request. Then, we're checking t
 Then, we can update our `/applications` route to use `isAuthenticated`:
 
 ```tsx startLineNumber=75
-prefix("/applications", [
-  route("/", [isAuthenticated, List]),
-])
+prefix("/applications", [route("/", [isAuthenticated, List])]);
 ```
 
 Now, we can also update our protected page route to use the `isAuthenticated` function, too:
@@ -121,18 +113,16 @@ index([ isAuthenticated, Home ]),
 Be sure to import `index` at the top of the file:
 
 ```tsx startLineNumber=2 "index"
-import { route, render, prefix, index } from "@redwoodjs/sdk/router";
+import { route, render, prefix, index } from "rwsdk/router";
 ```
 
 Test it out. 👨‍🍳 Chef's kiss! If you're logged in, you should see the "List" text. If you're not logged in, you'll be redirected to the login page.
 
 <Aside type="tip" title="Using multiple layers of Middleware">
-  You can use multiple layers of middleware, by continuing to write functions and adding them to the array. They'll run in the order they're listed. For example:
-  ```tsx
-  prefix("/applications", [
-    route("/", [isAuthenticated, isAdmin, List]),
-  ])
-  ```
+  You can use multiple layers of middleware, by continuing to write functions
+  and adding them to the array. They'll run in the order they're listed. For
+  example: ```tsx prefix("/applications", [ route("/", [isAuthenticated,
+  isAdmin, List]), ]) ```
 </Aside>
 
 Now, let's get some data into the database.
@@ -140,6 +130,7 @@ Now, let's get some data into the database.
 We can do this one of two ways:
 
 ### Option 1: Create a Seed File
+
 [Earlier, I mentioned that sometimes I'll create multiple seed files with various purposes.](/tutorial/full-stack-app/database-setup#seed-the-database). This is a perfect opportunity to create a separate file just for adding job applications to our database.
 
 Inside the `src/scripts` directory, create a new file called `applicationSeed.ts`.
@@ -147,7 +138,7 @@ Inside the `src/scripts` directory, create a new file called `applicationSeed.ts
 Let's stub it out:
 
 ```tsx title="src/scripts/applicationSeed.ts"
-import { defineScript } from "@redwoodjs/sdk/worker";
+import { defineScript } from "rwsdk/worker";
 import { db, setupDb } from "@/db";
 
 export default defineScript(async ({ env }) => {
@@ -265,7 +256,7 @@ This time instead of using an object with a `connect` key, we'll use a `create` 
 <summary>Complete applicationSeed.ts file</summary>
 
 ```tsx title="src/scripts/applicationSeed.ts"
-import { defineScript } from "@redwoodjs/sdk/worker";
+import { defineScript } from "rwsdk/worker";
 import { db, setupDb } from "@/db";
 
 export default defineScript(async ({ env }) => {
@@ -303,7 +294,7 @@ export default defineScript(async ({ env }) => {
         jobDescription: "Software Engineer",
         postingUrl: "https://redwoodjs.com",
         dateApplied: new Date(),
-      }
+      },
     });
   };
 
@@ -322,12 +313,12 @@ Prisma also has a `createMany` function where you can create multiple entries at
 - There's limited support for complex relational constraints and upsert operations.
 
 For reference: [`createMany` on Prisma's Documentation](https://www.prisma.io/docs/orm/prisma-client/queries/crud#create-multiple-records)
+
 </Aside>
 
 <Aside type="note" title="`skipDuplicates` is not supported">
-Since our database is a sqlite database, `skipDuplicates` is not supported.
+  Since our database is a sqlite database, `skipDuplicates` is not supported.
 </Aside>
-
 
 To run the seed file, within the Terminal:
 
@@ -405,7 +396,8 @@ Notice, we also made our `List` function an `async` function. We need to `await`
 ```
 
 <Aside type="note" title="Using `db`">
-Note, it's `db` then the name of the table. In this case, `application`. But, this could just as easily be `company`, `contact`, `status`, or `user`.
+  Note, it's `db` then the name of the table. In this case, `application`. But,
+  this could just as easily be `company`, `contact`, `status`, or `user`.
 </Aside>
 
 All the data from the database is returned as an array and saved in a variable called `applications`. Then, we can display all the data by using the `JSON.stringify` function. Wrapping our code in `pre` tags, it makes it easier to read.
@@ -417,6 +409,7 @@ All the data from the database is returned as an array and saved in a variable c
 - `2` specifies the number of spaces to use for indentation.
 
 [For reference: JSON.Stringify on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)
+
 </Aside>
 
 ![](./images/applications-list-json.png)
@@ -444,11 +437,7 @@ Similar to the auth pages, let's start by creating a layout that will wrap all o
 Inside our `layouts` folder, let's create a new file called `InteriorLayout.tsx`.
 
 <FileTree>
-- src/
-  - app/
-    - layouts/
-      - AuthLayout.tsx
-      - InteriorLayout.tsx
+  - src/ - app/ - layouts/ - AuthLayout.tsx - InteriorLayout.tsx
 </FileTree>
 
 Inside, we need should use some of the same styles that we used within our `AuthLayout.tsx` file. As a quick reminder, let's take a look at the `AuthLayout.tsx` file:
@@ -497,16 +486,17 @@ Then, let's do something similar with the child `div` from our `AuthLayout.tsx`.
   }
 
   .page-title {
-    @apply text-3xl
+    @apply text-3xl;
   }
 }
 ```
+
 </details>
 
 Let's also add our route to our `links.ts` file for type hinting:
 
 ```tsx title="src/app/shared/links.ts" collapse={4-9}
-import { defineLinks } from "@redwoodjs/sdk/router";
+import { defineLinks } from "rwsdk/router";
 
 export const link = defineLinks([
   "/",
@@ -555,19 +545,14 @@ return (
   <InteriorLayout>
     <pre>{JSON.stringify(applications, null, 2)}</pre>
   </InteriorLayout>
-)
+);
 ```
 
 ![](./images/applications-json-with-interior-layout.png)
 
 It's coming together! Across the top, let's add the logo and navigation. We may need to reuse this component in the future, so let's make it it's own component. Inside the `components` folder, let's create a new file called `Header.tsx`.
 
-<FileTree>
-- src/
-  - app/
-    - components/
-      - Header.tsx
-</FileTree>
+<FileTree>- src/ - app/ - components/ - Header.tsx</FileTree>
 
 ```tsx title="src/app/components/Header.tsx"
 const Header = () => {
@@ -596,25 +581,30 @@ Here are the basic building blocks we need.
 Inside the left `div`, let's add the logo and "Apply Wize" text and wrap it in a link:
 
 ```tsx title="src/app/components/Header.tsx" startLineNumber=5
-{/* left side */}
+{
+  /* left side */
+}
 <div>
   <a href={link("/")}>
     <img src="/images/logo.svg" alt="Apply Wize" />
     <span>Apply Wize</span>
   </a>
-</div>
+</div>;
 ```
 
 - Pretty straightforward. We're using the same `logo.svg` that we used on the auth pages. It should already be in your `public/images` folder.
 - Then, we're using the `link` helper to link to home page. At the top of your file, you'll need to import the `link` helper:
+
 ```tsx
-import { link } from '@/app/shared/links'
+import { link } from "@/app/shared/links";
 ```
 
 Now, let's add the navigation. For now this is only one link that goes to the dashboard page.
 
 ```tsx title="src/app/components/Header.tsx" collapse={3-6} {7-11}
-{/* left side */}
+{
+  /* left side */
+}
 <div>
   <a href={link("/")}>
     <img src="/images/logo.svg" alt="Apply Wize" />
@@ -622,27 +612,35 @@ Now, let's add the navigation. For now this is only one link that goes to the da
   </a>
   <nav>
     <ul>
-      <li><a href={link("/applications")}>Dashboard</a></li>
+      <li>
+        <a href={link("/applications")}>Dashboard</a>
+      </li>
     </ul>
   </nav>
-</div>
+</div>;
 ```
 
 For the right side, we want another unordered list and the Avatar component:
 
 ```tsx title="src/app/components/Header.tsx" startLineNumber=19
-{/* right side */}
+{
+  /* right side */
+}
 <nav>
   <ul>
-    <li><a href="#">Settings</a></li>
-    <li><a href={link("/user/logout")}>Logout</a></li>
+    <li>
+      <a href="#">Settings</a>
+    </li>
+    <li>
+      <a href={link("/user/logout")}>Logout</a>
+    </li>
     <li>
       <Avatar>
         <AvatarFallback>R</AvatarFallback>
       </Avatar>
     </li>
   </ul>
-</nav>
+</nav>;
 ```
 
 - Notice, I replaced the right side `div` with a `nav` element, keeping things nice and semantic.
@@ -650,7 +648,7 @@ For the right side, we want another unordered list and the Avatar component:
 - For the `Avatar` component, you'll need to import it at the top of your file. This is a shadcn/ui component, so it should already be part of your project.
 
 ```tsx showLineNumbers=false
-import { Avatar, AvatarFallback } from '@/app/components/ui/avatar'
+import { Avatar, AvatarFallback } from "@/app/components/ui/avatar";
 ```
 
 Normally, when you're using the `Avatar` component, you'll also want to use the `AvatarImage` component. This is where you define the Avatar image:
@@ -791,21 +789,26 @@ That should be it! (for the header at least)
 <summary>Finished `Header.tsx` component</summary>
 
 ```tsx title="src/app/components/Header.tsx"
-import { link } from '@/app/shared/links'
-import { Avatar, AvatarFallback } from './ui/avatar'
+import { link } from "@/app/shared/links";
+import { Avatar, AvatarFallback } from "./ui/avatar";
 
 const Header = () => {
   return (
     <header className="py-5 px-page-side h-20 flex justify-between items-center border-b-1 border-border mb-12">
       {/* left side */}
       <div className="flex items-center gap-8">
-        <a href={link("/")} className="flex items-center gap-3 font-display font-bold text-3xl">
+        <a
+          href={link("/")}
+          className="flex items-center gap-3 font-display font-bold text-3xl"
+        >
           <img src="/images/logo.svg" alt="Apply Wize" className="pt-5 -mb-3" />
           <span>Apply Wize</span>
         </a>
         <nav>
           <ul>
-            <li><a href={link("/applications")}>Dashboard</a></li>
+            <li>
+              <a href={link("/applications")}>Dashboard</a>
+            </li>
           </ul>
         </nav>
       </div>
@@ -813,8 +816,12 @@ const Header = () => {
       {/* right side */}
       <nav>
         <ul className="flex items-center gap-7">
-          <li><a href="#">Settings</a></li>
-          <li><a href={link("/user/logout")}>Logout</a></li>
+          <li>
+            <a href="#">Settings</a>
+          </li>
+          <li>
+            <a href={link("/user/logout")}>Logout</a>
+          </li>
           <li>
             <Avatar>
               <AvatarFallback>R</AvatarFallback>
@@ -823,11 +830,12 @@ const Header = () => {
         </ul>
       </nav>
     </header>
-  )
-}
+  );
+};
 
-export { Header }
+export { Header };
 ```
+
 </details>
 
 Now, let's stick our `Header` component into our `InteriorLayout.tsx` file:
@@ -835,7 +843,7 @@ Now, let's stick our `Header` component into our `InteriorLayout.tsx` file:
 ```tsx title="src/app/layouts/InteriorLayout.tsx" {1, 7}
 import { Header } from "@/app/components/Header";
 
-const InteriorLayout = ({ children }: { children: React.ReactNode}) => {
+const InteriorLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <div className="page-wrapper">
       <main className="page bg-white">
@@ -843,10 +851,10 @@ const InteriorLayout = ({ children }: { children: React.ReactNode}) => {
         <div>{children}</div>
       </main>
     </div>
-  )
-}
+  );
+};
 
-export { InteriorLayout }
+export { InteriorLayout };
 ```
 
 Check it out in the browser!
@@ -883,11 +891,12 @@ return (
 <Aside type="tip" title="shadcn/ui Button">
   Admittedly, it does look a little strange having an `a` tag inside a `Button` component.
 
-  In shadcn/ui, the ⁠Button component is designed to be flexible, allowing you to create buttons that can also act as links. This is a common pattern in modern web design where you want a consistent visual style for interactive elements.
+In shadcn/ui, the ⁠Button component is designed to be flexible, allowing you to create buttons that can also act as links. This is a common pattern in modern web design where you want a consistent visual style for interactive elements.
 
-  `asChild` is a special prop in shadcn/ui that tells the Button component to render its child element as-is. It allows you to keep the Button's styling while using a different underlying HTML element (like an ⁠`<a>` tag).
+`asChild` is a special prop in shadcn/ui that tells the Button component to render its child element as-is. It allows you to keep the Button's styling while using a different underlying HTML element (like an ⁠`<a>` tag).
 
-  [For reference: shadcn/ui Button Component Documentation](https://ui.shadcn.com/docs/components/button)
+[For reference: shadcn/ui Button Component Documentation](https://ui.shadcn.com/docs/components/button)
+
 </Aside>
 
 Now, let's add some styling:
@@ -909,23 +918,16 @@ Now, let's style the list of applications.
 
 Inside our `components` directory, let's create a new file, called `ApplicationsTable.tsx`.
 
-<FileTree>
-- src/
-  - app/
-    - components/
-      - ApplicationsTable.tsx
-</FileTree>
+<FileTree>- src/ - app/ - components/ - ApplicationsTable.tsx</FileTree>
 
 I'm going to stub out a basic component:
 
 ```tsx title="src/app/components/ApplicationsTable.tsx"
 const ApplicationsTable = () => {
-  return (
-    <div>ApplicationsTable</div>
-  )
-}
+  return <div>ApplicationsTable</div>;
+};
 
-export { ApplicationsTable }
+export { ApplicationsTable };
 ```
 
 Let's go ahead and put this on our `ApplicationsList.tsx` page, so we can see the updates we're making in the browser:
@@ -952,7 +954,15 @@ return (
 We've already added the [shadcn/ui Table component](https://ui.shadcn.com/docs/components/table) to our project, so let's go back to our `ApplicationsTable.tsx` file and use it. Just to start, I'm going to copy the example code from the shadcn/ui documentation and then we can rework it for our needs:
 
 ```tsx title="src/app/components/ApplicationsTable.tsx"
-import { Table, TableBody, TableCaption, TableCell, TableHead, TableHeader, TableRow } from "./ui/table"
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "./ui/table";
 
 const ApplicationsTable = () => {
   return (
@@ -975,10 +985,10 @@ const ApplicationsTable = () => {
         </TableRow>
       </TableBody>
     </Table>
-  )
-}
+  );
+};
 
-export { ApplicationsTable }
+export { ApplicationsTable };
 ```
 
 ![](./images/shadcn-table-component.png)
@@ -1021,7 +1031,9 @@ For our `TableBody`, we need our application data. First, let's set up our table
     <TableCell>RedwoodJS</TableCell>
     <TableCell>John Doe</TableCell>
     <TableCell>$150,000-$250,000</TableCell>
-    <TableCell><a href="#">View</a></TableCell>
+    <TableCell>
+      <a href="#">View</a>
+    </TableCell>
   </TableRow>
 </TableBody>
 ```
@@ -1047,11 +1059,11 @@ import { Badge } from "./ui/badge"
 Let's add styles based on the application status. We've already added some custom colors to our `styles.css` file, so let's use those.
 
 ```css styles.css startLineNumber=229
-  --color-tag-applied: #b1c7c0;
-  --color-tag-interview: #da9b7c;
-  --color-tag-new: #db9a9f;
-  --color-tag-rejected: #e4e3d4;
-  --color-tag-offer: #aae198;
+--color-tag-applied: #b1c7c0;
+--color-tag-interview: #da9b7c;
+--color-tag-new: #db9a9f;
+--color-tag-rejected: #e4e3d4;
+--color-tag-offer: #aae198;
 ```
 
 Inside of our `badge.tsx` component, there's a section at the top of `variants`:
@@ -1093,7 +1105,9 @@ const badgeVariants = cva(
 Let's go back to our `ApplicationsTable.tsx` component and update our badge:
 
 ```tsx title="src/app/components/ApplicationsTable.tsx" startLineNumber=20
-<TableCell><Badge variant="new">New</Badge></TableCell>
+<TableCell>
+  <Badge variant="new">New</Badge>
+</TableCell>
 ```
 
 For the contact column, let's include an avatar:
@@ -1112,7 +1126,7 @@ This is the same avatar component we used in the `Header` component.
 Be sure to import the `Avatar` and `AvatarFallback` components at the top of your file:
 
 ```tsx title="src/app/components/ApplicationsTable.tsx" showLineNumbers=false
-import { Avatar, AvatarFallback } from "./ui/avatar"
+import { Avatar, AvatarFallback } from "./ui/avatar";
 ```
 
 Let's add a few styles to fix the positioning:
@@ -1142,15 +1156,12 @@ We have several icons we want to use throughout our application. You can export 
 If you're exporting the icons from Figma, make sure you're grabbing the **frame** for the actual icon. All the icons are `24px` by `24px`.
 
 ![](./images/exporting-icons-out-of-figma.png)
+
 </Aside>
 
 I'm going to create a new folder in the root of our our project called `other` and then a sub directory inside that called `svg-icons` and place all of the icons inside the `svg-icons` directory.
 
-<FileTree>
-- other/
-  - svg-icons/
-- src/
-</FileTree>
+<FileTree>- other/ - svg-icons/ - src/</FileTree>
 
 My favorite way to implement SVG icons is through an SVG sprite. Basically, this combines all our SVG files into a single `sprite.svg` file. We can control which icon is displayed by setting the `id` attribute on the `use` element.
 
@@ -1165,7 +1176,8 @@ pnpm install lemon-lime-svgs --save-dev
 ```
 
 <Aside type="note" title="Save Dev">
-The purpose of this package is to help with the development process. The code does not need to go to production, so we can add the `--save-dev` flag.
+  The purpose of this package is to help with the development process. The code
+  does not need to go to production, so we can add the `--save-dev` flag.
 </Aside>
 
 Once installed, run the setup command:
@@ -1177,6 +1189,7 @@ npx lemon-lime-svgs setup
 ![](./images/setup-lemon-lime-svgs.png)
 
 This will ask a series of questions:
+
 - First, it will ask you what framework you're using. At it's core RedwoodSDK is React and Vite = 6
 - Next, it will ask you about file names and folder paths. It will make recommendations based on the framework you're using. Most of the defaults, work:
   - Input directory for SVG files: `./other/svg-icons` -- we've already set this directory up!
@@ -1216,7 +1229,7 @@ This component takes a `className`, if you want to add additional styles to the 
 Before we move on, I'm going to change this to a named export to be consistent with the other components we've created:
 
 ```tsx title="src/app/components/Icon.tsx" startLineNumber=15
-export { Icon }
+export { Icon };
 ```
 
 Now, let's take all our icon SVGs and dump them inside our `other/svg-icons` directory.
@@ -1249,7 +1262,8 @@ Inside our `ApplicationsTable.tsx` file:
 ![](./images/view-icon-in-browser.png)
 
 <Aside type="note" title="Caching">
-Due to caching, sometimes the icon doesn't update immediately. Try opening a browser window in incognito to see if that makes a difference.
+  Due to caching, sometimes the icon doesn't update immediately. Try opening a
+  browser window in incognito to see if that makes a difference.
 </Aside>
 
 ## Making our Table Dynamic
@@ -1282,24 +1296,26 @@ Now, let's go down to our `TableBody`. First we want to loop over all the applic
 
 ```tsx title="src/app/components/ApplicationsTable.tsx" startLineNumber=20
 <TableBody>
-  {applications.map(application => (
-  <TableRow>
-    <TableCell><Badge>New</Badge></TableCell>
-    <TableCell>April 15, 2025</TableCell>
-    <TableCell>Software Engineer</TableCell>
-    <TableCell>RedwoodJS</TableCell>
-    <TableCell className="flex items-center gap-2">
-      <Avatar>
-        <AvatarFallback>J</AvatarFallback>
-      </Avatar>
-      John Doe
-    </TableCell>
-    <TableCell>$150,000-$250,000</TableCell>
-    <TableCell>
-      <a href="#">
-        <Icon id="view" />
-      </a>
-    </TableCell>
+  {applications.map((application) => (
+    <TableRow>
+      <TableCell>
+        <Badge>New</Badge>
+      </TableCell>
+      <TableCell>April 15, 2025</TableCell>
+      <TableCell>Software Engineer</TableCell>
+      <TableCell>RedwoodJS</TableCell>
+      <TableCell className="flex items-center gap-2">
+        <Avatar>
+          <AvatarFallback>J</AvatarFallback>
+        </Avatar>
+        John Doe
+      </TableCell>
+      <TableCell>$150,000-$250,000</TableCell>
+      <TableCell>
+        <a href="#">
+          <Icon id="view" />
+        </a>
+      </TableCell>
     </TableRow>
   ))}
 </TableBody>
@@ -1308,11 +1324,12 @@ Now, let's go down to our `TableBody`. First we want to loop over all the applic
 Now, we can start replacing the static content with dynamic content.
 
 For our application status and our `Badge` component, we can swap out the `new` text with `{application.applicationStatus.status}`.
+
 ```tsx title="src/app/components/ApplicationsTable.tsx" startLineNumber=22
 <TableCell>
-    <Badge variant={application.applicationStatus.status}>
-      {application.applicationStatus.status}
-    </Badge>
+  <Badge variant={application.applicationStatus.status}>
+    {application.applicationStatus.status}
+  </Badge>
 </TableCell>
 ```
 
@@ -1372,24 +1389,25 @@ const ApplicationsTable = ({ applications }: {
 ```
 
 <Aside type="tip" title="TypeScript">
-If this starts to feel a little overwhelming, a few things that have helped me:
-- This is a great use case for AI. It knows your database schema and query. Ask it!
-- You know what the resulting data looks like.
-    ![](./images/json-with-relationships.png)
-    This is incredibly helpful when trying to create the type definition. You can also send the data to AI and ask it to help you create the type definition.
+  If this starts to feel a little overwhelming, a few things that have helped
+  me: - This is a great use case for AI. It knows your database schema and
+  query. Ask it! - You know what the resulting data looks like.
+  ![](./images/json-with-relationships.png) This is incredibly helpful when
+  trying to create the type definition. You can also send the data to AI and ask
+  it to help you create the type definition.
 </Aside>
 
 If you look at your `TableCell` again, you're probably still seeing an error 🤯
 
 ```tsx title="src/app/components/ApplicationsTable.tsx" startLineNumber=31
 <TableCell>
-    <Badge variant={application.applicationStatus.status}>
-      {application.applicationStatus.status}
-    </Badge>
+  <Badge variant={application.applicationStatus.status}>
+    {application.applicationStatus.status}
+  </Badge>
 </TableCell>
 ```
 
-When we pass in the `variant` prop for our `Badge` component, it's not just looking for a string, it's looking for a specific string: ``"default" | "secondary" | "destructive" | "outline" | "applied" | "interview" | "new" | "rejected" | "offer" | null | undefined``
+When we pass in the `variant` prop for our `Badge` component, it's not just looking for a string, it's looking for a specific string: `"default" | "secondary" | "destructive" | "outline" | "applied" | "interview" | "new" | "rejected" | "offer" | null | undefined`
 
 Inside our `badge` component, when we defined our `badgeVariants` for styles, it used our variant options to create a type definition. `badgeVariants` is exported from the `badge.tsx` component, making it easy to reuse and reference within our `ApplicationsTable.tsx`:
 
@@ -1409,6 +1427,7 @@ Inside our `badge` component, when we defined our `badgeVariants` for styles, it
 Class Variance Authority is a utility library, used within shadcn/ui, for creating and using CSS classes.
 
 For further reading, you can read the [official Class Variance Authority documentation.](https://cva.style/docs)
+
 </Aside>
 
 Sweet! Now, all of our TypeScript errors should be taken care of.
@@ -1526,22 +1545,37 @@ Perfect. Everything should check out. Try clicking on the view icon in the brows
 <summary>Final `ApplicationsTable.tsx` file</summary>
 
 ```tsx title="src/app/components/ApplicationsTable.tsx"
-import { Application, ApplicationStatus, Company, Contact } from "@prisma/client"
-import { Table, TableBody, TableCaption, TableCell, TableHead, TableHeader, TableRow } from "./ui/table"
-import { Avatar, AvatarFallback } from "./ui/avatar"
-import { Badge } from "./ui/badge"
-import { Icon } from "./Icon"
-import type { badgeVariants } from "./ui/badge"
-import { VariantProps } from "class-variance-authority"
-import { link } from "../shared/links"
+import {
+  Application,
+  ApplicationStatus,
+  Company,
+  Contact,
+} from "@prisma/client";
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "./ui/table";
+import { Avatar, AvatarFallback } from "./ui/avatar";
+import { Badge } from "./ui/badge";
+import { Icon } from "./Icon";
+import type { badgeVariants } from "./ui/badge";
+import { VariantProps } from "class-variance-authority";
+import { link } from "../shared/links";
 
-const ApplicationsTable = ({ applications }: {
+const ApplicationsTable = ({
+  applications,
+}: {
   applications: (Application & {
-    applicationStatus: ApplicationStatus,
+    applicationStatus: ApplicationStatus;
     company: Company & {
-      contacts: Contact[]
-    },
-  })[]
+      contacts: Contact[];
+    };
+  })[];
 }) => {
   return (
     <Table>
@@ -1555,31 +1589,38 @@ const ApplicationsTable = ({ applications }: {
         <TableHead></TableHead>
       </TableHeader>
       <TableBody>
-        {applications.map(application => (
-        <TableRow>
-          <TableCell>
-              <Badge variant={application.applicationStatus?.status.toLowerCase() as VariantProps<typeof badgeVariants>['variant']}>
+        {applications.map((application) => (
+          <TableRow>
+            <TableCell>
+              <Badge
+                variant={
+                  application.applicationStatus?.status.toLowerCase() as VariantProps<
+                    typeof badgeVariants
+                  >["variant"]
+                }
+              >
                 {application.applicationStatus?.status}
               </Badge>
-          </TableCell>
+            </TableCell>
             <TableCell>
-              {application.dateApplied?.toLocaleDateString('en-US', {
-                  year: 'numeric',
-                  month: 'long',
-                  day: 'numeric'
+              {application.dateApplied?.toLocaleDateString("en-US", {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
               })}
             </TableCell>
-            <TableCell>
-              {application.jobTitle}
-            </TableCell>
-            <TableCell>
-              {application.company.name}
-            </TableCell>
+            <TableCell>{application.jobTitle}</TableCell>
+            <TableCell>{application.company.name}</TableCell>
             <TableCell className="flex items-center gap-2">
               <Avatar>
-                <AvatarFallback>{application.company.contacts[0].firstName.charAt(0).toUpperCase()}</AvatarFallback>
+                <AvatarFallback>
+                  {application.company.contacts[0].firstName
+                    .charAt(0)
+                    .toUpperCase()}
+                </AvatarFallback>
               </Avatar>
-              {application.company.contacts[0].firstName} {application.company.contacts[0].lastName}
+              {application.company.contacts[0].firstName}{" "}
+              {application.company.contacts[0].lastName}
             </TableCell>
             <TableCell>
               ${application.salaryMin}-${application.salaryMax}
@@ -1593,11 +1634,12 @@ const ApplicationsTable = ({ applications }: {
         ))}
       </TableBody>
     </Table>
-  )
-}
+  );
+};
 
-export { ApplicationsTable }
+export { ApplicationsTable };
 ```
+
 </details>
 
 ### Finalizing the List Page
@@ -1717,7 +1759,7 @@ return (
       <div className="flex justify-between items-center">
         <Button asChild variant="secondary">
           <a href={`${link("/applications")}?status=archived`}>
-          <Icon id="archive" />
+            <Icon id="archive" />
             Archive
           </a>
         </Button>
@@ -1730,7 +1772,7 @@ return (
       </div>
     </>
   </InteriorLayout>
-)
+);
 ```
 
 Now, let's adjust the spacing around our table. On **line 22**, we're using a class of `px-page-side` to add some padding to the left and right side.
@@ -1760,13 +1802,17 @@ Before we preview this in the browser, let's adjust the vertical spacing.
 <Aside type="tip" title="Vertical Spacing">
   Whenever I'm adjusting the vertical spacing with margins, I always use margin bottom, pushing everything down. A couple of reasons: (1) it adds consistency to my code, and (2) it's easier to troubleshoot.
 
-  Plus, there's a feature within CSS called **collapsing margins**.
+Plus, there's a feature within CSS called **collapsing margins**.
 
-  > The top and bottom margins of blocks are sometimes combined (collapsed) into a single margin whose size is the largest of the individual margins (or just one of them, if they are equal), a behavior known as margin collapsing.
+> The top and bottom margins of blocks are sometimes combined (collapsed) into a single margin whose size is the largest of the individual margins (or just one of them, if they are equal), a behavior known as margin collapsing.
 
-  <cite>Reference: [Mastering margin collapsing on MDN Docs](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)</cite>
+<cite>
+  Reference: [Mastering margin collapsing on MDN
+  Docs](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)
+</cite>
 
-  This means that when you use a top and bottom margin, it can sometimes produce unexpected results. If you only use margin bottom, you can avoid this issue altogether.
+This means that when you use a top and bottom margin, it can sometimes produce unexpected results. If you only use margin bottom, you can avoid this issue altogether.
+
 </Aside>
 
 ```tsx title="src/app/pages/applications/List.tsx" "mb-5" "mb-8" "mb-10" collapse={4-13} startLineNumber=20
@@ -1825,7 +1871,8 @@ If you run this in the browser, you should see `{ status: 'archived' }` displaye
 <Aside type="note" title="Console">
   Since this code is running on the server, when you use `console.log` it will display the result in the Terminal.
 
-  When code is running in the browser and use `console.log` it will display within dev tools.
+When code is running in the browser and use `console.log` it will display within dev tools.
+
 </Aside>
 
 Now, that we've checked that our query parameter is working, we can remove our `console.log` statement and adjust our Prisma `findMany` query.
@@ -1838,13 +1885,13 @@ const applications = await db.application.findMany({
     applicationStatus: true,
     company: {
       include: {
-        contacts: true
-      }
-    }
+        contacts: true,
+      },
+    },
   },
   where: {
-    archived: status === "archived" ? true : false
-  }
+    archived: status === "archived" ? true : false,
+  },
 });
 ```
 
@@ -1926,13 +1973,13 @@ const List = async ({ request }: { request: Request }) => {
       applicationStatus: true,
       company: {
         include: {
-          contacts: true
-        }
-      }
+          contacts: true,
+        },
+      },
     },
     where: {
-      archived: status === "archived" ? true : false
-    }
+      archived: status === "archived" ? true : false,
+    },
   });
 
   return (
@@ -1981,13 +2028,15 @@ const List = async ({ request }: { request: Request }) => {
         </div>
       </div>
     </InteriorLayout>
-  )
-}
+  );
+};
 
-export { List }
+export { List };
 ```
+
 </details>
 
 <Aside type="tip" title="Code on GitHub">
-You can find the final code for this step on [GitHub](https://github.com/ahaywood/applywize/tree/main/end-of-5).
+  You can find the final code for this step on
+  [GitHub](https://github.com/ahaywood/applywize/tree/main/end-of-5).
 </Aside>

--- a/docs/src/content/docs/tutorial/full-stack-app/5-jobs-list.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/5-jobs-list.mdx
@@ -6,7 +6,7 @@ sidebar:
 description: A guide in my new Starlight docs site.
 ---
 
-import { Aside, FileTree } from "@astrojs/starlight/components";
+import { Aside, FileTree } from '@astrojs/starlight/components';
 
 The jobs application list page lists all the jobs that we've applied for. For this tutorial, it will also serve as the Dashboard.
 
@@ -21,17 +21,25 @@ But, first, we need a page and a route.
 In the `src > app > pages` directory, create a new folder called `applications`. Inside, create a file called `List.tsx`.
 
 <FileTree>
-  - src/ - app/ - pages/ - applications/ - List.tsx - auth/ - Home.tsx
+- src/
+  - app/
+    - pages/
+      - applications/
+        - List.tsx
+      - auth/
+      - Home.tsx
 </FileTree>
 
 We can stub out a basic page, just to make sure it's loading correctly.
 
 ```tsx title="src/app/pages/applications/List.tsx"
 const List = () => {
-  return <div>List</div>;
-};
+  return (
+    <div>List</div>
+  )
+}
 
-export { List };
+export { List }
 ```
 
 Now, within our `worker.tsx` file, we can add a route for our new page.
@@ -64,10 +72,8 @@ prefix("/applications", [
           headers: { Location: "/user/login" },
         });
       }
-    },
-    List,
-  ]),
-]);
+    }, List]),
+])
 ```
 
 This would get cumbersome (and annoying) if we have to do this for every.single.route we wanted to protect. Let's abstract this code into a reusable function.
@@ -89,7 +95,9 @@ We're passing in the `ctx` that we get with each request. Then, we're checking t
 Then, we can update our `/applications` route to use `isAuthenticated`:
 
 ```tsx startLineNumber=75
-prefix("/applications", [route("/", [isAuthenticated, List])]);
+prefix("/applications", [
+  route("/", [isAuthenticated, List]),
+])
 ```
 
 Now, we can also update our protected page route to use the `isAuthenticated` function, too:
@@ -113,16 +121,18 @@ index([ isAuthenticated, Home ]),
 Be sure to import `index` at the top of the file:
 
 ```tsx startLineNumber=2 "index"
-import { route, render, prefix, index } from "rwsdk/router";
+import { route, render, prefix, index } from "@redwoodjs/sdk/router";
 ```
 
 Test it out. 👨‍🍳 Chef's kiss! If you're logged in, you should see the "List" text. If you're not logged in, you'll be redirected to the login page.
 
 <Aside type="tip" title="Using multiple layers of Middleware">
-  You can use multiple layers of middleware, by continuing to write functions
-  and adding them to the array. They'll run in the order they're listed. For
-  example: ```tsx prefix("/applications", [ route("/", [isAuthenticated,
-  isAdmin, List]), ]) ```
+  You can use multiple layers of middleware, by continuing to write functions and adding them to the array. They'll run in the order they're listed. For example:
+  ```tsx
+  prefix("/applications", [
+    route("/", [isAuthenticated, isAdmin, List]),
+  ])
+  ```
 </Aside>
 
 Now, let's get some data into the database.
@@ -130,7 +140,6 @@ Now, let's get some data into the database.
 We can do this one of two ways:
 
 ### Option 1: Create a Seed File
-
 [Earlier, I mentioned that sometimes I'll create multiple seed files with various purposes.](/tutorial/full-stack-app/database-setup#seed-the-database). This is a perfect opportunity to create a separate file just for adding job applications to our database.
 
 Inside the `src/scripts` directory, create a new file called `applicationSeed.ts`.
@@ -138,7 +147,7 @@ Inside the `src/scripts` directory, create a new file called `applicationSeed.ts
 Let's stub it out:
 
 ```tsx title="src/scripts/applicationSeed.ts"
-import { defineScript } from "rwsdk/worker";
+import { defineScript } from "@redwoodjs/sdk/worker";
 import { db, setupDb } from "@/db";
 
 export default defineScript(async ({ env }) => {
@@ -256,7 +265,7 @@ This time instead of using an object with a `connect` key, we'll use a `create` 
 <summary>Complete applicationSeed.ts file</summary>
 
 ```tsx title="src/scripts/applicationSeed.ts"
-import { defineScript } from "rwsdk/worker";
+import { defineScript } from "@redwoodjs/sdk/worker";
 import { db, setupDb } from "@/db";
 
 export default defineScript(async ({ env }) => {
@@ -294,7 +303,7 @@ export default defineScript(async ({ env }) => {
         jobDescription: "Software Engineer",
         postingUrl: "https://redwoodjs.com",
         dateApplied: new Date(),
-      },
+      }
     });
   };
 
@@ -313,12 +322,12 @@ Prisma also has a `createMany` function where you can create multiple entries at
 - There's limited support for complex relational constraints and upsert operations.
 
 For reference: [`createMany` on Prisma's Documentation](https://www.prisma.io/docs/orm/prisma-client/queries/crud#create-multiple-records)
-
 </Aside>
 
 <Aside type="note" title="`skipDuplicates` is not supported">
-  Since our database is a sqlite database, `skipDuplicates` is not supported.
+Since our database is a sqlite database, `skipDuplicates` is not supported.
 </Aside>
+
 
 To run the seed file, within the Terminal:
 
@@ -396,8 +405,7 @@ Notice, we also made our `List` function an `async` function. We need to `await`
 ```
 
 <Aside type="note" title="Using `db`">
-  Note, it's `db` then the name of the table. In this case, `application`. But,
-  this could just as easily be `company`, `contact`, `status`, or `user`.
+Note, it's `db` then the name of the table. In this case, `application`. But, this could just as easily be `company`, `contact`, `status`, or `user`.
 </Aside>
 
 All the data from the database is returned as an array and saved in a variable called `applications`. Then, we can display all the data by using the `JSON.stringify` function. Wrapping our code in `pre` tags, it makes it easier to read.
@@ -409,7 +417,6 @@ All the data from the database is returned as an array and saved in a variable c
 - `2` specifies the number of spaces to use for indentation.
 
 [For reference: JSON.Stringify on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)
-
 </Aside>
 
 ![](./images/applications-list-json.png)
@@ -437,7 +444,11 @@ Similar to the auth pages, let's start by creating a layout that will wrap all o
 Inside our `layouts` folder, let's create a new file called `InteriorLayout.tsx`.
 
 <FileTree>
-  - src/ - app/ - layouts/ - AuthLayout.tsx - InteriorLayout.tsx
+- src/
+  - app/
+    - layouts/
+      - AuthLayout.tsx
+      - InteriorLayout.tsx
 </FileTree>
 
 Inside, we need should use some of the same styles that we used within our `AuthLayout.tsx` file. As a quick reminder, let's take a look at the `AuthLayout.tsx` file:
@@ -486,17 +497,16 @@ Then, let's do something similar with the child `div` from our `AuthLayout.tsx`.
   }
 
   .page-title {
-    @apply text-3xl;
+    @apply text-3xl
   }
 }
 ```
-
 </details>
 
 Let's also add our route to our `links.ts` file for type hinting:
 
 ```tsx title="src/app/shared/links.ts" collapse={4-9}
-import { defineLinks } from "rwsdk/router";
+import { defineLinks } from "@redwoodjs/sdk/router";
 
 export const link = defineLinks([
   "/",
@@ -545,14 +555,19 @@ return (
   <InteriorLayout>
     <pre>{JSON.stringify(applications, null, 2)}</pre>
   </InteriorLayout>
-);
+)
 ```
 
 ![](./images/applications-json-with-interior-layout.png)
 
 It's coming together! Across the top, let's add the logo and navigation. We may need to reuse this component in the future, so let's make it it's own component. Inside the `components` folder, let's create a new file called `Header.tsx`.
 
-<FileTree>- src/ - app/ - components/ - Header.tsx</FileTree>
+<FileTree>
+- src/
+  - app/
+    - components/
+      - Header.tsx
+</FileTree>
 
 ```tsx title="src/app/components/Header.tsx"
 const Header = () => {
@@ -581,30 +596,25 @@ Here are the basic building blocks we need.
 Inside the left `div`, let's add the logo and "Apply Wize" text and wrap it in a link:
 
 ```tsx title="src/app/components/Header.tsx" startLineNumber=5
-{
-  /* left side */
-}
+{/* left side */}
 <div>
   <a href={link("/")}>
     <img src="/images/logo.svg" alt="Apply Wize" />
     <span>Apply Wize</span>
   </a>
-</div>;
+</div>
 ```
 
 - Pretty straightforward. We're using the same `logo.svg` that we used on the auth pages. It should already be in your `public/images` folder.
 - Then, we're using the `link` helper to link to home page. At the top of your file, you'll need to import the `link` helper:
-
 ```tsx
-import { link } from "@/app/shared/links";
+import { link } from '@/app/shared/links'
 ```
 
 Now, let's add the navigation. For now this is only one link that goes to the dashboard page.
 
 ```tsx title="src/app/components/Header.tsx" collapse={3-6} {7-11}
-{
-  /* left side */
-}
+{/* left side */}
 <div>
   <a href={link("/")}>
     <img src="/images/logo.svg" alt="Apply Wize" />
@@ -612,35 +622,27 @@ Now, let's add the navigation. For now this is only one link that goes to the da
   </a>
   <nav>
     <ul>
-      <li>
-        <a href={link("/applications")}>Dashboard</a>
-      </li>
+      <li><a href={link("/applications")}>Dashboard</a></li>
     </ul>
   </nav>
-</div>;
+</div>
 ```
 
 For the right side, we want another unordered list and the Avatar component:
 
 ```tsx title="src/app/components/Header.tsx" startLineNumber=19
-{
-  /* right side */
-}
+{/* right side */}
 <nav>
   <ul>
-    <li>
-      <a href="#">Settings</a>
-    </li>
-    <li>
-      <a href={link("/user/logout")}>Logout</a>
-    </li>
+    <li><a href="#">Settings</a></li>
+    <li><a href={link("/user/logout")}>Logout</a></li>
     <li>
       <Avatar>
         <AvatarFallback>R</AvatarFallback>
       </Avatar>
     </li>
   </ul>
-</nav>;
+</nav>
 ```
 
 - Notice, I replaced the right side `div` with a `nav` element, keeping things nice and semantic.
@@ -648,7 +650,7 @@ For the right side, we want another unordered list and the Avatar component:
 - For the `Avatar` component, you'll need to import it at the top of your file. This is a shadcn/ui component, so it should already be part of your project.
 
 ```tsx showLineNumbers=false
-import { Avatar, AvatarFallback } from "@/app/components/ui/avatar";
+import { Avatar, AvatarFallback } from '@/app/components/ui/avatar'
 ```
 
 Normally, when you're using the `Avatar` component, you'll also want to use the `AvatarImage` component. This is where you define the Avatar image:
@@ -789,26 +791,21 @@ That should be it! (for the header at least)
 <summary>Finished `Header.tsx` component</summary>
 
 ```tsx title="src/app/components/Header.tsx"
-import { link } from "@/app/shared/links";
-import { Avatar, AvatarFallback } from "./ui/avatar";
+import { link } from '@/app/shared/links'
+import { Avatar, AvatarFallback } from './ui/avatar'
 
 const Header = () => {
   return (
     <header className="py-5 px-page-side h-20 flex justify-between items-center border-b-1 border-border mb-12">
       {/* left side */}
       <div className="flex items-center gap-8">
-        <a
-          href={link("/")}
-          className="flex items-center gap-3 font-display font-bold text-3xl"
-        >
+        <a href={link("/")} className="flex items-center gap-3 font-display font-bold text-3xl">
           <img src="/images/logo.svg" alt="Apply Wize" className="pt-5 -mb-3" />
           <span>Apply Wize</span>
         </a>
         <nav>
           <ul>
-            <li>
-              <a href={link("/applications")}>Dashboard</a>
-            </li>
+            <li><a href={link("/applications")}>Dashboard</a></li>
           </ul>
         </nav>
       </div>
@@ -816,12 +813,8 @@ const Header = () => {
       {/* right side */}
       <nav>
         <ul className="flex items-center gap-7">
-          <li>
-            <a href="#">Settings</a>
-          </li>
-          <li>
-            <a href={link("/user/logout")}>Logout</a>
-          </li>
+          <li><a href="#">Settings</a></li>
+          <li><a href={link("/user/logout")}>Logout</a></li>
           <li>
             <Avatar>
               <AvatarFallback>R</AvatarFallback>
@@ -830,12 +823,11 @@ const Header = () => {
         </ul>
       </nav>
     </header>
-  );
-};
+  )
+}
 
-export { Header };
+export { Header }
 ```
-
 </details>
 
 Now, let's stick our `Header` component into our `InteriorLayout.tsx` file:
@@ -843,7 +835,7 @@ Now, let's stick our `Header` component into our `InteriorLayout.tsx` file:
 ```tsx title="src/app/layouts/InteriorLayout.tsx" {1, 7}
 import { Header } from "@/app/components/Header";
 
-const InteriorLayout = ({ children }: { children: React.ReactNode }) => {
+const InteriorLayout = ({ children }: { children: React.ReactNode}) => {
   return (
     <div className="page-wrapper">
       <main className="page bg-white">
@@ -851,10 +843,10 @@ const InteriorLayout = ({ children }: { children: React.ReactNode }) => {
         <div>{children}</div>
       </main>
     </div>
-  );
-};
+  )
+}
 
-export { InteriorLayout };
+export { InteriorLayout }
 ```
 
 Check it out in the browser!
@@ -891,12 +883,11 @@ return (
 <Aside type="tip" title="shadcn/ui Button">
   Admittedly, it does look a little strange having an `a` tag inside a `Button` component.
 
-In shadcn/ui, the ⁠Button component is designed to be flexible, allowing you to create buttons that can also act as links. This is a common pattern in modern web design where you want a consistent visual style for interactive elements.
+  In shadcn/ui, the ⁠Button component is designed to be flexible, allowing you to create buttons that can also act as links. This is a common pattern in modern web design where you want a consistent visual style for interactive elements.
 
-`asChild` is a special prop in shadcn/ui that tells the Button component to render its child element as-is. It allows you to keep the Button's styling while using a different underlying HTML element (like an ⁠`<a>` tag).
+  `asChild` is a special prop in shadcn/ui that tells the Button component to render its child element as-is. It allows you to keep the Button's styling while using a different underlying HTML element (like an ⁠`<a>` tag).
 
-[For reference: shadcn/ui Button Component Documentation](https://ui.shadcn.com/docs/components/button)
-
+  [For reference: shadcn/ui Button Component Documentation](https://ui.shadcn.com/docs/components/button)
 </Aside>
 
 Now, let's add some styling:
@@ -918,16 +909,23 @@ Now, let's style the list of applications.
 
 Inside our `components` directory, let's create a new file, called `ApplicationsTable.tsx`.
 
-<FileTree>- src/ - app/ - components/ - ApplicationsTable.tsx</FileTree>
+<FileTree>
+- src/
+  - app/
+    - components/
+      - ApplicationsTable.tsx
+</FileTree>
 
 I'm going to stub out a basic component:
 
 ```tsx title="src/app/components/ApplicationsTable.tsx"
 const ApplicationsTable = () => {
-  return <div>ApplicationsTable</div>;
-};
+  return (
+    <div>ApplicationsTable</div>
+  )
+}
 
-export { ApplicationsTable };
+export { ApplicationsTable }
 ```
 
 Let's go ahead and put this on our `ApplicationsList.tsx` page, so we can see the updates we're making in the browser:
@@ -954,15 +952,7 @@ return (
 We've already added the [shadcn/ui Table component](https://ui.shadcn.com/docs/components/table) to our project, so let's go back to our `ApplicationsTable.tsx` file and use it. Just to start, I'm going to copy the example code from the shadcn/ui documentation and then we can rework it for our needs:
 
 ```tsx title="src/app/components/ApplicationsTable.tsx"
-import {
-  Table,
-  TableBody,
-  TableCaption,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "./ui/table";
+import { Table, TableBody, TableCaption, TableCell, TableHead, TableHeader, TableRow } from "./ui/table"
 
 const ApplicationsTable = () => {
   return (
@@ -985,10 +975,10 @@ const ApplicationsTable = () => {
         </TableRow>
       </TableBody>
     </Table>
-  );
-};
+  )
+}
 
-export { ApplicationsTable };
+export { ApplicationsTable }
 ```
 
 ![](./images/shadcn-table-component.png)
@@ -1031,9 +1021,7 @@ For our `TableBody`, we need our application data. First, let's set up our table
     <TableCell>RedwoodJS</TableCell>
     <TableCell>John Doe</TableCell>
     <TableCell>$150,000-$250,000</TableCell>
-    <TableCell>
-      <a href="#">View</a>
-    </TableCell>
+    <TableCell><a href="#">View</a></TableCell>
   </TableRow>
 </TableBody>
 ```
@@ -1059,11 +1047,11 @@ import { Badge } from "./ui/badge"
 Let's add styles based on the application status. We've already added some custom colors to our `styles.css` file, so let's use those.
 
 ```css styles.css startLineNumber=229
---color-tag-applied: #b1c7c0;
---color-tag-interview: #da9b7c;
---color-tag-new: #db9a9f;
---color-tag-rejected: #e4e3d4;
---color-tag-offer: #aae198;
+  --color-tag-applied: #b1c7c0;
+  --color-tag-interview: #da9b7c;
+  --color-tag-new: #db9a9f;
+  --color-tag-rejected: #e4e3d4;
+  --color-tag-offer: #aae198;
 ```
 
 Inside of our `badge.tsx` component, there's a section at the top of `variants`:
@@ -1105,9 +1093,7 @@ const badgeVariants = cva(
 Let's go back to our `ApplicationsTable.tsx` component and update our badge:
 
 ```tsx title="src/app/components/ApplicationsTable.tsx" startLineNumber=20
-<TableCell>
-  <Badge variant="new">New</Badge>
-</TableCell>
+<TableCell><Badge variant="new">New</Badge></TableCell>
 ```
 
 For the contact column, let's include an avatar:
@@ -1126,7 +1112,7 @@ This is the same avatar component we used in the `Header` component.
 Be sure to import the `Avatar` and `AvatarFallback` components at the top of your file:
 
 ```tsx title="src/app/components/ApplicationsTable.tsx" showLineNumbers=false
-import { Avatar, AvatarFallback } from "./ui/avatar";
+import { Avatar, AvatarFallback } from "./ui/avatar"
 ```
 
 Let's add a few styles to fix the positioning:
@@ -1156,12 +1142,15 @@ We have several icons we want to use throughout our application. You can export 
 If you're exporting the icons from Figma, make sure you're grabbing the **frame** for the actual icon. All the icons are `24px` by `24px`.
 
 ![](./images/exporting-icons-out-of-figma.png)
-
 </Aside>
 
 I'm going to create a new folder in the root of our our project called `other` and then a sub directory inside that called `svg-icons` and place all of the icons inside the `svg-icons` directory.
 
-<FileTree>- other/ - svg-icons/ - src/</FileTree>
+<FileTree>
+- other/
+  - svg-icons/
+- src/
+</FileTree>
 
 My favorite way to implement SVG icons is through an SVG sprite. Basically, this combines all our SVG files into a single `sprite.svg` file. We can control which icon is displayed by setting the `id` attribute on the `use` element.
 
@@ -1176,8 +1165,7 @@ pnpm install lemon-lime-svgs --save-dev
 ```
 
 <Aside type="note" title="Save Dev">
-  The purpose of this package is to help with the development process. The code
-  does not need to go to production, so we can add the `--save-dev` flag.
+The purpose of this package is to help with the development process. The code does not need to go to production, so we can add the `--save-dev` flag.
 </Aside>
 
 Once installed, run the setup command:
@@ -1189,7 +1177,6 @@ npx lemon-lime-svgs setup
 ![](./images/setup-lemon-lime-svgs.png)
 
 This will ask a series of questions:
-
 - First, it will ask you what framework you're using. At it's core RedwoodSDK is React and Vite = 6
 - Next, it will ask you about file names and folder paths. It will make recommendations based on the framework you're using. Most of the defaults, work:
   - Input directory for SVG files: `./other/svg-icons` -- we've already set this directory up!
@@ -1229,7 +1216,7 @@ This component takes a `className`, if you want to add additional styles to the 
 Before we move on, I'm going to change this to a named export to be consistent with the other components we've created:
 
 ```tsx title="src/app/components/Icon.tsx" startLineNumber=15
-export { Icon };
+export { Icon }
 ```
 
 Now, let's take all our icon SVGs and dump them inside our `other/svg-icons` directory.
@@ -1262,8 +1249,7 @@ Inside our `ApplicationsTable.tsx` file:
 ![](./images/view-icon-in-browser.png)
 
 <Aside type="note" title="Caching">
-  Due to caching, sometimes the icon doesn't update immediately. Try opening a
-  browser window in incognito to see if that makes a difference.
+Due to caching, sometimes the icon doesn't update immediately. Try opening a browser window in incognito to see if that makes a difference.
 </Aside>
 
 ## Making our Table Dynamic
@@ -1296,26 +1282,24 @@ Now, let's go down to our `TableBody`. First we want to loop over all the applic
 
 ```tsx title="src/app/components/ApplicationsTable.tsx" startLineNumber=20
 <TableBody>
-  {applications.map((application) => (
-    <TableRow>
-      <TableCell>
-        <Badge>New</Badge>
-      </TableCell>
-      <TableCell>April 15, 2025</TableCell>
-      <TableCell>Software Engineer</TableCell>
-      <TableCell>RedwoodJS</TableCell>
-      <TableCell className="flex items-center gap-2">
-        <Avatar>
-          <AvatarFallback>J</AvatarFallback>
-        </Avatar>
-        John Doe
-      </TableCell>
-      <TableCell>$150,000-$250,000</TableCell>
-      <TableCell>
-        <a href="#">
-          <Icon id="view" />
-        </a>
-      </TableCell>
+  {applications.map(application => (
+  <TableRow>
+    <TableCell><Badge>New</Badge></TableCell>
+    <TableCell>April 15, 2025</TableCell>
+    <TableCell>Software Engineer</TableCell>
+    <TableCell>RedwoodJS</TableCell>
+    <TableCell className="flex items-center gap-2">
+      <Avatar>
+        <AvatarFallback>J</AvatarFallback>
+      </Avatar>
+      John Doe
+    </TableCell>
+    <TableCell>$150,000-$250,000</TableCell>
+    <TableCell>
+      <a href="#">
+        <Icon id="view" />
+      </a>
+    </TableCell>
     </TableRow>
   ))}
 </TableBody>
@@ -1324,12 +1308,11 @@ Now, let's go down to our `TableBody`. First we want to loop over all the applic
 Now, we can start replacing the static content with dynamic content.
 
 For our application status and our `Badge` component, we can swap out the `new` text with `{application.applicationStatus.status}`.
-
 ```tsx title="src/app/components/ApplicationsTable.tsx" startLineNumber=22
 <TableCell>
-  <Badge variant={application.applicationStatus.status}>
-    {application.applicationStatus.status}
-  </Badge>
+    <Badge variant={application.applicationStatus.status}>
+      {application.applicationStatus.status}
+    </Badge>
 </TableCell>
 ```
 
@@ -1389,25 +1372,24 @@ const ApplicationsTable = ({ applications }: {
 ```
 
 <Aside type="tip" title="TypeScript">
-  If this starts to feel a little overwhelming, a few things that have helped
-  me: - This is a great use case for AI. It knows your database schema and
-  query. Ask it! - You know what the resulting data looks like.
-  ![](./images/json-with-relationships.png) This is incredibly helpful when
-  trying to create the type definition. You can also send the data to AI and ask
-  it to help you create the type definition.
+If this starts to feel a little overwhelming, a few things that have helped me:
+- This is a great use case for AI. It knows your database schema and query. Ask it!
+- You know what the resulting data looks like.
+    ![](./images/json-with-relationships.png)
+    This is incredibly helpful when trying to create the type definition. You can also send the data to AI and ask it to help you create the type definition.
 </Aside>
 
 If you look at your `TableCell` again, you're probably still seeing an error 🤯
 
 ```tsx title="src/app/components/ApplicationsTable.tsx" startLineNumber=31
 <TableCell>
-  <Badge variant={application.applicationStatus.status}>
-    {application.applicationStatus.status}
-  </Badge>
+    <Badge variant={application.applicationStatus.status}>
+      {application.applicationStatus.status}
+    </Badge>
 </TableCell>
 ```
 
-When we pass in the `variant` prop for our `Badge` component, it's not just looking for a string, it's looking for a specific string: `"default" | "secondary" | "destructive" | "outline" | "applied" | "interview" | "new" | "rejected" | "offer" | null | undefined`
+When we pass in the `variant` prop for our `Badge` component, it's not just looking for a string, it's looking for a specific string: ``"default" | "secondary" | "destructive" | "outline" | "applied" | "interview" | "new" | "rejected" | "offer" | null | undefined``
 
 Inside our `badge` component, when we defined our `badgeVariants` for styles, it used our variant options to create a type definition. `badgeVariants` is exported from the `badge.tsx` component, making it easy to reuse and reference within our `ApplicationsTable.tsx`:
 
@@ -1427,7 +1409,6 @@ Inside our `badge` component, when we defined our `badgeVariants` for styles, it
 Class Variance Authority is a utility library, used within shadcn/ui, for creating and using CSS classes.
 
 For further reading, you can read the [official Class Variance Authority documentation.](https://cva.style/docs)
-
 </Aside>
 
 Sweet! Now, all of our TypeScript errors should be taken care of.
@@ -1545,37 +1526,22 @@ Perfect. Everything should check out. Try clicking on the view icon in the brows
 <summary>Final `ApplicationsTable.tsx` file</summary>
 
 ```tsx title="src/app/components/ApplicationsTable.tsx"
-import {
-  Application,
-  ApplicationStatus,
-  Company,
-  Contact,
-} from "@prisma/client";
-import {
-  Table,
-  TableBody,
-  TableCaption,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "./ui/table";
-import { Avatar, AvatarFallback } from "./ui/avatar";
-import { Badge } from "./ui/badge";
-import { Icon } from "./Icon";
-import type { badgeVariants } from "./ui/badge";
-import { VariantProps } from "class-variance-authority";
-import { link } from "../shared/links";
+import { Application, ApplicationStatus, Company, Contact } from "@prisma/client"
+import { Table, TableBody, TableCaption, TableCell, TableHead, TableHeader, TableRow } from "./ui/table"
+import { Avatar, AvatarFallback } from "./ui/avatar"
+import { Badge } from "./ui/badge"
+import { Icon } from "./Icon"
+import type { badgeVariants } from "./ui/badge"
+import { VariantProps } from "class-variance-authority"
+import { link } from "../shared/links"
 
-const ApplicationsTable = ({
-  applications,
-}: {
+const ApplicationsTable = ({ applications }: {
   applications: (Application & {
-    applicationStatus: ApplicationStatus;
+    applicationStatus: ApplicationStatus,
     company: Company & {
-      contacts: Contact[];
-    };
-  })[];
+      contacts: Contact[]
+    },
+  })[]
 }) => {
   return (
     <Table>
@@ -1589,38 +1555,31 @@ const ApplicationsTable = ({
         <TableHead></TableHead>
       </TableHeader>
       <TableBody>
-        {applications.map((application) => (
-          <TableRow>
-            <TableCell>
-              <Badge
-                variant={
-                  application.applicationStatus?.status.toLowerCase() as VariantProps<
-                    typeof badgeVariants
-                  >["variant"]
-                }
-              >
+        {applications.map(application => (
+        <TableRow>
+          <TableCell>
+              <Badge variant={application.applicationStatus?.status.toLowerCase() as VariantProps<typeof badgeVariants>['variant']}>
                 {application.applicationStatus?.status}
               </Badge>
-            </TableCell>
+          </TableCell>
             <TableCell>
-              {application.dateApplied?.toLocaleDateString("en-US", {
-                year: "numeric",
-                month: "long",
-                day: "numeric",
+              {application.dateApplied?.toLocaleDateString('en-US', {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric'
               })}
             </TableCell>
-            <TableCell>{application.jobTitle}</TableCell>
-            <TableCell>{application.company.name}</TableCell>
+            <TableCell>
+              {application.jobTitle}
+            </TableCell>
+            <TableCell>
+              {application.company.name}
+            </TableCell>
             <TableCell className="flex items-center gap-2">
               <Avatar>
-                <AvatarFallback>
-                  {application.company.contacts[0].firstName
-                    .charAt(0)
-                    .toUpperCase()}
-                </AvatarFallback>
+                <AvatarFallback>{application.company.contacts[0].firstName.charAt(0).toUpperCase()}</AvatarFallback>
               </Avatar>
-              {application.company.contacts[0].firstName}{" "}
-              {application.company.contacts[0].lastName}
+              {application.company.contacts[0].firstName} {application.company.contacts[0].lastName}
             </TableCell>
             <TableCell>
               ${application.salaryMin}-${application.salaryMax}
@@ -1634,12 +1593,11 @@ const ApplicationsTable = ({
         ))}
       </TableBody>
     </Table>
-  );
-};
+  )
+}
 
-export { ApplicationsTable };
+export { ApplicationsTable }
 ```
-
 </details>
 
 ### Finalizing the List Page
@@ -1759,7 +1717,7 @@ return (
       <div className="flex justify-between items-center">
         <Button asChild variant="secondary">
           <a href={`${link("/applications")}?status=archived`}>
-            <Icon id="archive" />
+          <Icon id="archive" />
             Archive
           </a>
         </Button>
@@ -1772,7 +1730,7 @@ return (
       </div>
     </>
   </InteriorLayout>
-);
+)
 ```
 
 Now, let's adjust the spacing around our table. On **line 22**, we're using a class of `px-page-side` to add some padding to the left and right side.
@@ -1802,17 +1760,13 @@ Before we preview this in the browser, let's adjust the vertical spacing.
 <Aside type="tip" title="Vertical Spacing">
   Whenever I'm adjusting the vertical spacing with margins, I always use margin bottom, pushing everything down. A couple of reasons: (1) it adds consistency to my code, and (2) it's easier to troubleshoot.
 
-Plus, there's a feature within CSS called **collapsing margins**.
+  Plus, there's a feature within CSS called **collapsing margins**.
 
-> The top and bottom margins of blocks are sometimes combined (collapsed) into a single margin whose size is the largest of the individual margins (or just one of them, if they are equal), a behavior known as margin collapsing.
+  > The top and bottom margins of blocks are sometimes combined (collapsed) into a single margin whose size is the largest of the individual margins (or just one of them, if they are equal), a behavior known as margin collapsing.
 
-<cite>
-  Reference: [Mastering margin collapsing on MDN
-  Docs](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)
-</cite>
+  <cite>Reference: [Mastering margin collapsing on MDN Docs](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)</cite>
 
-This means that when you use a top and bottom margin, it can sometimes produce unexpected results. If you only use margin bottom, you can avoid this issue altogether.
-
+  This means that when you use a top and bottom margin, it can sometimes produce unexpected results. If you only use margin bottom, you can avoid this issue altogether.
 </Aside>
 
 ```tsx title="src/app/pages/applications/List.tsx" "mb-5" "mb-8" "mb-10" collapse={4-13} startLineNumber=20
@@ -1871,8 +1825,7 @@ If you run this in the browser, you should see `{ status: 'archived' }` displaye
 <Aside type="note" title="Console">
   Since this code is running on the server, when you use `console.log` it will display the result in the Terminal.
 
-When code is running in the browser and use `console.log` it will display within dev tools.
-
+  When code is running in the browser and use `console.log` it will display within dev tools.
 </Aside>
 
 Now, that we've checked that our query parameter is working, we can remove our `console.log` statement and adjust our Prisma `findMany` query.
@@ -1885,13 +1838,13 @@ const applications = await db.application.findMany({
     applicationStatus: true,
     company: {
       include: {
-        contacts: true,
-      },
-    },
+        contacts: true
+      }
+    }
   },
   where: {
-    archived: status === "archived" ? true : false,
-  },
+    archived: status === "archived" ? true : false
+  }
 });
 ```
 
@@ -1973,13 +1926,13 @@ const List = async ({ request }: { request: Request }) => {
       applicationStatus: true,
       company: {
         include: {
-          contacts: true,
-        },
-      },
+          contacts: true
+        }
+      }
     },
     where: {
-      archived: status === "archived" ? true : false,
-    },
+      archived: status === "archived" ? true : false
+    }
   });
 
   return (
@@ -2028,15 +1981,13 @@ const List = async ({ request }: { request: Request }) => {
         </div>
       </div>
     </InteriorLayout>
-  );
-};
+  )
+}
 
-export { List };
+export { List }
 ```
-
 </details>
 
 <Aside type="tip" title="Code on GitHub">
-  You can find the final code for this step on
-  [GitHub](https://github.com/ahaywood/applywize/tree/main/end-of-5).
+You can find the final code for this step on [GitHub](https://github.com/ahaywood/applywize/tree/main/end-of-5).
 </Aside>

--- a/docs/src/content/docs/tutorial/full-stack-app/5-jobs-list.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/5-jobs-list.mdx
@@ -121,7 +121,7 @@ index([ isAuthenticated, Home ]),
 Be sure to import `index` at the top of the file:
 
 ```tsx startLineNumber=2 "index"
-import { route, render, prefix, index } from "@redwoodjs/sdk/router";
+import { route, render, prefix, index } from "rwsdk/router";
 ```
 
 Test it out. 👨‍🍳 Chef's kiss! If you're logged in, you should see the "List" text. If you're not logged in, you'll be redirected to the login page.
@@ -147,7 +147,7 @@ Inside the `src/scripts` directory, create a new file called `applicationSeed.ts
 Let's stub it out:
 
 ```tsx title="src/scripts/applicationSeed.ts"
-import { defineScript } from "@redwoodjs/sdk/worker";
+import { defineScript } from "rwsdk/worker";
 import { db, setupDb } from "@/db";
 
 export default defineScript(async ({ env }) => {
@@ -265,7 +265,7 @@ This time instead of using an object with a `connect` key, we'll use a `create` 
 <summary>Complete applicationSeed.ts file</summary>
 
 ```tsx title="src/scripts/applicationSeed.ts"
-import { defineScript } from "@redwoodjs/sdk/worker";
+import { defineScript } from "rwsdk/worker";
 import { db, setupDb } from "@/db";
 
 export default defineScript(async ({ env }) => {
@@ -506,7 +506,7 @@ Then, let's do something similar with the child `div` from our `AuthLayout.tsx`.
 Let's also add our route to our `links.ts` file for type hinting:
 
 ```tsx title="src/app/shared/links.ts" collapse={4-9}
-import { defineLinks } from "@redwoodjs/sdk/router";
+import { defineLinks } from "rwsdk/router";
 
 export const link = defineLinks([
   "/",

--- a/docs/src/content/docs/tutorial/full-stack-app/6-jobs-form.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/6-jobs-form.mdx
@@ -6,7 +6,7 @@ sidebar:
 description: A guide in my new Starlight docs site.
 ---
 
-import { Aside, FileTree } from "@astrojs/starlight/components";
+import { Aside, FileTree } from '@astrojs/starlight/components';
 
 ## Building the Form
 
@@ -20,7 +20,13 @@ In the last section, we set up the `/applications/new` route, but we haven't cre
 
 Inside the `src/app/pages/applications` folder, let's create a new file called `New.tsx`.
 
-<FileTree>- src/ - app/ - pages/ - applications/ - New.tsx</FileTree>
+<FileTree>
+- src/
+  - app/
+    - pages/
+      - applications/
+        - New.tsx
+</FileTree>
 
 We can stub out a basic component:
 
@@ -129,7 +135,7 @@ Now, we an start modifying the code to fit our needs.
 At the top of the `src/app/components/ui/breadcrumb.tsx` file, we need to add a `use client` directive, otherwise our page will error out.
 
 ```tsx title="src/app/components/ui/breadcrumb.tsx"
-"use client";
+"use client"
 ```
 
 Let's wrap our breadcrumbs with a `div` and add a few classes to adjust the spacing.
@@ -188,7 +194,12 @@ Moving down the page, we have a two column form. There are parts of our form tha
 
 Inside the `src/app/components` folder, let's create a new file called `ApplicationForm.tsx`.
 
-<FileTree>- src/ - app/ - components/ - ApplicationForm.tsx</FileTree>
+<FileTree>
+- src/
+  - app/
+    - components/
+      - ApplicationForm.tsx
+</FileTree>
 
 Stubbing out our component:
 
@@ -281,19 +292,22 @@ Now, let's start building out our form.
           <input type="text" id="url" name="url" />
         </div>
         <div className="field">
-          <Button role="submit">Create</Button>
+          <Button role="submit">
+            Create
+          </Button>
         </div>
       </div>
     </div>
 
     {/* right side */}
-    <div></div>
+    <div>
+
+    </div>
   </div>
 </form>
 ```
 
 This is a big chunk of code, but it should be pretty straightforward. It's a standard form, using HTML labels and inputs with fields for:
-
 - Company Name
 - Job Title
 - Job Description / Requirements
@@ -386,8 +400,10 @@ textarea {
 For the minimum and maximum salary fields, we have to add a few custom styles in order to get the "Min" and "Max" labels to appear inside the input.
 
 <figure>
-  ![](./images/figma-salary-min-max.png)
-  <figcaption>Salary min and max within Figma.</figcaption>
+![](./images/figma-salary-min-max.png)
+<figcaption>
+  Salary min and max within Figma.
+</figcaption>
 </figure>
 
 Let's revisit the JSX. This is what we have right now:
@@ -517,7 +533,6 @@ Now, let's write the code for the right side.
 ### Right Side
 
 Looking at the design in Figma, we have 3 boxes.
-
 1. Application submission date, with a date picker
 2. Application status, with a dropdown
 3. Contacts list
@@ -529,15 +544,13 @@ For most of these pieces, we can use existing shadcn/ui components.
 I'm going to use a wrapping `div` with a class of `box` to wrap each of these sections.
 
 ```tsx title="src/app/components/ApplicationForm.tsx" startLineNumber=56
-{
-  /* right side */
-}
+{/* right side */}
 <div>
   <div className="box">
     <label>Application submission date</label>
     <DatePicker name="dateApplied" />
   </div>
-</div>;
+</div>
 ```
 
 Our `DatePicker` component is a shadcn/ui component, so we'll need to import it at the top of our file:
@@ -561,7 +574,7 @@ export function DatePicker({ name }: { name: string }) {
 Now, we need to do something with it. If you skim through the code, it's saving the selected `date` in a piece of state, defined at the top of the component:
 
 ```tsx title="src/app/components/ui/DatePicker.tsx" startLineNumber=17
-const [date, setDate] = React.useState<Date>();
+const [date, setDate] = React.useState<Date>()
 ```
 
 We can use that in conjunction with our `name` prop! Scroll down to the bottom of the `DatePicker` component, where we'll create a hidden input. We can give our `input` the `name` that we passed in as a prop and set the value to the `date` that we're saving in state.
@@ -571,7 +584,6 @@ We can use that in conjunction with our `name` prop! Scroll down to the bottom o
 ```
 
 You probably noticed, we're formatting the `date` value.
-
 - The `?` says, "if the `date` is defined, then format it".
 - The `.toISOString()` method converts the `date` to a string in ISO 8601 format.
 
@@ -579,7 +591,7 @@ Now, our component is returning two children, so we'll need to wrap our entire r
 
 ```tsx title="src/app/components/ui/datepicker.tsx" "<>" "</>" startLineNumber=16 collapse={6-27}
 export function DatePicker({ name }: { name: string }) {
-  const [date, setDate] = React.useState<Date>();
+  const [date, setDate] = React.useState<Date>()
 
   return (
     <>
@@ -589,7 +601,7 @@ export function DatePicker({ name }: { name: string }) {
             variant={"outline"}
             className={cn(
               "w-[280px] justify-start text-left font-normal",
-              !date && "text-muted-foreground",
+              !date && "text-muted-foreground"
             )}
           >
             <CalendarIcon className="mr-2 h-4 w-4" />
@@ -607,7 +619,7 @@ export function DatePicker({ name }: { name: string }) {
       </Popover>
       <input type="hidden" name={name} value={date ? date.toISOString() : ""} />
     </>
-  );
+  )
 }
 ```
 
@@ -630,13 +642,7 @@ Moving on to the next box, we have the Application Status:
 Here, we're using a shadcn/ui `Select` component. We'll need to import this at the top of our file:
 
 ```tsx title="src/app/components/ApplicationForm.tsx" showLineNumbers={false}
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "./ui/select";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select"
 ```
 
 Let's look a little bit more at the shadcn/ui `Select` component. You can also [check out the official documentation](https://ui.shadcn.com/docs/components/select).
@@ -681,10 +687,9 @@ Scroll down to our `Select` component. We want to loop over all of our statuses 
     <SelectValue placeholder="Select a Status" />
   </SelectTrigger>
   <SelectContent>
-    {statuses &&
-      statuses.map((status) => (
-        <SelectItem value={status.status}>{status.status}</SelectItem>
-      ))}
+    {statuses && statuses.map(status => (
+      <SelectItem value={status.status}>{status.status}</SelectItem>
+    ))}
   </SelectContent>
 </Select>
 ```
@@ -784,20 +789,25 @@ Now, we need to write the `handleSubmit` function. Still within the `Application
 Now, let's set up the `createApplication` function. Create a file for our action. Inside, the `src/app/pages/applications` folder, let's create a new file called `actions.ts`.
 
 <FileTree>
-  - src/ - app/ - pages/ - applications/ - actions.ts - List.tsx - New.tsx
+- src/
+  - app/
+    - pages/
+      - applications/
+        - actions.ts
+        - List.tsx
+        - New.tsx
 </FileTree>
 
 <Aside type="tip" title="actions.ts file">
 This is personal preference, but I like co-locating my actions with the pages that need them.
 
 If it's a shared action, you can put it in a folder like `src/app/lib/actions` and naming the file based on the action.
-
 </Aside>
 
 At the top of our `actions.ts` file, we need the `"use server"` directive to ensure our code runs on the server (see the [React documentation on this](https://react.dev/reference/rsc/use-server) for more info).
 
 ```tsx title="/src/app/pages/applications/actions.ts"
-"use server";
+"use server"
 ```
 
 Then, let's create a function called `createApplication`.
@@ -868,12 +878,13 @@ try {
 Before looking at this within the browser, make sure that you go back to the `ApplicationsForm` component and import the `createApplication` function at the top of your file:
 
 ```tsx title="/src/app/components/ApplicationForm.tsx" startLineNumber={7}
-import { createApplication } from "@/app/pages/applications/actions";
+import { createApplication } from "@/app/pages/applications/actions"
 ```
 
 Now, let's test this out. Fill out the form, click the "Create" button, and you should be redirected to the applications page and see your new application in the list. 😎
 
 ![](./images/working-job-application-form.png)
+
 
 Our user id is still hard coded in:
 
@@ -891,7 +902,7 @@ We can access the current user by importing the `requestInfo` object. This conta
 
 ```tsx title="/src/app/pages/applications/actions.ts" {"1. import package":1} {"2. Get the ctx from the requestInfo object": 6} {"3. If the user does not exist on the ctx, throw an error": 9} {"4. Replace the hard coded user id with the one from the ctx": 18} {2, 7, 10-12, 19} showLineNumbers=false
 .
-import { requestInfo } from "rwsdk/worker";
+import { requestInfo } from "@redwoodjs/sdk/worker";
 
 export const createApplication = async (formData: FormData) => {
   try {
@@ -916,18 +927,15 @@ export const createApplication = async (formData: FormData) => {
 Test this out again and everything should still work. 🥳
 
 <Aside type="note" title="Handling Forms in React 19">
-  If you're interested in reading more on handling forms in React 19, here are a
-  few resources: - [React v19](https://react.dev/blog/2024/12/05/react-19) -
-  [React Hook Form vs React
-  19](https://mattburgess.medium.com/react-hook-form-vs-react-19-1e28009e6557) -
-  [Exploring React 19 Features: New Hooks and Actions for Better Form
-  Handling](https://curiosum.com/blog/react-19-features) - [A deep dive on forms
-  with modern React](https://www.epicreact.dev/react-forms)
+If you're interested in reading more on handling forms in React 19, here are a few resources:
+- [React v19](https://react.dev/blog/2024/12/05/react-19)
+- [React Hook Form vs React 19](https://mattburgess.medium.com/react-hook-form-vs-react-19-1e28009e6557)
+- [Exploring React 19 Features: New Hooks and Actions for Better Form Handling](https://curiosum.com/blog/react-19-features)
+- [A deep dive on forms with modern React](https://www.epicreact.dev/react-forms)
 </Aside>
 
 <Aside type="tip" title="Code on GitHub">
-  You can find the final code for this step on
-  [GitHub](https://github.com/ahaywood/applywize/tree/main/end-of-6).
+You can find the final code for this step on [GitHub](https://github.com/ahaywood/applywize/tree/main/end-of-6).
 </Aside>
 
 ## Further reading

--- a/docs/src/content/docs/tutorial/full-stack-app/6-jobs-form.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/6-jobs-form.mdx
@@ -6,7 +6,7 @@ sidebar:
 description: A guide in my new Starlight docs site.
 ---
 
-import { Aside, FileTree } from '@astrojs/starlight/components';
+import { Aside, FileTree } from "@astrojs/starlight/components";
 
 ## Building the Form
 
@@ -20,13 +20,7 @@ In the last section, we set up the `/applications/new` route, but we haven't cre
 
 Inside the `src/app/pages/applications` folder, let's create a new file called `New.tsx`.
 
-<FileTree>
-- src/
-  - app/
-    - pages/
-      - applications/
-        - New.tsx
-</FileTree>
+<FileTree>- src/ - app/ - pages/ - applications/ - New.tsx</FileTree>
 
 We can stub out a basic component:
 
@@ -135,7 +129,7 @@ Now, we an start modifying the code to fit our needs.
 At the top of the `src/app/components/ui/breadcrumb.tsx` file, we need to add a `use client` directive, otherwise our page will error out.
 
 ```tsx title="src/app/components/ui/breadcrumb.tsx"
-"use client"
+"use client";
 ```
 
 Let's wrap our breadcrumbs with a `div` and add a few classes to adjust the spacing.
@@ -194,12 +188,7 @@ Moving down the page, we have a two column form. There are parts of our form tha
 
 Inside the `src/app/components` folder, let's create a new file called `ApplicationForm.tsx`.
 
-<FileTree>
-- src/
-  - app/
-    - components/
-      - ApplicationForm.tsx
-</FileTree>
+<FileTree>- src/ - app/ - components/ - ApplicationForm.tsx</FileTree>
 
 Stubbing out our component:
 
@@ -292,22 +281,19 @@ Now, let's start building out our form.
           <input type="text" id="url" name="url" />
         </div>
         <div className="field">
-          <Button role="submit">
-            Create
-          </Button>
+          <Button role="submit">Create</Button>
         </div>
       </div>
     </div>
 
     {/* right side */}
-    <div>
-
-    </div>
+    <div></div>
   </div>
 </form>
 ```
 
 This is a big chunk of code, but it should be pretty straightforward. It's a standard form, using HTML labels and inputs with fields for:
+
 - Company Name
 - Job Title
 - Job Description / Requirements
@@ -400,10 +386,8 @@ textarea {
 For the minimum and maximum salary fields, we have to add a few custom styles in order to get the "Min" and "Max" labels to appear inside the input.
 
 <figure>
-![](./images/figma-salary-min-max.png)
-<figcaption>
-  Salary min and max within Figma.
-</figcaption>
+  ![](./images/figma-salary-min-max.png)
+  <figcaption>Salary min and max within Figma.</figcaption>
 </figure>
 
 Let's revisit the JSX. This is what we have right now:
@@ -533,6 +517,7 @@ Now, let's write the code for the right side.
 ### Right Side
 
 Looking at the design in Figma, we have 3 boxes.
+
 1. Application submission date, with a date picker
 2. Application status, with a dropdown
 3. Contacts list
@@ -544,13 +529,15 @@ For most of these pieces, we can use existing shadcn/ui components.
 I'm going to use a wrapping `div` with a class of `box` to wrap each of these sections.
 
 ```tsx title="src/app/components/ApplicationForm.tsx" startLineNumber=56
-{/* right side */}
+{
+  /* right side */
+}
 <div>
   <div className="box">
     <label>Application submission date</label>
     <DatePicker name="dateApplied" />
   </div>
-</div>
+</div>;
 ```
 
 Our `DatePicker` component is a shadcn/ui component, so we'll need to import it at the top of our file:
@@ -574,7 +561,7 @@ export function DatePicker({ name }: { name: string }) {
 Now, we need to do something with it. If you skim through the code, it's saving the selected `date` in a piece of state, defined at the top of the component:
 
 ```tsx title="src/app/components/ui/DatePicker.tsx" startLineNumber=17
-const [date, setDate] = React.useState<Date>()
+const [date, setDate] = React.useState<Date>();
 ```
 
 We can use that in conjunction with our `name` prop! Scroll down to the bottom of the `DatePicker` component, where we'll create a hidden input. We can give our `input` the `name` that we passed in as a prop and set the value to the `date` that we're saving in state.
@@ -584,6 +571,7 @@ We can use that in conjunction with our `name` prop! Scroll down to the bottom o
 ```
 
 You probably noticed, we're formatting the `date` value.
+
 - The `?` says, "if the `date` is defined, then format it".
 - The `.toISOString()` method converts the `date` to a string in ISO 8601 format.
 
@@ -591,7 +579,7 @@ Now, our component is returning two children, so we'll need to wrap our entire r
 
 ```tsx title="src/app/components/ui/datepicker.tsx" "<>" "</>" startLineNumber=16 collapse={6-27}
 export function DatePicker({ name }: { name: string }) {
-  const [date, setDate] = React.useState<Date>()
+  const [date, setDate] = React.useState<Date>();
 
   return (
     <>
@@ -601,7 +589,7 @@ export function DatePicker({ name }: { name: string }) {
             variant={"outline"}
             className={cn(
               "w-[280px] justify-start text-left font-normal",
-              !date && "text-muted-foreground"
+              !date && "text-muted-foreground",
             )}
           >
             <CalendarIcon className="mr-2 h-4 w-4" />
@@ -619,7 +607,7 @@ export function DatePicker({ name }: { name: string }) {
       </Popover>
       <input type="hidden" name={name} value={date ? date.toISOString() : ""} />
     </>
-  )
+  );
 }
 ```
 
@@ -642,7 +630,13 @@ Moving on to the next box, we have the Application Status:
 Here, we're using a shadcn/ui `Select` component. We'll need to import this at the top of our file:
 
 ```tsx title="src/app/components/ApplicationForm.tsx" showLineNumbers={false}
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./ui/select";
 ```
 
 Let's look a little bit more at the shadcn/ui `Select` component. You can also [check out the official documentation](https://ui.shadcn.com/docs/components/select).
@@ -687,9 +681,10 @@ Scroll down to our `Select` component. We want to loop over all of our statuses 
     <SelectValue placeholder="Select a Status" />
   </SelectTrigger>
   <SelectContent>
-    {statuses && statuses.map(status => (
-      <SelectItem value={status.status}>{status.status}</SelectItem>
-    ))}
+    {statuses &&
+      statuses.map((status) => (
+        <SelectItem value={status.status}>{status.status}</SelectItem>
+      ))}
   </SelectContent>
 </Select>
 ```
@@ -789,25 +784,20 @@ Now, we need to write the `handleSubmit` function. Still within the `Application
 Now, let's set up the `createApplication` function. Create a file for our action. Inside, the `src/app/pages/applications` folder, let's create a new file called `actions.ts`.
 
 <FileTree>
-- src/
-  - app/
-    - pages/
-      - applications/
-        - actions.ts
-        - List.tsx
-        - New.tsx
+  - src/ - app/ - pages/ - applications/ - actions.ts - List.tsx - New.tsx
 </FileTree>
 
 <Aside type="tip" title="actions.ts file">
 This is personal preference, but I like co-locating my actions with the pages that need them.
 
 If it's a shared action, you can put it in a folder like `src/app/lib/actions` and naming the file based on the action.
+
 </Aside>
 
 At the top of our `actions.ts` file, we need the `"use server"` directive to ensure our code runs on the server (see the [React documentation on this](https://react.dev/reference/rsc/use-server) for more info).
 
 ```tsx title="/src/app/pages/applications/actions.ts"
-"use server"
+"use server";
 ```
 
 Then, let's create a function called `createApplication`.
@@ -878,13 +868,12 @@ try {
 Before looking at this within the browser, make sure that you go back to the `ApplicationsForm` component and import the `createApplication` function at the top of your file:
 
 ```tsx title="/src/app/components/ApplicationForm.tsx" startLineNumber={7}
-import { createApplication } from "@/app/pages/applications/actions"
+import { createApplication } from "@/app/pages/applications/actions";
 ```
 
 Now, let's test this out. Fill out the form, click the "Create" button, and you should be redirected to the applications page and see your new application in the list. 😎
 
 ![](./images/working-job-application-form.png)
-
 
 Our user id is still hard coded in:
 
@@ -902,7 +891,7 @@ We can access the current user by importing the `requestInfo` object. This conta
 
 ```tsx title="/src/app/pages/applications/actions.ts" {"1. import package":1} {"2. Get the ctx from the requestInfo object": 6} {"3. If the user does not exist on the ctx, throw an error": 9} {"4. Replace the hard coded user id with the one from the ctx": 18} {2, 7, 10-12, 19} showLineNumbers=false
 .
-import { requestInfo } from "@redwoodjs/sdk/worker";
+import { requestInfo } from "rwsdk/worker";
 
 export const createApplication = async (formData: FormData) => {
   try {
@@ -927,15 +916,18 @@ export const createApplication = async (formData: FormData) => {
 Test this out again and everything should still work. 🥳
 
 <Aside type="note" title="Handling Forms in React 19">
-If you're interested in reading more on handling forms in React 19, here are a few resources:
-- [React v19](https://react.dev/blog/2024/12/05/react-19)
-- [React Hook Form vs React 19](https://mattburgess.medium.com/react-hook-form-vs-react-19-1e28009e6557)
-- [Exploring React 19 Features: New Hooks and Actions for Better Form Handling](https://curiosum.com/blog/react-19-features)
-- [A deep dive on forms with modern React](https://www.epicreact.dev/react-forms)
+  If you're interested in reading more on handling forms in React 19, here are a
+  few resources: - [React v19](https://react.dev/blog/2024/12/05/react-19) -
+  [React Hook Form vs React
+  19](https://mattburgess.medium.com/react-hook-form-vs-react-19-1e28009e6557) -
+  [Exploring React 19 Features: New Hooks and Actions for Better Form
+  Handling](https://curiosum.com/blog/react-19-features) - [A deep dive on forms
+  with modern React](https://www.epicreact.dev/react-forms)
 </Aside>
 
 <Aside type="tip" title="Code on GitHub">
-You can find the final code for this step on [GitHub](https://github.com/ahaywood/applywize/tree/main/end-of-6).
+  You can find the final code for this step on
+  [GitHub](https://github.com/ahaywood/applywize/tree/main/end-of-6).
 </Aside>
 
 ## Further reading

--- a/docs/src/content/docs/tutorial/full-stack-app/6-jobs-form.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/6-jobs-form.mdx
@@ -902,7 +902,7 @@ We can access the current user by importing the `requestInfo` object. This conta
 
 ```tsx title="/src/app/pages/applications/actions.ts" {"1. import package":1} {"2. Get the ctx from the requestInfo object": 6} {"3. If the user does not exist on the ctx, throw an error": 9} {"4. Replace the hard coded user id with the one from the ctx": 18} {2, 7, 10-12, 19} showLineNumbers=false
 .
-import { requestInfo } from "@redwoodjs/sdk/worker";
+import { requestInfo } from "rwsdk/worker";
 
 export const createApplication = async (formData: FormData) => {
   try {

--- a/docs/src/content/docs/tutorial/full-stack-app/8-jobs-details.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/8-jobs-details.mdx
@@ -6,7 +6,7 @@ sidebar:
 description: A guide in my new Starlight docs site.
 ---
 
-import { Aside, FileTree } from '@astrojs/starlight/components';
+import { Aside, FileTree } from "@astrojs/starlight/components";
 
 Can you believe it?! This is the last piece we need before deploying our application.
 
@@ -23,26 +23,18 @@ Pretty simple, right?
 Let's start by creating a new file in our `src/app/pages/applications` folder called `Details.tsx`.
 
 <FileTree>
-- src
-  - app
-    - pages
-      - applications
-        - actions.ts
-        - Details.tsx
-        - List.tsx
-        - New.tsx
+  - src - app - pages - applications - actions.ts - Details.tsx - List.tsx -
+  New.tsx
 </FileTree>
 
 We can start with the basics:
 
 ```tsx title="/src/app/pages/applications/Details.tsx"
 const Details = () => {
-  return (
-    <div>Details</div>
-  )
-}
+  return <div>Details</div>;
+};
 
-export { Details }
+export { Details };
 ```
 
 Now, let's jump over to our `worker.tsx` file and update the route for our details page.
@@ -82,13 +74,13 @@ return (
   <InteriorLayout>
     <p>Details</p>
   </InteriorLayout>
-)
+);
 ```
 
 Be sure to import `InteriorLayout` at the top of our file:
 
 ```tsx title="/src/app/pages/applications/Details.tsx"
-import { InteriorLayout } from "@/app/layouts/InteriorLayout"
+import { InteriorLayout } from "@/app/layouts/InteriorLayout";
 ```
 
 Already, that makes a huge difference:
@@ -159,7 +151,7 @@ return (
     </div>
     <p>Details</p>
   </InteriorLayout>
-)
+);
 ```
 
 We need to update the breadcrumb links. The first link is for our Dashboard:
@@ -183,7 +175,7 @@ Everything after `applications/` is the application id.
 We can get all the details we need based on the `RequestInfo` object that gets passed into all pages by default.
 
 ```tsx title="/src/app/pages/applications/Details.tsx" startLineNumber={3} {1} "{ params }: RequestInfo"
-import { RequestInfo } from "@redwoodjs/sdk/worker"
+import { RequestInfo } from "rwsdk/worker"
 
 const Details = async ({ params }: RequestInfo) => {
 ```
@@ -195,12 +187,13 @@ The `RequestInfo` object contains:
 - `ctx`: The app context
 
 [You can find more information here.](/reference/sdk-worker/#requestinfo-requestinfo)
+
 </Aside>
 
 Let's `console.log` the `params`, right before our `return` statement:
 
 ```tsx title="/src/app/pages/applications/Details.tsx" startLineNumber={6}
-console.log({ params })
+console.log({ params });
 ```
 
 Since this code is running on the server, this will get logged to the terminal, _not_ the browser.
@@ -209,7 +202,7 @@ Since this code is running on the server, this will get logged to the terminal, 
 
 Perfect! We can get the application ID by referencing `params.id`.
 
-Now, we can remove our `console.log` and  make our database call:
+Now, we can remove our `console.log` and make our database call:
 
 ```tsx title="/src/app/pages/applications/Details.tsx" startLineNumber={4} {1, 4-8}
 import { db } from "@/db"
@@ -254,7 +247,7 @@ const application = await db.application.findUnique({
   include: {
     company: true,
   },
-})
+});
 ```
 
 and actually, while we're here, let's go ahead and include our `applicationStatus` and `contact` relationships as well. Since the `contact` relationship is through our `company` object, we need to go another level deeper:
@@ -272,7 +265,7 @@ const application = await db.application.findUnique({
       },
     },
   },
-})
+});
 ```
 
 We can get rid of our `console.log` statement and move down the page.
@@ -311,9 +304,9 @@ Below our bread crumbs, let's start with our JSX and then we can come back and s
 At the top of our file, we need to add a few imports:
 
 ```tsx title="/src/app/pages/applications/Details.tsx" showLineNumbers=false
-import { Badge, badgeVariants } from "@/app/components/ui/badge"
-import { Button } from "@/app/components/ui/button"
-import { VariantProps } from "class-variance-authority"
+import { Badge, badgeVariants } from "@/app/components/ui/badge";
+import { Button } from "@/app/components/ui/button";
+import { VariantProps } from "class-variance-authority";
 ```
 
 Now, let's do another pass, this time adding our styles.
@@ -362,12 +355,26 @@ I want to add some space to the left and right side. But, this will also need to
     <div>
       <div className="flex items-center gap-5 mb-1">
         <h1 className="page-title">{application?.jobTitle}</h1>
-        <Badge variant={application?.applicationStatus?.status.toLowerCase() as VariantProps<typeof badgeVariants>['variant']}>{application?.applicationStatus?.status}</Badge>
+        <Badge
+          variant={
+            application?.applicationStatus?.status.toLowerCase() as VariantProps<
+              typeof badgeVariants
+            >["variant"]
+          }
+        >
+          {application?.applicationStatus?.status}
+        </Badge>
       </div>
-      <p><span className="text-zinc-500">at</span> {application?.company?.name}</p>
+      <p>
+        <span className="text-zinc-500">at</span> {application?.company?.name}
+      </p>
     </div>
     <div>
-      <Button><a href={application?.postingUrl as string} target="_blank">View Application</a></Button>
+      <Button>
+        <a href={application?.postingUrl as string} target="_blank">
+          View Application
+        </a>
+      </Button>
     </div>
   </header>
 
@@ -397,7 +404,7 @@ Now, within our CSS file, inside the `@layer components` section, let's add our 
 
 ```css title="/src/styles.css" startLineNumber={319}
 .two-column-grid {
-  @apply grid grid-cols-2 gap-[200px] mb-[75px]
+  @apply grid grid-cols-2 gap-[200px] mb-[75px];
 }
 ```
 
@@ -553,7 +560,9 @@ Now, let's paste our code into our `Details.tsx` file.
   {contacts && (
     <ul>
       {contacts.map((contact) => (
-        <li key={contact.id}><ContactCard contact={contact} /></li>
+        <li key={contact.id}>
+          <ContactCard contact={contact} />
+        </li>
       ))}
     </ul>
   )}
@@ -563,7 +572,7 @@ Now, let's paste our code into our `Details.tsx` file.
 At the top of our file, import the `ContactCard` component:
 
 ```tsx title="/src/app/pages/applications/Details.tsx" showLineNumbers=false
-import { ContactCard } from "@/app/components/ContactCard"
+import { ContactCard } from "@/app/components/ContactCard";
 ```
 
 On our Contact box, we have some linting errors because it cannot find our `contacts`.
@@ -573,13 +582,17 @@ On our Contact box, we have some linting errors because it cannot find our `cont
 We have this data, but it's nested inside our `application.company` object. We can adjust our conditional statement and the object we're mapping over to get rid of the error:
 
 ```tsx title="/src/app/pages/applications/Details.tsx" startLineNumber={78} "application?.company?.contacts"
-{application?.company?.contacts && (
-  <ul>
-    {application?.company?.contacts.map((contact) => (
-      <li key={contact.id}><ContactCard contact={contact} /></li>
-    ))}
-  </ul>
-)}
+{
+  application?.company?.contacts && (
+    <ul>
+      {application?.company?.contacts.map((contact) => (
+        <li key={contact.id}>
+          <ContactCard contact={contact} />
+        </li>
+      ))}
+    </ul>
+  );
+}
 ```
 
 Amazing!
@@ -598,28 +611,35 @@ I made the `isEditable` prop optional and set it to `true` by default. This way,
 Now, I'm going to wrap our Delete button with a conditional statement that checks if `isEditable` is `true`:
 
 ```tsx title="/src/app/components/ContactCard.tsx" startLineNumber={22} {1, 10}
-{isEditable && (
-  <div className="hidden group-hover/card:block pr-10 absolute top-1 -left-[37px]">
-    <button role="button"
-      className="hover:bg-black cursor-pointer text-white fill-current rounded-full bg-destructive p-1"
-      onClick={(e) => handleDelete(e)}
-    >
-      <Icon id="close" size={16} />
-    </button>
-  </div>
-)}
+{
+  isEditable && (
+    <div className="hidden group-hover/card:block pr-10 absolute top-1 -left-[37px]">
+      <button
+        role="button"
+        className="hover:bg-black cursor-pointer text-white fill-current rounded-full bg-destructive p-1"
+        onClick={(e) => handleDelete(e)}
+      >
+        <Icon id="close" size={16} />
+      </button>
+    </div>
+  );
+}
 ```
 
 Back on our `Details` page, where we're looping over the `ContactCard` component, we can pass in `false` for the `isEditable` prop:
 
 ```tsx title="/src/app/pages/applications/Details.tsx" startLineNumber={78} "isEditable={false}"
-{application?.company?.contacts && (
-  <ul>
-    {application?.company?.contacts.map((contact) => (
-      <li key={contact.id}><ContactCard contact={contact} isEditable={false} /></li>
-    ))}
-  </ul>
-)}
+{
+  application?.company?.contacts && (
+    <ul>
+      {application?.company?.contacts.map((contact) => (
+        <li key={contact.id}>
+          <ContactCard contact={contact} isEditable={false} />
+        </li>
+      ))}
+    </ul>
+  );
+}
 ```
 
 If you test this out in the browser, you'll see that the delete button doesn't appear when you hover over a contact card on the `Details` page, but it still appears on the `New Application` page.
@@ -657,23 +677,16 @@ The `Dialog` component requires button clicks and maintaining state, so we'll ne
 
 Inside our `src/app/components`, let's create a new file and name it `DeleteApplicationButton.tsx`
 
-<FileTree>
-- src/
-  - app/
-    - components/
-      - DeleteApplicationButton.tsx
-</FileTree>
+<FileTree>- src/ - app/ - components/ - DeleteApplicationButton.tsx</FileTree>
 
 Let's start with a bare bones component:
 
 ```tsx title="/src/app/components/DeleteApplicationButton.tsx"
 const DeleteApplicationButton = () => {
-  return (
-    <div>DeleteApplicationButton</div>
-  )
-}
+  return <div>DeleteApplicationButton</div>;
+};
 
-export { DeleteApplicationButton }
+export { DeleteApplicationButton };
 ```
 
 Then, we can replace the placeholder `<div>DeleteApplicationButton</div>` with the Dialog code from shadcn/ui:
@@ -735,7 +748,9 @@ If you look at the DOM that's rendered in the browser, `DialogTrigger` renders a
 
 ```tsx title="/src/app/components/DeleteApplicationButton.tsx" startLineNumber={20} "asChild"
 <DialogTrigger asChild>
-  <Button variant="link" className="text-destructive fill-current"><Icon id="trash" size={16} /> Delete</Button>
+  <Button variant="link" className="text-destructive fill-current">
+    <Icon id="trash" size={16} /> Delete
+  </Button>
 </DialogTrigger>
 ```
 
@@ -749,7 +764,8 @@ For the `DialogDescription`, we can use the text: "This will permanently delete 
 
 ```tsx title="/src/app/components/DeleteApplicationButton.tsx" startLineNumber={26}
 <DialogDescription>
-  This will permanently delete the application and any related companies and contacts. This action cannot be undone.
+  This will permanently delete the application and any related companies and
+  contacts. This action cannot be undone.
 </DialogDescription>
 ```
 
@@ -910,7 +926,9 @@ Then, we can use the `Dialog`'s props, `open` and `onOpenChange`, to control the
 Now, we can update the "Nevermind" button to close the dialog box, by updating the `isOpen` state:
 
 ```tsx title="/src/app/components/DeleteApplicationButton.tsx" startLineNumber={34}
-<Button variant="secondary" onClick={ () => setIsOpen(false) }>Nevermind</Button>
+<Button variant="secondary" onClick={() => setIsOpen(false)}>
+  Nevermind
+</Button>
 ```
 
 If you test this in the browser, the "Nevermind" button should close the dialog box, without deleting the application. 😎
@@ -924,15 +942,8 @@ Our application is looking great, but we're missing one thing: the ability to ed
 Let's take the smarter, not harder approach and start with our `New` application form page and modify it. Let's duplicate the `New.tsx` file and name the new file `Edit.tsx`.
 
 <FileTree>
-- src/
-  - app/
-    - pages/
-      - applications/
-        - actions.ts
-        - Details.tsx
-        - Edit.tsx
-        - List.tsx
-        - New.tsx
+  - src/ - app/ - pages/ - applications/ - actions.ts - Details.tsx - Edit.tsx -
+  List.tsx - New.tsx
 </FileTree>
 
 Inside, we need to rename our component to `Edit`
@@ -996,7 +1007,7 @@ Now, let's update the **Edit** button on the **Details** page so that we can eas
 You'll also need to import the `links` function at the top of our file:
 
 ```tsx title="/src/app/pages/applications/Details.tsx" showLineNumbers=false
-import { link } from "@/app/shared/links"
+import { link } from "@/app/shared/links";
 ```
 
 If you look at this in the browser and click on the **Edit** button, it should take you to a page that looks like the new application form. But, the URL is different.
@@ -1031,13 +1042,13 @@ const Edit = async ({ params, ctx }: RequestInfo) => {
 Be sure to import `RequestInfo` at the top of our file:
 
 ```tsx title="/src/app/pages/applications/Edit.tsx" showLineNumbers=false
-import { RequestInfo } from "@redwoodjs/sdk/worker"
+import { RequestInfo } from "rwsdk/worker";
 ```
 
 If we work our way down the file, we still need to grab _all_ the application statuses to populate the dropdown menu:
 
 ```tsx title="/src/app/pages/applications/Edit.tsx" startLineNumber={22}
-const statuses = await db.applicationStatus.findMany()
+const statuses = await db.applicationStatus.findMany();
 ```
 
 But, we can _delete_ the block of code where we get all the contacts that aren't related to a company:
@@ -1046,9 +1057,9 @@ But, we can _delete_ the block of code where we get all the contacts that aren't
 const contacts = await db.contact.findMany({
   where: {
     companyId: null,
-    userId: ctx.user?.id || ""
-  }
-})
+    userId: ctx.user?.id || "",
+  },
+});
 ```
 
 We already have all the contact information we need through the `application` database call.
@@ -1078,6 +1089,7 @@ Let's keep moving down the file. We can change our `BreadcrumbPage` to display t
 - Then, I changed the `BreadcrumbPage` to `Edit Application`.
 ---
 ```
+
 ![](./images/edit-job-application-breadcrumbs.png)
 
 Looking at the next section:
@@ -1141,17 +1153,16 @@ We updated the types that we're importing from Prisma to remove `Contact` and in
 
 You'll notice that our `Application` type also includes the `company` and `contacts` details.
 
-
 <Aside type="tip" title="Application Type">
 If the Application type looks too long and complex, you can always abstract it into it's own type:
 
 ```tsx
 type ApplicationWithCompanyAndContacts = Application & {
-  applicationStatus: ApplicationStatus
+  applicationStatus: ApplicationStatus;
   company: Company & {
-    contacts: Contact[]
-  }
-}
+    contacts: Contact[];
+  };
+};
 ```
 
 and then reference it like this:
@@ -1160,6 +1171,7 @@ and then reference it like this:
 const EditApplicationForm = ({ statuses, application }:
   { statuses: ApplicationStatus[], application: ApplicationWithCompanyAndContacts }) => {
 ```
+
 </Aside>
 
 Let's work our way through the form, for each input field, we want to set a `defaultValue`, referencing the application details.
@@ -1182,9 +1194,7 @@ Let's work our way through the form, for each input field, we want to set a `def
 Then, for the submit button, change the label from "Create" to "Update":
 
 ```tsx title="/src/app/components/EditApplicationForm.tsx" startLineNumber={77} "Update"
-<Button type="submit">
-  Update
-</Button>
+<Button type="submit">Update</Button>
 ```
 
 Let's add a second button, to cancel:
@@ -1208,7 +1218,10 @@ Let's add a second button, to cancel:
 For the Date Picker, we need to adjust the component slightly. If you try to pass in a `defaultValue`:
 
 ```tsx title="/src/app/components/EditApplicationForm.tsx" showLineNumbers=false
-<DatePicker name="dateApplied" defaultValue={application?.dateApplied?.toISOString() ?? ''} />
+<DatePicker
+  name="dateApplied"
+  defaultValue={application?.dateApplied?.toISOString() ?? ""}
+/>
 ```
 
 It will show a linting error because it's not prepared to accept that prop:
@@ -1263,7 +1276,10 @@ Instead of duplicating the `ContactForm` component, let's make it "smart" enough
 Inside our `EditApplicationForm` component, where we're using our `ContactForm` component, let's pass in the `companyId`:
 
 ```tsx title="/src/app/components/EditApplicationForm.tsx" startLineNumber={125} "companyId={application?.company?.id ?? ''"
-<ContactForm callback={() => setIsContactSheetOpen(false)} companyId={application?.company?.id ?? ''} />
+<ContactForm
+  callback={() => setIsContactSheetOpen(false)}
+  companyId={application?.company?.id ?? ""}
+/>
 ```
 
 Right away, you will see an error because our `ContactForm` isn't expecting a `companyId` prop. Let's fix that:
@@ -1283,7 +1299,7 @@ Inside the `handleSubmit` function, let's `append` the `companyId` to our `formD
 const handleSubmit = async (formData: FormData) => {
   formData.append("companyId", companyId);
   const result = await createContact(formData);
-}
+};
 ```
 
 Now, let's jump over to our `createContact` function, inside our `src/app/pages/applications/actions.tsx` file and get the `companyId` from the form data:
@@ -1341,7 +1357,7 @@ const handleSubmit = async (formData: FormData) => {
   } else {
     console.error(result.error);
   }
-}
+};
 ```
 
 We can remove line `26`, where we're appending the `contacts` to the `formData`.
@@ -1356,7 +1372,7 @@ const handleSubmit = async (formData: FormData) => {
   } else {
     console.error(result.error);
   }
-}
+};
 ```
 
 Be sure to update the import statement at the top of your file:
@@ -1418,11 +1434,12 @@ This is great, the only problem is that the application `id` does not exist in o
 Let's go back to our `EditApplicationForm` and add a `hidden` input field to our form:
 
 ```tsx title="/src/app/components/EditApplicationForm.tsx" startLineNumber={25} "id={application?.id ?? ''}"
-<input type="hidden" id="id" name="id" defaultValue={application?.id ?? ''} />
+<input type="hidden" id="id" name="id" defaultValue={application?.id ?? ""} />
 ```
 
 <Aside type="tip" title="Hidden Input Field">
-This is personal preference, but I like to list any `hidden` inputs next to the submit button, making them easy to find.
+  This is personal preference, but I like to list any `hidden` inputs next to
+  the submit button, making them easy to find.
 </Aside>
 
 Perfect! Now test the update form within the browser. You should be able to edit and save changes to our application.
@@ -1430,5 +1447,6 @@ Perfect! Now test the update form within the browser. You should be able to edit
 💥 We did it! Now, we just need to get our application online where people can use it!
 
 <Aside type="tip" title="Code on GitHub">
-You can find the final code for this step on [GitHub](https://github.com/ahaywood/applywize/tree/main).
+  You can find the final code for this step on
+  [GitHub](https://github.com/ahaywood/applywize/tree/main).
 </Aside>

--- a/docs/src/content/docs/tutorial/full-stack-app/8-jobs-details.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/8-jobs-details.mdx
@@ -6,7 +6,7 @@ sidebar:
 description: A guide in my new Starlight docs site.
 ---
 
-import { Aside, FileTree } from "@astrojs/starlight/components";
+import { Aside, FileTree } from '@astrojs/starlight/components';
 
 Can you believe it?! This is the last piece we need before deploying our application.
 
@@ -23,18 +23,26 @@ Pretty simple, right?
 Let's start by creating a new file in our `src/app/pages/applications` folder called `Details.tsx`.
 
 <FileTree>
-  - src - app - pages - applications - actions.ts - Details.tsx - List.tsx -
-  New.tsx
+- src
+  - app
+    - pages
+      - applications
+        - actions.ts
+        - Details.tsx
+        - List.tsx
+        - New.tsx
 </FileTree>
 
 We can start with the basics:
 
 ```tsx title="/src/app/pages/applications/Details.tsx"
 const Details = () => {
-  return <div>Details</div>;
-};
+  return (
+    <div>Details</div>
+  )
+}
 
-export { Details };
+export { Details }
 ```
 
 Now, let's jump over to our `worker.tsx` file and update the route for our details page.
@@ -74,13 +82,13 @@ return (
   <InteriorLayout>
     <p>Details</p>
   </InteriorLayout>
-);
+)
 ```
 
 Be sure to import `InteriorLayout` at the top of our file:
 
 ```tsx title="/src/app/pages/applications/Details.tsx"
-import { InteriorLayout } from "@/app/layouts/InteriorLayout";
+import { InteriorLayout } from "@/app/layouts/InteriorLayout"
 ```
 
 Already, that makes a huge difference:
@@ -151,7 +159,7 @@ return (
     </div>
     <p>Details</p>
   </InteriorLayout>
-);
+)
 ```
 
 We need to update the breadcrumb links. The first link is for our Dashboard:
@@ -175,7 +183,7 @@ Everything after `applications/` is the application id.
 We can get all the details we need based on the `RequestInfo` object that gets passed into all pages by default.
 
 ```tsx title="/src/app/pages/applications/Details.tsx" startLineNumber={3} {1} "{ params }: RequestInfo"
-import { RequestInfo } from "rwsdk/worker"
+import { RequestInfo } from "@redwoodjs/sdk/worker"
 
 const Details = async ({ params }: RequestInfo) => {
 ```
@@ -187,13 +195,12 @@ The `RequestInfo` object contains:
 - `ctx`: The app context
 
 [You can find more information here.](/reference/sdk-worker/#requestinfo-requestinfo)
-
 </Aside>
 
 Let's `console.log` the `params`, right before our `return` statement:
 
 ```tsx title="/src/app/pages/applications/Details.tsx" startLineNumber={6}
-console.log({ params });
+console.log({ params })
 ```
 
 Since this code is running on the server, this will get logged to the terminal, _not_ the browser.
@@ -202,7 +209,7 @@ Since this code is running on the server, this will get logged to the terminal, 
 
 Perfect! We can get the application ID by referencing `params.id`.
 
-Now, we can remove our `console.log` and make our database call:
+Now, we can remove our `console.log` and  make our database call:
 
 ```tsx title="/src/app/pages/applications/Details.tsx" startLineNumber={4} {1, 4-8}
 import { db } from "@/db"
@@ -247,7 +254,7 @@ const application = await db.application.findUnique({
   include: {
     company: true,
   },
-});
+})
 ```
 
 and actually, while we're here, let's go ahead and include our `applicationStatus` and `contact` relationships as well. Since the `contact` relationship is through our `company` object, we need to go another level deeper:
@@ -265,7 +272,7 @@ const application = await db.application.findUnique({
       },
     },
   },
-});
+})
 ```
 
 We can get rid of our `console.log` statement and move down the page.
@@ -304,9 +311,9 @@ Below our bread crumbs, let's start with our JSX and then we can come back and s
 At the top of our file, we need to add a few imports:
 
 ```tsx title="/src/app/pages/applications/Details.tsx" showLineNumbers=false
-import { Badge, badgeVariants } from "@/app/components/ui/badge";
-import { Button } from "@/app/components/ui/button";
-import { VariantProps } from "class-variance-authority";
+import { Badge, badgeVariants } from "@/app/components/ui/badge"
+import { Button } from "@/app/components/ui/button"
+import { VariantProps } from "class-variance-authority"
 ```
 
 Now, let's do another pass, this time adding our styles.
@@ -355,26 +362,12 @@ I want to add some space to the left and right side. But, this will also need to
     <div>
       <div className="flex items-center gap-5 mb-1">
         <h1 className="page-title">{application?.jobTitle}</h1>
-        <Badge
-          variant={
-            application?.applicationStatus?.status.toLowerCase() as VariantProps<
-              typeof badgeVariants
-            >["variant"]
-          }
-        >
-          {application?.applicationStatus?.status}
-        </Badge>
+        <Badge variant={application?.applicationStatus?.status.toLowerCase() as VariantProps<typeof badgeVariants>['variant']}>{application?.applicationStatus?.status}</Badge>
       </div>
-      <p>
-        <span className="text-zinc-500">at</span> {application?.company?.name}
-      </p>
+      <p><span className="text-zinc-500">at</span> {application?.company?.name}</p>
     </div>
     <div>
-      <Button>
-        <a href={application?.postingUrl as string} target="_blank">
-          View Application
-        </a>
-      </Button>
+      <Button><a href={application?.postingUrl as string} target="_blank">View Application</a></Button>
     </div>
   </header>
 
@@ -404,7 +397,7 @@ Now, within our CSS file, inside the `@layer components` section, let's add our 
 
 ```css title="/src/styles.css" startLineNumber={319}
 .two-column-grid {
-  @apply grid grid-cols-2 gap-[200px] mb-[75px];
+  @apply grid grid-cols-2 gap-[200px] mb-[75px]
 }
 ```
 
@@ -560,9 +553,7 @@ Now, let's paste our code into our `Details.tsx` file.
   {contacts && (
     <ul>
       {contacts.map((contact) => (
-        <li key={contact.id}>
-          <ContactCard contact={contact} />
-        </li>
+        <li key={contact.id}><ContactCard contact={contact} /></li>
       ))}
     </ul>
   )}
@@ -572,7 +563,7 @@ Now, let's paste our code into our `Details.tsx` file.
 At the top of our file, import the `ContactCard` component:
 
 ```tsx title="/src/app/pages/applications/Details.tsx" showLineNumbers=false
-import { ContactCard } from "@/app/components/ContactCard";
+import { ContactCard } from "@/app/components/ContactCard"
 ```
 
 On our Contact box, we have some linting errors because it cannot find our `contacts`.
@@ -582,17 +573,13 @@ On our Contact box, we have some linting errors because it cannot find our `cont
 We have this data, but it's nested inside our `application.company` object. We can adjust our conditional statement and the object we're mapping over to get rid of the error:
 
 ```tsx title="/src/app/pages/applications/Details.tsx" startLineNumber={78} "application?.company?.contacts"
-{
-  application?.company?.contacts && (
-    <ul>
-      {application?.company?.contacts.map((contact) => (
-        <li key={contact.id}>
-          <ContactCard contact={contact} />
-        </li>
-      ))}
-    </ul>
-  );
-}
+{application?.company?.contacts && (
+  <ul>
+    {application?.company?.contacts.map((contact) => (
+      <li key={contact.id}><ContactCard contact={contact} /></li>
+    ))}
+  </ul>
+)}
 ```
 
 Amazing!
@@ -611,35 +598,28 @@ I made the `isEditable` prop optional and set it to `true` by default. This way,
 Now, I'm going to wrap our Delete button with a conditional statement that checks if `isEditable` is `true`:
 
 ```tsx title="/src/app/components/ContactCard.tsx" startLineNumber={22} {1, 10}
-{
-  isEditable && (
-    <div className="hidden group-hover/card:block pr-10 absolute top-1 -left-[37px]">
-      <button
-        role="button"
-        className="hover:bg-black cursor-pointer text-white fill-current rounded-full bg-destructive p-1"
-        onClick={(e) => handleDelete(e)}
-      >
-        <Icon id="close" size={16} />
-      </button>
-    </div>
-  );
-}
+{isEditable && (
+  <div className="hidden group-hover/card:block pr-10 absolute top-1 -left-[37px]">
+    <button role="button"
+      className="hover:bg-black cursor-pointer text-white fill-current rounded-full bg-destructive p-1"
+      onClick={(e) => handleDelete(e)}
+    >
+      <Icon id="close" size={16} />
+    </button>
+  </div>
+)}
 ```
 
 Back on our `Details` page, where we're looping over the `ContactCard` component, we can pass in `false` for the `isEditable` prop:
 
 ```tsx title="/src/app/pages/applications/Details.tsx" startLineNumber={78} "isEditable={false}"
-{
-  application?.company?.contacts && (
-    <ul>
-      {application?.company?.contacts.map((contact) => (
-        <li key={contact.id}>
-          <ContactCard contact={contact} isEditable={false} />
-        </li>
-      ))}
-    </ul>
-  );
-}
+{application?.company?.contacts && (
+  <ul>
+    {application?.company?.contacts.map((contact) => (
+      <li key={contact.id}><ContactCard contact={contact} isEditable={false} /></li>
+    ))}
+  </ul>
+)}
 ```
 
 If you test this out in the browser, you'll see that the delete button doesn't appear when you hover over a contact card on the `Details` page, but it still appears on the `New Application` page.
@@ -677,16 +657,23 @@ The `Dialog` component requires button clicks and maintaining state, so we'll ne
 
 Inside our `src/app/components`, let's create a new file and name it `DeleteApplicationButton.tsx`
 
-<FileTree>- src/ - app/ - components/ - DeleteApplicationButton.tsx</FileTree>
+<FileTree>
+- src/
+  - app/
+    - components/
+      - DeleteApplicationButton.tsx
+</FileTree>
 
 Let's start with a bare bones component:
 
 ```tsx title="/src/app/components/DeleteApplicationButton.tsx"
 const DeleteApplicationButton = () => {
-  return <div>DeleteApplicationButton</div>;
-};
+  return (
+    <div>DeleteApplicationButton</div>
+  )
+}
 
-export { DeleteApplicationButton };
+export { DeleteApplicationButton }
 ```
 
 Then, we can replace the placeholder `<div>DeleteApplicationButton</div>` with the Dialog code from shadcn/ui:
@@ -748,9 +735,7 @@ If you look at the DOM that's rendered in the browser, `DialogTrigger` renders a
 
 ```tsx title="/src/app/components/DeleteApplicationButton.tsx" startLineNumber={20} "asChild"
 <DialogTrigger asChild>
-  <Button variant="link" className="text-destructive fill-current">
-    <Icon id="trash" size={16} /> Delete
-  </Button>
+  <Button variant="link" className="text-destructive fill-current"><Icon id="trash" size={16} /> Delete</Button>
 </DialogTrigger>
 ```
 
@@ -764,8 +749,7 @@ For the `DialogDescription`, we can use the text: "This will permanently delete 
 
 ```tsx title="/src/app/components/DeleteApplicationButton.tsx" startLineNumber={26}
 <DialogDescription>
-  This will permanently delete the application and any related companies and
-  contacts. This action cannot be undone.
+  This will permanently delete the application and any related companies and contacts. This action cannot be undone.
 </DialogDescription>
 ```
 
@@ -926,9 +910,7 @@ Then, we can use the `Dialog`'s props, `open` and `onOpenChange`, to control the
 Now, we can update the "Nevermind" button to close the dialog box, by updating the `isOpen` state:
 
 ```tsx title="/src/app/components/DeleteApplicationButton.tsx" startLineNumber={34}
-<Button variant="secondary" onClick={() => setIsOpen(false)}>
-  Nevermind
-</Button>
+<Button variant="secondary" onClick={ () => setIsOpen(false) }>Nevermind</Button>
 ```
 
 If you test this in the browser, the "Nevermind" button should close the dialog box, without deleting the application. 😎
@@ -942,8 +924,15 @@ Our application is looking great, but we're missing one thing: the ability to ed
 Let's take the smarter, not harder approach and start with our `New` application form page and modify it. Let's duplicate the `New.tsx` file and name the new file `Edit.tsx`.
 
 <FileTree>
-  - src/ - app/ - pages/ - applications/ - actions.ts - Details.tsx - Edit.tsx -
-  List.tsx - New.tsx
+- src/
+  - app/
+    - pages/
+      - applications/
+        - actions.ts
+        - Details.tsx
+        - Edit.tsx
+        - List.tsx
+        - New.tsx
 </FileTree>
 
 Inside, we need to rename our component to `Edit`
@@ -1007,7 +996,7 @@ Now, let's update the **Edit** button on the **Details** page so that we can eas
 You'll also need to import the `links` function at the top of our file:
 
 ```tsx title="/src/app/pages/applications/Details.tsx" showLineNumbers=false
-import { link } from "@/app/shared/links";
+import { link } from "@/app/shared/links"
 ```
 
 If you look at this in the browser and click on the **Edit** button, it should take you to a page that looks like the new application form. But, the URL is different.
@@ -1042,13 +1031,13 @@ const Edit = async ({ params, ctx }: RequestInfo) => {
 Be sure to import `RequestInfo` at the top of our file:
 
 ```tsx title="/src/app/pages/applications/Edit.tsx" showLineNumbers=false
-import { RequestInfo } from "rwsdk/worker";
+import { RequestInfo } from "@redwoodjs/sdk/worker"
 ```
 
 If we work our way down the file, we still need to grab _all_ the application statuses to populate the dropdown menu:
 
 ```tsx title="/src/app/pages/applications/Edit.tsx" startLineNumber={22}
-const statuses = await db.applicationStatus.findMany();
+const statuses = await db.applicationStatus.findMany()
 ```
 
 But, we can _delete_ the block of code where we get all the contacts that aren't related to a company:
@@ -1057,9 +1046,9 @@ But, we can _delete_ the block of code where we get all the contacts that aren't
 const contacts = await db.contact.findMany({
   where: {
     companyId: null,
-    userId: ctx.user?.id || "",
-  },
-});
+    userId: ctx.user?.id || ""
+  }
+})
 ```
 
 We already have all the contact information we need through the `application` database call.
@@ -1089,7 +1078,6 @@ Let's keep moving down the file. We can change our `BreadcrumbPage` to display t
 - Then, I changed the `BreadcrumbPage` to `Edit Application`.
 ---
 ```
-
 ![](./images/edit-job-application-breadcrumbs.png)
 
 Looking at the next section:
@@ -1153,16 +1141,17 @@ We updated the types that we're importing from Prisma to remove `Contact` and in
 
 You'll notice that our `Application` type also includes the `company` and `contacts` details.
 
+
 <Aside type="tip" title="Application Type">
 If the Application type looks too long and complex, you can always abstract it into it's own type:
 
 ```tsx
 type ApplicationWithCompanyAndContacts = Application & {
-  applicationStatus: ApplicationStatus;
+  applicationStatus: ApplicationStatus
   company: Company & {
-    contacts: Contact[];
-  };
-};
+    contacts: Contact[]
+  }
+}
 ```
 
 and then reference it like this:
@@ -1171,7 +1160,6 @@ and then reference it like this:
 const EditApplicationForm = ({ statuses, application }:
   { statuses: ApplicationStatus[], application: ApplicationWithCompanyAndContacts }) => {
 ```
-
 </Aside>
 
 Let's work our way through the form, for each input field, we want to set a `defaultValue`, referencing the application details.
@@ -1194,7 +1182,9 @@ Let's work our way through the form, for each input field, we want to set a `def
 Then, for the submit button, change the label from "Create" to "Update":
 
 ```tsx title="/src/app/components/EditApplicationForm.tsx" startLineNumber={77} "Update"
-<Button type="submit">Update</Button>
+<Button type="submit">
+  Update
+</Button>
 ```
 
 Let's add a second button, to cancel:
@@ -1218,10 +1208,7 @@ Let's add a second button, to cancel:
 For the Date Picker, we need to adjust the component slightly. If you try to pass in a `defaultValue`:
 
 ```tsx title="/src/app/components/EditApplicationForm.tsx" showLineNumbers=false
-<DatePicker
-  name="dateApplied"
-  defaultValue={application?.dateApplied?.toISOString() ?? ""}
-/>
+<DatePicker name="dateApplied" defaultValue={application?.dateApplied?.toISOString() ?? ''} />
 ```
 
 It will show a linting error because it's not prepared to accept that prop:
@@ -1276,10 +1263,7 @@ Instead of duplicating the `ContactForm` component, let's make it "smart" enough
 Inside our `EditApplicationForm` component, where we're using our `ContactForm` component, let's pass in the `companyId`:
 
 ```tsx title="/src/app/components/EditApplicationForm.tsx" startLineNumber={125} "companyId={application?.company?.id ?? ''"
-<ContactForm
-  callback={() => setIsContactSheetOpen(false)}
-  companyId={application?.company?.id ?? ""}
-/>
+<ContactForm callback={() => setIsContactSheetOpen(false)} companyId={application?.company?.id ?? ''} />
 ```
 
 Right away, you will see an error because our `ContactForm` isn't expecting a `companyId` prop. Let's fix that:
@@ -1299,7 +1283,7 @@ Inside the `handleSubmit` function, let's `append` the `companyId` to our `formD
 const handleSubmit = async (formData: FormData) => {
   formData.append("companyId", companyId);
   const result = await createContact(formData);
-};
+}
 ```
 
 Now, let's jump over to our `createContact` function, inside our `src/app/pages/applications/actions.tsx` file and get the `companyId` from the form data:
@@ -1357,7 +1341,7 @@ const handleSubmit = async (formData: FormData) => {
   } else {
     console.error(result.error);
   }
-};
+}
 ```
 
 We can remove line `26`, where we're appending the `contacts` to the `formData`.
@@ -1372,7 +1356,7 @@ const handleSubmit = async (formData: FormData) => {
   } else {
     console.error(result.error);
   }
-};
+}
 ```
 
 Be sure to update the import statement at the top of your file:
@@ -1434,12 +1418,11 @@ This is great, the only problem is that the application `id` does not exist in o
 Let's go back to our `EditApplicationForm` and add a `hidden` input field to our form:
 
 ```tsx title="/src/app/components/EditApplicationForm.tsx" startLineNumber={25} "id={application?.id ?? ''}"
-<input type="hidden" id="id" name="id" defaultValue={application?.id ?? ""} />
+<input type="hidden" id="id" name="id" defaultValue={application?.id ?? ''} />
 ```
 
 <Aside type="tip" title="Hidden Input Field">
-  This is personal preference, but I like to list any `hidden` inputs next to
-  the submit button, making them easy to find.
+This is personal preference, but I like to list any `hidden` inputs next to the submit button, making them easy to find.
 </Aside>
 
 Perfect! Now test the update form within the browser. You should be able to edit and save changes to our application.
@@ -1447,6 +1430,5 @@ Perfect! Now test the update form within the browser. You should be able to edit
 💥 We did it! Now, we just need to get our application online where people can use it!
 
 <Aside type="tip" title="Code on GitHub">
-  You can find the final code for this step on
-  [GitHub](https://github.com/ahaywood/applywize/tree/main).
+You can find the final code for this step on [GitHub](https://github.com/ahaywood/applywize/tree/main).
 </Aside>

--- a/docs/src/content/docs/tutorial/full-stack-app/8-jobs-details.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/8-jobs-details.mdx
@@ -183,7 +183,7 @@ Everything after `applications/` is the application id.
 We can get all the details we need based on the `RequestInfo` object that gets passed into all pages by default.
 
 ```tsx title="/src/app/pages/applications/Details.tsx" startLineNumber={3} {1} "{ params }: RequestInfo"
-import { RequestInfo } from "@redwoodjs/sdk/worker"
+import { RequestInfo } from "rwsdk/worker"
 
 const Details = async ({ params }: RequestInfo) => {
 ```
@@ -1031,7 +1031,7 @@ const Edit = async ({ params, ctx }: RequestInfo) => {
 Be sure to import `RequestInfo` at the top of our file:
 
 ```tsx title="/src/app/pages/applications/Edit.tsx" showLineNumbers=false
-import { RequestInfo } from "@redwoodjs/sdk/worker"
+import { RequestInfo } from "rwsdk/worker"
 ```
 
 If we work our way down the file, we still need to grab _all_ the application statuses to populate the dropdown menu:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Redwood SDK monorepo",
   "scripts": {
-    "link-sdk": "(cd sdk && pnpm build) && for starter in starters/*; do (cd $starter && npm pkg set dependencies.@redwoodjs/sdk='workspace:*'); done && pnpm install --ignore-scripts --no-frozen-lockfile",
+    "link-sdk": "(cd sdk && pnpm build) && for starter in starters/*; do (cd $starter && npm pkg set dependencies.rwsdk='workspace:*'); done && pnpm install --ignore-scripts --no-frozen-lockfile",
     "check-starters:dev": "for starter in starters/*; do ./scripts/check-app.sh dev $starter; done",
     "check-starters:preview": "for starter in starters/*; do ./scripts/check-app.sh preview $starter; done",
     "format": "prettier --write ./sdk/src starters/*/src"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,9 +168,9 @@ importers:
 
   starters/minimal:
     dependencies:
-      '@redwoodjs/sdk':
-        specifier: 0.0.79
-        version: 0.0.79(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250428.0)
+      rwsdk:
+        specifier: 0.0.79-test.20250506144558
+        version: 0.0.79-test.20250506144558(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250428.0)
     devDependencies:
       '@types/node':
         specifier: ^22.14.0
@@ -199,15 +199,15 @@ importers:
       '@prisma/client':
         specifier: ~6.5.0
         version: 6.5.0(prisma@6.5.0(typescript@5.8.3))(typescript@5.8.3)
-      '@redwoodjs/sdk':
-        specifier: 0.0.79
-        version: 0.0.79(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250428.0)
       '@simplewebauthn/browser':
         specifier: ^13.1.0
         version: 13.1.0
       '@simplewebauthn/server':
         specifier: ^13.1.1
         version: 13.1.1
+      rwsdk:
+        specifier: 0.0.79-test.20250506144558
+        version: 0.0.79-test.20250506144558(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250428.0)
     devDependencies:
       '@types/node':
         specifier: ^22.14.0
@@ -1230,12 +1230,6 @@ packages:
     resolution: {integrity: sha512-MHime7cxj7KGrapGZ1VqLkXXq5BLNqvjNZndRJVvMkUWn92F2bsezlWW1lKDoFaKCKu2xv9LRUZL99RYOs+ccA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
-
-  '@redwoodjs/sdk@0.0.79':
-    resolution: {integrity: sha512-d8dibPm594iiqV8mbwk7BGbMZZjtAFx3VeWaj3QCb98lPaEObQcjNr0NjpgFJmSs9j7r46tZoSXOUNQlZGPT2A==}
-    hasBin: true
-    peerDependencies:
-      vite: ^6.2.6
 
   '@rollup/plugin-replace@6.0.2':
     resolution: {integrity: sha512-7QaYCf8bqF04dOy7w/eHmJeNExxTYwvKAmlSAH/EaWWUzbT0h5sbF6bktFoX/0F/0qwng5/dWFMyf3gzaM8DsQ==}
@@ -3280,6 +3274,12 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  rwsdk@0.0.79-test.20250506144558:
+    resolution: {integrity: sha512-volpeTQUQwrww/1fpB0GYMhxNXCcyMmI3fYrkB8U3pGGOa27caLLpfPvgD+YE6XZL0rv8v6+uQCoswbgp/bRsg==}
+    hasBin: true
+    peerDependencies:
+      vite: ^6.2.6
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -4899,90 +4899,6 @@ snapshots:
   '@qwik.dev/partytown@0.11.0':
     dependencies:
       dotenv: 16.4.7
-
-  '@redwoodjs/sdk@0.0.79(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250428.0)':
-    dependencies:
-      '@cloudflare/vite-plugin': 1.1.0(rollup@4.40.0)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(workerd@1.20250428.0)(wrangler@4.14.1)
-      '@cloudflare/workers-types': 4.20250407.0
-      '@types/fs-extra': 11.0.4
-      '@types/react': 19.1.2
-      '@types/react-dom': 19.1.2(@types/react@19.1.2)
-      '@types/react-is': 19.0.0
-      '@vitejs/plugin-react': 4.3.4(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))
-      debug: 4.4.0
-      enhanced-resolve: 5.18.1
-      es-module-lexer: 1.6.0
-      eventsource-parser: 3.0.0
-      execa: 9.5.2
-      fs-extra: 11.3.0
-      glob: 11.0.1
-      jsonc-parser: 3.3.1
-      lodash: 4.17.21
-      magic-string: 0.30.17
-      miniflare: 4.20250428.1
-      picocolors: 1.1.1
-      react: 19.2.0-canary-39cad7af-20250411
-      react-dom: 19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411)
-      react-is: 19.0.0
-      react-server-dom-webpack: 19.2.0-canary-39cad7af-20250411(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)(webpack@5.97.1(esbuild@0.25.0))
-      rsc-html-stream: 0.0.3
-      tmp-promise: 3.0.3
-      ts-morph: 25.0.1
-      unique-names-generator: 4.7.1
-      vibe-rules: 0.2.31
-      vite: 6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0)
-      vite-tsconfig-paths: 5.1.4(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))
-      wrangler: 4.14.1(@cloudflare/workers-types@4.20250407.0)
-    transitivePeerDependencies:
-      - bufferutil
-      - rollup
-      - supports-color
-      - typescript
-      - utf-8-validate
-      - webpack
-      - workerd
-
-  '@redwoodjs/sdk@0.0.79(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250428.0)':
-    dependencies:
-      '@cloudflare/vite-plugin': 1.1.0(rollup@4.40.0)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(workerd@1.20250428.0)(wrangler@4.14.1)
-      '@cloudflare/workers-types': 4.20250407.0
-      '@types/fs-extra': 11.0.4
-      '@types/react': 19.1.2
-      '@types/react-dom': 19.1.2(@types/react@19.1.2)
-      '@types/react-is': 19.0.0
-      '@vitejs/plugin-react': 4.3.4(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))
-      debug: 4.4.0
-      enhanced-resolve: 5.18.1
-      es-module-lexer: 1.6.0
-      eventsource-parser: 3.0.0
-      execa: 9.5.2
-      fs-extra: 11.3.0
-      glob: 11.0.1
-      jsonc-parser: 3.3.1
-      lodash: 4.17.21
-      magic-string: 0.30.17
-      miniflare: 4.20250428.1
-      picocolors: 1.1.1
-      react: 19.2.0-canary-39cad7af-20250411
-      react-dom: 19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411)
-      react-is: 19.0.0
-      react-server-dom-webpack: 19.2.0-canary-39cad7af-20250411(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)(webpack@5.97.1)
-      rsc-html-stream: 0.0.3
-      tmp-promise: 3.0.3
-      ts-morph: 25.0.1
-      unique-names-generator: 4.7.1
-      vibe-rules: 0.2.31
-      vite: 6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0)
-      vite-tsconfig-paths: 5.1.4(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))
-      wrangler: 4.14.1(@cloudflare/workers-types@4.20250407.0)
-    transitivePeerDependencies:
-      - bufferutil
-      - rollup
-      - supports-color
-      - typescript
-      - utf-8-validate
-      - webpack
-      - workerd
 
   '@rollup/plugin-replace@6.0.2(rollup@4.40.0)':
     dependencies:
@@ -7696,6 +7612,90 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rwsdk@0.0.79-test.20250506144558(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250428.0):
+    dependencies:
+      '@cloudflare/vite-plugin': 1.1.0(rollup@4.40.0)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(workerd@1.20250428.0)(wrangler@4.14.1)
+      '@cloudflare/workers-types': 4.20250407.0
+      '@types/fs-extra': 11.0.4
+      '@types/react': 19.1.2
+      '@types/react-dom': 19.1.2(@types/react@19.1.2)
+      '@types/react-is': 19.0.0
+      '@vitejs/plugin-react': 4.3.4(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))
+      debug: 4.4.0
+      enhanced-resolve: 5.18.1
+      es-module-lexer: 1.6.0
+      eventsource-parser: 3.0.0
+      execa: 9.5.2
+      fs-extra: 11.3.0
+      glob: 11.0.1
+      jsonc-parser: 3.3.1
+      lodash: 4.17.21
+      magic-string: 0.30.17
+      miniflare: 4.20250428.1
+      picocolors: 1.1.1
+      react: 19.2.0-canary-39cad7af-20250411
+      react-dom: 19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411)
+      react-is: 19.0.0
+      react-server-dom-webpack: 19.2.0-canary-39cad7af-20250411(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)(webpack@5.97.1(esbuild@0.25.0))
+      rsc-html-stream: 0.0.3
+      tmp-promise: 3.0.3
+      ts-morph: 25.0.1
+      unique-names-generator: 4.7.1
+      vibe-rules: 0.2.31
+      vite: 6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0)
+      vite-tsconfig-paths: 5.1.4(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))
+      wrangler: 4.14.1(@cloudflare/workers-types@4.20250407.0)
+    transitivePeerDependencies:
+      - bufferutil
+      - rollup
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - webpack
+      - workerd
+
+  rwsdk@0.0.79-test.20250506144558(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250428.0):
+    dependencies:
+      '@cloudflare/vite-plugin': 1.1.0(rollup@4.40.0)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(workerd@1.20250428.0)(wrangler@4.14.1)
+      '@cloudflare/workers-types': 4.20250407.0
+      '@types/fs-extra': 11.0.4
+      '@types/react': 19.1.2
+      '@types/react-dom': 19.1.2(@types/react@19.1.2)
+      '@types/react-is': 19.0.0
+      '@vitejs/plugin-react': 4.3.4(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))
+      debug: 4.4.0
+      enhanced-resolve: 5.18.1
+      es-module-lexer: 1.6.0
+      eventsource-parser: 3.0.0
+      execa: 9.5.2
+      fs-extra: 11.3.0
+      glob: 11.0.1
+      jsonc-parser: 3.3.1
+      lodash: 4.17.21
+      magic-string: 0.30.17
+      miniflare: 4.20250428.1
+      picocolors: 1.1.1
+      react: 19.2.0-canary-39cad7af-20250411
+      react-dom: 19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411)
+      react-is: 19.0.0
+      react-server-dom-webpack: 19.2.0-canary-39cad7af-20250411(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)(webpack@5.97.1)
+      rsc-html-stream: 0.0.3
+      tmp-promise: 3.0.3
+      ts-morph: 25.0.1
+      unique-names-generator: 4.7.1
+      vibe-rules: 0.2.31
+      vite: 6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0)
+      vite-tsconfig-paths: 5.1.4(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))
+      wrangler: 4.14.1(@cloudflare/workers-types@4.20250407.0)
+    transitivePeerDependencies:
+      - bufferutil
+      - rollup
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - webpack
+      - workerd
 
   safe-buffer@5.2.1: {}
 

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@redwoodjs/sdk",
+  "name": "rwsdk",
   "version": "0.0.79",
   "description": "Build fast, server-driven webapps on Cloudflare with SSR, RSC, and realtime",
   "type": "module",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rwsdk",
-  "version": "0.0.79",
+  "version": "0.0.79-test.20250506144558",
   "description": "Build fast, server-driven webapps on Cloudflare with SSR, RSC, and realtime",
   "type": "module",
   "bin": {

--- a/sdk/scripts/release.sh
+++ b/sdk/scripts/release.sh
@@ -2,7 +2,7 @@
 
 set -e  # Stop on first error
 
-DEPENDENCY_NAME="@redwoodjs/sdk"  # Replace with the actual package name
+DEPENDENCY_NAME="rwsdk"  # Replace with the actual package name
 
 show_help() {
   echo "Usage: pnpm release <patch|minor|major|test> [--dry]"

--- a/sdk/src/llms/rules/interruptors.ts
+++ b/sdk/src/llms/rules/interruptors.ts
@@ -123,7 +123,7 @@ route('/', [
 ### Composing Multiple Interruptors
 
 \`\`\`tsx
-import { route } from "@redwoodjs/sdk/router";
+import { route } from "rwsdk/router";
 import {
   requireAuth,
   validateUser,
@@ -154,7 +154,7 @@ route("/api/users", [
 ### Role-Based Access Control
 
 \`\`\`tsx
-import { getSession } from "@redwoodjs/sdk/auth";
+import { getSession } from "rwsdk/auth";
 
 // Create a function that generates role-based interruptors
 export function hasRole(allowedRoles) {
@@ -184,7 +184,7 @@ export const isUser = hasRole(["ADMIN", "EDITOR", "USER"]);
 Create a file at \`./src/app/interruptors.ts\`:
 
 \`\`\`tsx
-import { getSession } from "@redwoodjs/sdk/auth";
+import { getSession } from "rwsdk/auth";
 
 // Authentication interruptors
 export async function requireAuth({ request, ctx }) {
@@ -228,7 +228,7 @@ Then import these interruptors in your route files:
 
 \`\`\`tsx
 // src/app/pages/admin/routes.ts
-import { route } from "@redwoodjs/sdk/router";
+import { route } from "rwsdk/router";
 import { isAdmin, logRequests } from "@/app/interruptors";
 
 import { AdminDashboard } from "./AdminDashboard";

--- a/sdk/src/llms/rules/react.ts
+++ b/sdk/src/llms/rules/react.ts
@@ -73,7 +73,7 @@ Example:
 \`\`\`tsx
 "use server";
 
-import { requestInfo } from "@redwoodjs/sdk/worker";
+import { requestInfo } from "rwsdk/worker";
 
 export async function addTodo(formData: FormData) {
   const { ctx } = requestInfo;
@@ -88,7 +88,7 @@ export async function addTodo(formData: FormData) {
 2. Access context via:
    - requestInfo in server functions:
    \`\`\`
-   import { requestInfo } from "@redwoodjs/sdk/worker";
+   import { requestInfo } from "rwsdk/worker";
    const { ctx } = requestInfo
    \`\`\`
 3. Context is populated by middleware and interruptors and is request-scoped.

--- a/sdk/src/llms/rules/request-response.ts
+++ b/sdk/src/llms/rules/request-response.ts
@@ -68,7 +68,7 @@ route("/docs/*/version/*", function handler({ params }) {
 #### Plain Text Response
 
 \`\`\`tsx
-import { route } from "@redwoodjs/sdk/router";
+import { route } from "rwsdk/router";
 
 route("/api/status", function handler() {
   return new Response("OK", {
@@ -81,7 +81,7 @@ route("/api/status", function handler() {
 #### JSON Response
 
 \`\`\`tsx
-import { route } from "@redwoodjs/sdk/router";
+import { route } from "rwsdk/router";
 
 route("/api/users/:id", function handler({ params }) {
   const userData = { id: params.id, name: "John Doe", email: "john@example.com" }
@@ -98,7 +98,7 @@ route("/api/users/:id", function handler({ params }) {
 #### JSX/React Components Response
 
 \`\`\`tsx
-import { route } from "@redwoodjs/sdk/router";
+import { route } from "rwsdk/router";
 import { UserProfile } from '@/app/components/UserProfile'
 
 route("/users/:id", function handler({ params }) {
@@ -109,7 +109,7 @@ route("/users/:id", function handler({ params }) {
 #### Custom Document Template
 
 \`\`\`tsx
-import { render, route } from "@redwoodjs/sdk/router";
+import { render, route } from "rwsdk/router";
 import { Document } from '@/app/Document'
 
 render(Document, [
@@ -125,7 +125,7 @@ render(Document, [
 ### Error Handling
 
 \`\`\`tsx
-import { route } from "@redwoodjs/sdk/router";
+import { route } from "rwsdk/router";
 
 route("/api/posts/:id", async function handler({ params }) {
   try {
@@ -154,7 +154,7 @@ route("/api/posts/:id", async function handler({ params }) {
 Create a file at \`./src/app/pages/blog/routes.ts\`:
 
 \`\`\`tsx
-import { route } from "@redwoodjs/sdk/router";
+import { route } from "rwsdk/router";
 import { isAdminUser } from '@/app/interceptors'
 
 import { BlogLandingPage } from './BlogLandingPage'
@@ -172,7 +172,7 @@ Then import these routes in your main worker file:
 
 \`\`\`tsx
 // src/worker.tsx
-import { defineApp, render, route, prefix } from "@redwoodjs/sdk/router";
+import { defineApp, render, route, prefix } from "rwsdk/router";
 import { Document } from '@/app/Document'
 import { HomePage } from '@/app/pages/home/HomePage'
 import { routes as blogRoutes } from '@/app/pages/blog/routes'
@@ -189,7 +189,7 @@ export default defineApp([
 ### Advanced: Route with Query Parameters
 
 \`\`\`tsx
-import { route } from "@redwoodjs/sdk/router";
+import { route } from "rwsdk/router";
 
 route("/api/search", function handler({ request }) {
   const url = new URL(request.url)

--- a/sdk/src/scripts/__sdk.mts
+++ b/sdk/src/scripts/__sdk.mts
@@ -5,7 +5,7 @@ export const __sdk = async (...args: string[]) => {
 
   await $({
     shell: true,
-  })`(cd ../../sdk && NODE_ENV=development pnpm build) && pnpm clean:vite && rm -r node_modules/@redwoodjs/sdk/dist && cp -r ../../sdk/{package.json,dist} node_modules/@redwoodjs/sdk/`;
+  })`(cd ../../sdk && NODE_ENV=development pnpm build) && pnpm clean:vite && rm -r node_modules/rwsdk/dist && cp -r ../../sdk/{package.json,dist} node_modules/rwsdk/`;
 
   if (args.length > 0) {
     await $({ stdio: "inherit" })`pnpm ${args.join(" ")}`;

--- a/sdk/src/scripts/debug-sync.mts
+++ b/sdk/src/scripts/debug-sync.mts
@@ -10,7 +10,7 @@ export const debugSync = async () => {
     process.exit(1);
   }
 
-  const syncCommand = `echo 🏗️ rebuilding... && pnpm build && rm -rf ${targetDir}/node_modules/@redwoodjs/sdk/{dist,vendor} && cp -r dist ${targetDir}/node_modules/@redwoodjs/sdk/ && cp -r vendor ${targetDir}/node_modules/@redwoodjs/sdk/ && echo ✅ done`;
+  const syncCommand = `echo 🏗️ rebuilding... && pnpm build && rm -rf ${targetDir}/node_modules/rwsdk/{dist,vendor} && cp -r dist ${targetDir}/node_modules/rwsdk/ && cp -r vendor ${targetDir}/node_modules/rwsdk/ && echo ✅ done`;
 
   // Run initial sync
   await $({ stdio: "inherit", shell: true })`${syncCommand}`;

--- a/sdk/src/scripts/ensure-deploy-env.mts
+++ b/sdk/src/scripts/ensure-deploy-env.mts
@@ -57,7 +57,7 @@ const hasAuthUsage = async () => {
   const files = await glob("src/**/*.{ts,tsx}", { ignore: "node_modules/**" });
   for (const file of files) {
     const content = await readFile(file, "utf-8");
-    if (content.includes("@redwoodjs/sdk/auth")) {
+    if (content.includes("rwsdk/auth")) {
       return true;
     }
   }

--- a/sdk/src/vite/transformJsxScriptTagsPlugin.mts
+++ b/sdk/src/vite/transformJsxScriptTagsPlugin.mts
@@ -122,7 +122,7 @@ export async function transformJsxScriptTagsCode(
   // Scan for imports only once
   sourceFile.getImportDeclarations().forEach((importDecl) => {
     const moduleSpecifier = importDecl.getModuleSpecifierValue();
-    if (moduleSpecifier === "@redwoodjs/sdk/worker") {
+    if (moduleSpecifier === "rwsdk/worker") {
       sdkWorkerImportDecl = importDecl;
       // Check if requestInfo is already imported
       if (
@@ -359,7 +359,7 @@ export async function transformJsxScriptTagsCode(
     } else {
       // Add new import declaration
       sourceFile.addImportDeclaration({
-        moduleSpecifier: "@redwoodjs/sdk/worker",
+        moduleSpecifier: "rwsdk/worker",
         namedImports: ["requestInfo"],
       });
     }

--- a/sdk/src/vite/transformJsxScriptTagsPlugin.test.mts
+++ b/sdk/src/vite/transformJsxScriptTagsPlugin.test.mts
@@ -18,8 +18,7 @@ describe("transformJsxScriptTagsCode", () => {
 
     const result = await transformJsxScriptTagsCode(code, mockManifest);
 
-    expect(result?.code)
-      .toEqual(`import { requestInfo } from "@redwoodjs/sdk/worker";
+    expect(result?.code).toEqual(`import { requestInfo } from "rwsdk/worker";
 
       jsx("script", {
         src: "/assets/client-a1b2c3d4.js",
@@ -39,8 +38,7 @@ describe("transformJsxScriptTagsCode", () => {
 
     const result = await transformJsxScriptTagsCode(code, mockManifest);
 
-    expect(result?.code)
-      .toEqual(`import { requestInfo } from "@redwoodjs/sdk/worker";
+    expect(result?.code).toEqual(`import { requestInfo } from "rwsdk/worker";
 
       jsx("script", {
         type: "module",
@@ -57,8 +55,7 @@ describe("transformJsxScriptTagsCode", () => {
 
     const result = await transformJsxScriptTagsCode(code, mockManifest);
 
-    expect(result?.code)
-      .toEqual(`import { requestInfo } from "@redwoodjs/sdk/worker";
+    expect(result?.code).toEqual(`import { requestInfo } from "rwsdk/worker";
 
       jsx("script", { type: "module", children: "import(\\"\/assets\/client-a1b2c3d4.js\\")",
           nonce: requestInfo.rw.nonce
@@ -83,8 +80,7 @@ describe("transformJsxScriptTagsCode", () => {
 
     const result = await transformJsxScriptTagsCode(code, mockManifest);
 
-    expect(result?.code)
-      .toEqual(`import { requestInfo } from "@redwoodjs/sdk/worker";
+    expect(result?.code).toEqual(`import { requestInfo } from "rwsdk/worker";
 
       jsx("script", {
         type: "module",
@@ -114,8 +110,7 @@ describe("transformJsxScriptTagsCode", () => {
 
     const result = await transformJsxScriptTagsCode(code, mockManifest);
 
-    expect(result?.code)
-      .toEqual(`import { requestInfo } from "@redwoodjs/sdk/worker";
+    expect(result?.code).toEqual(`import { requestInfo } from "rwsdk/worker";
 
       jsx("script", {
         type: "module",
@@ -191,8 +186,7 @@ describe("transformJsxScriptTagsCode", () => {
 
     const result = await transformJsxScriptTagsCode(code, mockManifest);
 
-    expect(result?.code)
-      .toEqual(`import { requestInfo } from "@redwoodjs/sdk/worker";
+    expect(result?.code).toEqual(`import { requestInfo } from "rwsdk/worker";
 
       jsx("html", {
         lang: "en",
@@ -238,8 +232,7 @@ describe("transformJsxScriptTagsCode", () => {
 
     const result = await transformJsxScriptTagsCode(code, mockManifest);
 
-    expect(result?.code)
-      .toEqual(`import { requestInfo } from "@redwoodjs/sdk/worker";
+    expect(result?.code).toEqual(`import { requestInfo } from "rwsdk/worker";
 
       jsx("script", {
         src: "/src/non-existent.js",
@@ -259,8 +252,7 @@ describe("transformJsxScriptTagsCode", () => {
 
     const result = await transformJsxScriptTagsCode(code, mockManifest);
 
-    expect(result?.code)
-      .toEqual(`import { requestInfo } from "@redwoodjs/sdk/worker";
+    expect(result?.code).toEqual(`import { requestInfo } from "rwsdk/worker";
 
       jsx("script", {
         src: "/assets/client-a1b2c3d4.js",
@@ -280,8 +272,7 @@ describe("transformJsxScriptTagsCode", () => {
 
     const result = await transformJsxScriptTagsCode(code, {});
 
-    expect(result?.code)
-      .toEqual(`import { requestInfo } from "@redwoodjs/sdk/worker";
+    expect(result?.code).toEqual(`import { requestInfo } from "rwsdk/worker";
 
       jsx("script", {
         type: "module",
@@ -321,7 +312,7 @@ describe("transformJsxScriptTagsCode", () => {
   it("uses existing requestInfo import if already present", async () => {
     const code = `
       import { foo } from 'bar';
-      import { requestInfo, someOtherThing } from "@redwoodjs/sdk/worker";
+      import { requestInfo, someOtherThing } from "rwsdk/worker";
       
       jsx("script", {
         type: "module",
@@ -333,7 +324,7 @@ describe("transformJsxScriptTagsCode", () => {
 
     expect(result?.code).toEqual(`
       import { foo } from 'bar';
-      import { requestInfo, someOtherThing } from "@redwoodjs/sdk/worker";
+      import { requestInfo, someOtherThing } from "rwsdk/worker";
       
       jsx("script", {
         type: "module",
@@ -352,7 +343,7 @@ describe("transformJsxScriptTagsCode", () => {
   it("adds requestInfo to existing SDK import if module already imported", async () => {
     const code = `
       import { foo } from 'bar';
-      import { someOtherThing } from "@redwoodjs/sdk/worker";
+      import { someOtherThing } from "rwsdk/worker";
       
       jsx("script", {
         type: "module",
@@ -364,7 +355,7 @@ describe("transformJsxScriptTagsCode", () => {
 
     expect(result?.code).toEqual(`
       import { foo } from 'bar';
-      import { someOtherThing, requestInfo } from "@redwoodjs/sdk/worker";
+      import { someOtherThing, requestInfo } from "rwsdk/worker";
       
       jsx("script", {
         type: "module",
@@ -385,8 +376,7 @@ describe("transformJsxScriptTagsCode", () => {
     // Call without providing manifest (simulating dev mode)
     const result = await transformJsxScriptTagsCode(code);
 
-    expect(result?.code)
-      .toEqual(`import { requestInfo } from "@redwoodjs/sdk/worker";
+    expect(result?.code).toEqual(`import { requestInfo } from "rwsdk/worker";
 
       jsx("script", {
         src: "/src/client.tsx",

--- a/sdk/src/vite/transformJsxScriptTagsPlugin.test.mts
+++ b/sdk/src/vite/transformJsxScriptTagsPlugin.test.mts
@@ -334,9 +334,8 @@ describe("transformJsxScriptTagsCode", () => {
     `);
 
     // Ensure we didn't duplicate the import
-    const importCount = (
-      result?.code.match(/from "@redwoodjs\/sdk\/worker"/g) || []
-    ).length;
+    const importCount = (result?.code.match(/from "rwsdk\/worker"/g) || [])
+      .length;
     expect(importCount).toBe(1);
   });
 

--- a/sdk/src/vite/useClientPlugin.mts
+++ b/sdk/src/vite/useClientPlugin.mts
@@ -57,7 +57,7 @@ export async function transformUseClientCode(
 
   // Add import declaration properly through the AST
   sourceFile.addImportDeclaration({
-    moduleSpecifier: "@redwoodjs/sdk/worker",
+    moduleSpecifier: "rwsdk/worker",
     namedImports: [{ name: "registerClientReference" }],
   });
 

--- a/sdk/src/vite/useClientPlugin.test.mts
+++ b/sdk/src/vite/useClientPlugin.test.mts
@@ -15,7 +15,7 @@ export const Component = () => {
   return jsx('div', { children: 'Hello' });
 }`),
     ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+      "import { registerClientReference } from "rwsdk/worker";
       const ComponentSSR = () => {
         return jsx('div', { children: 'Hello' });
       }
@@ -32,7 +32,7 @@ export const foo = "bar"
 export const baz = 23
 }`),
     ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+      "import { registerClientReference } from "rwsdk/worker";
       export const foo = "bar"
       export const baz = 23
       }"
@@ -47,7 +47,7 @@ export const Component = async () => {
   return jsx('div', { children: 'Hello' });
 }`),
     ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+      "import { registerClientReference } from "rwsdk/worker";
       const ComponentSSR = async () => {
         return jsx('div', { children: 'Hello' });
       }
@@ -64,7 +64,7 @@ export function Component() {
   return jsx('div', { children: 'Hello' });
 }`),
     ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+      "import { registerClientReference } from "rwsdk/worker";
 
       function ComponentSSR() {
         return jsx('div', { children: 'Hello' });
@@ -82,7 +82,7 @@ export async function Component() {
   return jsx('div', { children: 'Hello' });
 }`),
     ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+      "import { registerClientReference } from "rwsdk/worker";
 
       async function ComponentSSR() {
         return jsx('div', { children: 'Hello' });
@@ -104,7 +104,7 @@ export const Second = () => {
   return jsx('div', { children: 'Second' });
 }`),
     ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+      "import { registerClientReference } from "rwsdk/worker";
       const FirstSSR = () => {
         return jsx('div', { children: 'First' });
       }
@@ -131,7 +131,7 @@ export const Second = async () => {
   return jsx('div', { children: 'Second' });
 }`),
     ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+      "import { registerClientReference } from "rwsdk/worker";
       const FirstSSR = async () => {
         return jsx('div', { children: 'First' });
       }
@@ -158,7 +158,7 @@ export function Second() {
   return jsx('div', { children: 'Second' });
 }`),
     ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+      "import { registerClientReference } from "rwsdk/worker";
 
       function FirstSSR() {
         return jsx('div', { children: 'First' });
@@ -186,7 +186,7 @@ export async function Second() {
   return jsx('div', { children: 'Second' });
 }`),
     ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+      "import { registerClientReference } from "rwsdk/worker";
 
       async function FirstSSR() {
         return jsx('div', { children: 'First' });
@@ -216,7 +216,7 @@ const Second = () => {
 
 export { First, Second }`),
     ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+      "import { registerClientReference } from "rwsdk/worker";
       const FirstSSR = () => {
         return jsx('div', { children: 'First' });
       }
@@ -306,7 +306,7 @@ export { Button, buttonVariants }
       import { jsx, jsxs } from "react/jsx-runtime"
 
       import { cn } from "@/lib/utils"
-      import { registerClientReference } from "@redwoodjs/sdk/worker";
+      import { registerClientReference } from "rwsdk/worker";
 
       const buttonVariants = cva(
         "font-bold inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
@@ -382,7 +382,7 @@ const Second = async () => {
 
 export { First, Second }`),
     ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+      "import { registerClientReference } from "rwsdk/worker";
       const FirstSSR = async () => {
         return jsx('div', { children: 'First' });
       }
@@ -411,7 +411,7 @@ function Second() {
 
 export { First, Second }`),
     ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+      "import { registerClientReference } from "rwsdk/worker";
 
       function FirstSSR() {
         return jsx('div', { children: 'First' });
@@ -441,7 +441,7 @@ async function Second() {
 
 export { First, Second }`),
     ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+      "import { registerClientReference } from "rwsdk/worker";
 
       async function FirstSSR() {
         return jsx('div', { children: 'First' });
@@ -465,7 +465,7 @@ export default () => {
   return jsx('div', { children: 'Hello' });
 }`),
     ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+      "import { registerClientReference } from "rwsdk/worker";
       const DefaultComponent0SSR = () => {
         return jsx('div', { children: 'Hello' });
       }
@@ -482,7 +482,7 @@ export default async () => {
   return jsx('div', { children: 'Hello' });
 }`),
     ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+      "import { registerClientReference } from "rwsdk/worker";
       const DefaultComponent0SSR = async () => {
         return jsx('div', { children: 'Hello' });
       }
@@ -661,7 +661,7 @@ export const MovieSelector = ({
       import { jsxDEV } from "react/jsx-dev-runtime";
       import { useState, useEffect, useRef } from "react";
       import { ChevronDownIcon, CheckIcon } from "./icons";
-      import { registerClientReference } from "@redwoodjs/sdk/worker";
+      import { registerClientReference } from "rwsdk/worker";
 
       const MovieSelectorSSR = ({
         label,
@@ -834,7 +834,7 @@ export default function Component({ prop1, prop2 }) {
   return jsx('div', { children: 'Hello' });
 }`),
     ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+      "import { registerClientReference } from "rwsdk/worker";
 
       function ComponentSSR({ prop1, prop2 }) {
         return jsx('div', { children: 'Hello' });
@@ -852,7 +852,7 @@ export default async function Component() {
   return jsx('div', { children: 'Hello' });
 }`),
     ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+      "import { registerClientReference } from "rwsdk/worker";
 
       async function ComponentSSR() {
         return jsx('div', { children: 'Hello' });
@@ -939,7 +939,7 @@ export function ComplexComponent({ initialCount = 0 }) {
   });
 }`),
     ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+      "import { registerClientReference } from "rwsdk/worker";
 
       function ComplexComponentSSR({ initialCount = 0 }) {
         const [count, setCount] = useState(initialCount);
@@ -1045,7 +1045,7 @@ export default function Main() {
 export { Second, Third }
 export { Fourth as AnotherName }`),
     ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+      "import { registerClientReference } from "rwsdk/worker";
       const FirstSSR = () => {
         return jsx('div', { children: 'First' });
       }
@@ -1089,7 +1089,7 @@ function Component({ prop1, prop2 }) {
 
 export default Component;`),
     ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "@redwoodjs/sdk/worker";
+      "import { registerClientReference } from "rwsdk/worker";
 
       function ComponentSSR({ prop1, prop2 }) {
         return jsx('div', { children: 'Hello' });
@@ -1105,7 +1105,7 @@ export default Component;`),
 import { jsxDEV } from "react/jsx-dev-runtime";
 import { sendMessage } from "./functions";
 import { useState } from "react";
-import { consumeEventStream } from "@redwoodjs/sdk/client";
+import { consumeEventStream } from "rwsdk/client";
 
 export function Chat() {
   const [message, setMessage] = useState("");
@@ -1186,8 +1186,8 @@ export function Chat() {
       "import { jsxDEV } from "react/jsx-dev-runtime";
       import { sendMessage } from "./functions";
       import { useState } from "react";
-      import { consumeEventStream } from "@redwoodjs/sdk/client";
-      import { registerClientReference } from "@redwoodjs/sdk/worker";
+      import { consumeEventStream } from "rwsdk/client";
+      import { registerClientReference } from "rwsdk/worker";
 
       function ChatSSR() {
         const [message, setMessage] = useState("");

--- a/sdk/src/vite/useServerPlugin.mts
+++ b/sdk/src/vite/useServerPlugin.mts
@@ -23,7 +23,7 @@ export const useServerPlugin = (): Plugin => ({
       if (this.environment.name === "worker") {
         // TODO: Rewrite the code, but register the "function" against
         s.prepend(`
-import { registerServerReference } from "@redwoodjs/sdk/worker";
+import { registerServerReference } from "rwsdk/worker";
 `);
         const [_, exports] = parse(code);
 
@@ -35,7 +35,7 @@ registerServerReference(${e.ln}, ${JSON.stringify(relativeId)}, ${JSON.stringify
       }
       if (this.environment.name === "client") {
         s = new MagicString(`\
-import { createServerReference } from "@redwoodjs/sdk/client";
+import { createServerReference } from "rwsdk/client";
 `);
         const [_, exports] = parse(code);
         for (const e of exports) {

--- a/starters/minimal/package.json
+++ b/starters/minimal/package.json
@@ -22,7 +22,7 @@
     "types": "tsc"
   },
   "dependencies": {
-    "@redwoodjs/sdk": "0.0.79"
+    "rwsdk": "0.0.79-test.20250506144558"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/starters/minimal/package.json
+++ b/starters/minimal/package.json
@@ -22,7 +22,7 @@
     "types": "tsc"
   },
   "dependencies": {
-    "rwsdk": "0.0.79"
+    "@redwoodjs/sdk": "0.0.79"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/starters/minimal/package.json
+++ b/starters/minimal/package.json
@@ -22,7 +22,7 @@
     "types": "tsc"
   },
   "dependencies": {
-    "@redwoodjs/sdk": "0.0.79"
+    "rwsdk": "0.0.79"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/starters/minimal/src/app/headers.ts
+++ b/starters/minimal/src/app/headers.ts
@@ -1,5 +1,5 @@
-import { RouteMiddleware } from "@redwoodjs/sdk/router";
-import { IS_DEV } from "@redwoodjs/sdk/constants";
+import { RouteMiddleware } from "rwsdk/router";
+import { IS_DEV } from "rwsdk/constants";
 
 export const setCommonHeaders =
   (): RouteMiddleware =>

--- a/starters/minimal/src/app/pages/Home.tsx
+++ b/starters/minimal/src/app/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { RequestInfo } from "@redwoodjs/sdk/worker";
+import { RequestInfo } from "rwsdk/worker";
 
 export function Home({ ctx }: RequestInfo) {
   return (

--- a/starters/minimal/src/app/shared/links.ts
+++ b/starters/minimal/src/app/shared/links.ts
@@ -1,3 +1,3 @@
-import { defineLinks } from "@redwoodjs/sdk/router";
+import { defineLinks } from "rwsdk/router";
 
 export const link = defineLinks(["/"]);

--- a/starters/minimal/src/client.tsx
+++ b/starters/minimal/src/client.tsx
@@ -1,3 +1,3 @@
-import { initClient } from "@redwoodjs/sdk/client";
+import { initClient } from "rwsdk/client";
 
 initClient();

--- a/starters/minimal/src/worker.tsx
+++ b/starters/minimal/src/worker.tsx
@@ -1,5 +1,5 @@
-import { defineApp } from "@redwoodjs/sdk/worker";
-import { index, render } from "@redwoodjs/sdk/router";
+import { defineApp } from "rwsdk/worker";
+import { index, render } from "rwsdk/router";
 
 import { Document } from "@/app/Document";
 import { Home } from "@/app/pages/Home";

--- a/starters/minimal/types/rw.d.ts
+++ b/starters/minimal/types/rw.d.ts
@@ -1,5 +1,5 @@
 import { AppContext } from "../src/worker";
 
-declare module "@redwoodjs/sdk/worker" {
+declare module "rwsdk/worker" {
   interface DefaultAppContext extends AppContext {}
 }

--- a/starters/minimal/vite.config.mts
+++ b/starters/minimal/vite.config.mts
@@ -1,5 +1,5 @@
 import { defineConfig } from "vite";
-import { redwood } from "@redwoodjs/sdk/vite";
+import { redwood } from "rwsdk/vite";
 
 export default defineConfig({
   plugins: [redwood()],

--- a/starters/standard/package.json
+++ b/starters/standard/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@prisma/adapter-d1": "~6.5.0",
     "@prisma/client": "~6.5.0",
-    "@redwoodjs/sdk": "0.0.79",
+    "rwsdk": "0.0.79-test.20250506144558",
     "@simplewebauthn/browser": "^13.1.0",
     "@simplewebauthn/server": "^13.1.1"
   },

--- a/starters/standard/package.json
+++ b/starters/standard/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@prisma/adapter-d1": "~6.5.0",
     "@prisma/client": "~6.5.0",
-    "@redwoodjs/sdk": "0.0.79",
+    "rwsdk": "0.0.79",
     "@simplewebauthn/browser": "^13.1.0",
     "@simplewebauthn/server": "^13.1.1"
   },

--- a/starters/standard/package.json
+++ b/starters/standard/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@prisma/adapter-d1": "~6.5.0",
     "@prisma/client": "~6.5.0",
-    "rwsdk": "0.0.79",
+    "@redwoodjs/sdk": "0.0.79",
     "@simplewebauthn/browser": "^13.1.0",
     "@simplewebauthn/server": "^13.1.1"
   },

--- a/starters/standard/src/app/headers.ts
+++ b/starters/standard/src/app/headers.ts
@@ -1,5 +1,5 @@
-import { RouteMiddleware } from "@redwoodjs/sdk/router";
-import { IS_DEV } from "@redwoodjs/sdk/constants";
+import { RouteMiddleware } from "rwsdk/router";
+import { IS_DEV } from "rwsdk/constants";
 
 export const setCommonHeaders =
   (): RouteMiddleware =>

--- a/starters/standard/src/app/pages/Home.tsx
+++ b/starters/standard/src/app/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { RequestInfo } from "@redwoodjs/sdk/worker";
+import { RequestInfo } from "rwsdk/worker";
 
 export function Home({ ctx }: RequestInfo) {
   return (

--- a/starters/standard/src/app/pages/user/functions.ts
+++ b/starters/standard/src/app/pages/user/functions.ts
@@ -9,7 +9,7 @@ import {
 } from "@simplewebauthn/server";
 
 import { sessions } from "@/session/store";
-import { requestInfo } from "@redwoodjs/sdk/worker";
+import { requestInfo } from "rwsdk/worker";
 import { db } from "@/db";
 import { env } from "cloudflare:workers";
 

--- a/starters/standard/src/app/pages/user/routes.ts
+++ b/starters/standard/src/app/pages/user/routes.ts
@@ -1,4 +1,4 @@
-import { route } from "@redwoodjs/sdk/router";
+import { route } from "rwsdk/router";
 import { Login } from "./Login";
 import { sessions } from "@/session/store";
 

--- a/starters/standard/src/app/shared/links.ts
+++ b/starters/standard/src/app/shared/links.ts
@@ -1,3 +1,3 @@
-import { defineLinks } from "@redwoodjs/sdk/router";
+import { defineLinks } from "rwsdk/router";
 
 export const link = defineLinks(["/"]);

--- a/starters/standard/src/client.tsx
+++ b/starters/standard/src/client.tsx
@@ -1,3 +1,3 @@
-import { initClient } from "@redwoodjs/sdk/client";
+import { initClient } from "rwsdk/client";
 
 initClient();

--- a/starters/standard/src/scripts/seed.ts
+++ b/starters/standard/src/scripts/seed.ts
@@ -1,4 +1,4 @@
-import { defineScript } from "@redwoodjs/sdk/worker";
+import { defineScript } from "rwsdk/worker";
 import { db, setupDb } from "@/db";
 
 export default defineScript(async ({ env }) => {

--- a/starters/standard/src/session/durableObject.ts
+++ b/starters/standard/src/session/durableObject.ts
@@ -1,4 +1,4 @@
-import { MAX_SESSION_DURATION } from "@redwoodjs/sdk/auth";
+import { MAX_SESSION_DURATION } from "rwsdk/auth";
 import { DurableObject } from "cloudflare:workers";
 
 export interface Session {

--- a/starters/standard/src/session/store.ts
+++ b/starters/standard/src/session/store.ts
@@ -1,4 +1,4 @@
-import { defineDurableSession } from "@redwoodjs/sdk/auth";
+import { defineDurableSession } from "rwsdk/auth";
 
 export let sessions: ReturnType<typeof createSessionStore>;
 

--- a/starters/standard/src/worker.tsx
+++ b/starters/standard/src/worker.tsx
@@ -1,5 +1,5 @@
-import { defineApp, ErrorResponse } from "@redwoodjs/sdk/worker";
-import { route, render, prefix } from "@redwoodjs/sdk/router";
+import { defineApp, ErrorResponse } from "rwsdk/worker";
+import { route, render, prefix } from "rwsdk/router";
 import { Document } from "@/app/Document";
 import { Home } from "@/app/pages/Home";
 import { setCommonHeaders } from "@/app/headers";

--- a/starters/standard/types/rw.d.ts
+++ b/starters/standard/types/rw.d.ts
@@ -1,5 +1,5 @@
 import { AppContext } from "../src/worker";
 
-declare module "@redwoodjs/sdk/worker" {
+declare module "rwsdk/worker" {
   interface DefaultAppContext extends AppContext {}
 }

--- a/starters/standard/vite.config.mts
+++ b/starters/standard/vite.config.mts
@@ -1,5 +1,5 @@
 import { defineConfig } from "vite";
-import { redwood } from "@redwoodjs/sdk/vite";
+import { redwood } from "rwsdk/vite";
 
 export default defineConfig({
   plugins: [redwood()],


### PR DESCRIPTION
Renames `@redwoodjs/sdk` to `rwsdk`!

## ⚠️ Note (will also appear in release)

To continue receiving updates and support, please:

1. Uninstall the old package:
```bash
npm uninstall @redwoodjs/sdk
```
2. Install the new package:
```
npm install rwsdk
```

3. Update all import paths:
```ts
// Before:
import { defineApp } from '@redwoodjs/sdk/worker'

// After:
import { defineApp } from 'rwsdk/worker'
```
---

* The GitHub repository remains the same: https://github.com/redwoodjs/sdk
* All future releases will be under the `rwsdk` name.