### PR TITLE
fix: Avoid grep for 'use client' scan

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,8 +169,8 @@ importers:
   starters/minimal:
     dependencies:
       rwsdk:
-        specifier: 0.0.80
-        version: 0.0.80(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250428.0)
+        specifier: 0.0.80-test.20250507145208
+        version: 0.0.80-test.20250507145208(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250428.0)
     devDependencies:
       '@types/node':
         specifier: ^22.14.0
@@ -206,8 +206,8 @@ importers:
         specifier: ^13.1.1
         version: 13.1.1
       rwsdk:
-        specifier: 0.0.80
-        version: 0.0.80(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250428.0)
+        specifier: 0.0.80-test.20250507145208
+        version: 0.0.80-test.20250507145208(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250428.0)
     devDependencies:
       '@types/node':
         specifier: ^22.14.0
@@ -3274,8 +3274,8 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
-  rwsdk@0.0.80:
-    resolution: {integrity: sha512-78BeG+gEAvkehjwYYyIBCKXeFjjEUmluOeGjxaU59yl0moUeql9ijwb+gNE6y3Rw3MOPsJhODAD0ZdzSrpoJHw==}
+  rwsdk@0.0.80-test.20250507145208:
+    resolution: {integrity: sha512-IvECxoqLNvFHhC82odOMb62G0UCs2w4Hi98/N5TO59TPzlb1Sr4tHK2tqAa0ny8VvcRVXmUtf72dG1McgiBw5g==}
     hasBin: true
     peerDependencies:
       vite: ^6.2.6
@@ -7613,7 +7613,7 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  rwsdk@0.0.80(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250428.0):
+  rwsdk@0.0.80-test.20250507145208(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1(esbuild@0.25.0))(workerd@1.20250428.0):
     dependencies:
       '@cloudflare/vite-plugin': 1.1.0(rollup@4.40.0)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(workerd@1.20250428.0)(wrangler@4.14.1)
       '@cloudflare/workers-types': 4.20250407.0
@@ -7655,7 +7655,7 @@ snapshots:
       - webpack
       - workerd
 
-  rwsdk@0.0.80(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250428.0):
+  rwsdk@0.0.80-test.20250507145208(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250428.0):
     dependencies:
       '@cloudflare/vite-plugin': 1.1.0(rollup@4.40.0)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(workerd@1.20250428.0)(wrangler@4.14.1)
       '@cloudflare/workers-types': 4.20250407.0

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rwsdk",
-  "version": "0.0.80",
+  "version": "0.0.80-test.20250507145208",
   "description": "Build fast, server-driven webapps on Cloudflare with SSR, RSC, and realtime",
   "type": "module",
   "bin": {

--- a/starters/minimal/package.json
+++ b/starters/minimal/package.json
@@ -22,7 +22,7 @@
     "types": "tsc"
   },
   "dependencies": {
-    "rwsdk": "0.0.80"
+    "rwsdk": "0.0.80-test.20250507145208"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/starters/standard/package.json
+++ b/starters/standard/package.json
@@ -31,7 +31,7 @@
     "@prisma/client": "~6.5.0",
     "@simplewebauthn/browser": "^13.1.0",
     "@simplewebauthn/server": "^13.1.1",
-    "rwsdk": "0.0.80"
+    "rwsdk": "0.0.80-test.20250507145208"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",


### PR DESCRIPTION
## Context

On deploys/builds, RedwoodSDK scans for "use client" directives to build a lookup map used for dynamically importing client-only modules. This is needed for codesplitting to load them correctly in production.

## Problem

The old version used a `grep` subprocess to find files. This worked locally but consistently failed in GitHub Actions — particularly with Cloudflare’s PR deploy setup. When that happened, the lookup map was empty and led to runtime errors like:
```
No module found for '/src/app/components/SomeComponent.tsx'
```
Not sure exactly why `grep` failed — could be anything from missing binaries to BusyBox behaviour or quoting issues in the container. Either way, it was brittle. Also, the approach was wrong to begin with since it matched "use client" anywhere in a file, not just where it actually matters: the first non-empty line.

## Solution

Replaced the grep call with a pure JS implementation using glob and fs/promises. It finds all .ts and .tsx files under the given path, reads each one, and checks just the first non-empty line for "use client".

* GH issue: https://github.com/redwoodjs/sdk/issues/413
* Discord thread: https://discord.com/channels/679514959968993311/1369406751887065129