### PR TITLE
feat: Smoke tests check server render

### DIFF
--- a/sdk/src/lib/smokeTests/cleanup.mts
+++ b/sdk/src/lib/smokeTests/cleanup.mts
@@ -64,8 +64,8 @@ export async function cleanupResources(
     }
   }
 
-  // Clean up resources
-  if (resources.workerName) {
+  // Clean up resources only if release tests have run
+  if (resources.workerName && state.releaseTestsRan) {
     // First, clean up any D1 databases associated with this worker
     try {
       log(
@@ -158,6 +158,13 @@ export async function cleanupResources(
           error instanceof Error && error.stack ? error.stack : undefined,
       });
     }
+  } else if (resources.workerName && !state.releaseTestsRan) {
+    log(
+      "Skipping worker and D1 database cleanup because release tests did not run",
+    );
+    console.log(
+      "⏭️ Skipping worker and D1 database cleanup (release tests did not run)",
+    );
   } else {
     log("No worker name provided for cleanup");
   }

--- a/sdk/src/lib/smokeTests/reporting.mts
+++ b/sdk/src/lib/smokeTests/reporting.mts
@@ -160,15 +160,18 @@ export async function generateFinalReport(): Promise<void> {
       console.log(
         `  │  └─ Client-side: ${formatTestStatus(state.testStatus.dev.initialClientSide)}`,
       );
-      console.log(`  └─ Realtime Tests:`);
+      console.log(`  ├─ Realtime Tests:`);
       console.log(
-        `     ├─ Upgrade: ${formatTestStatus(state.testStatus.dev.realtimeUpgrade)}`,
+        `  │  ├─ Upgrade: ${formatTestStatus(state.testStatus.dev.realtimeUpgrade)}`,
       );
       console.log(
-        `     ├─ Server-side: ${formatTestStatus(state.testStatus.dev.realtimeServerSide)}`,
+        `  │  ├─ Server-side: ${formatTestStatus(state.testStatus.dev.realtimeServerSide)}`,
       );
       console.log(
-        `     └─ Client-side: ${formatTestStatus(state.testStatus.dev.realtimeClientSide)}`,
+        `  │  └─ Client-side: ${formatTestStatus(state.testStatus.dev.realtimeClientSide)}`,
+      );
+      console.log(
+        `  └─ Server Render Check: ${formatTestStatus(state.testStatus.dev.serverRenderCheck)}`,
       );
     }
 
@@ -195,15 +198,18 @@ export async function generateFinalReport(): Promise<void> {
         console.log(
           `  │  └─ Client-side: ${formatTestStatus(state.testStatus.production.initialClientSide)}`,
         );
-        console.log(`  └─ Realtime Tests:`);
+        console.log(`  ├─ Realtime Tests:`);
         console.log(
-          `     ├─ Upgrade: ${formatTestStatus(state.testStatus.production.realtimeUpgrade)}`,
+          `  │  ├─ Upgrade: ${formatTestStatus(state.testStatus.production.realtimeUpgrade)}`,
         );
         console.log(
-          `     ├─ Server-side: ${formatTestStatus(state.testStatus.production.realtimeServerSide)}`,
+          `  │  ├─ Server-side: ${formatTestStatus(state.testStatus.production.realtimeServerSide)}`,
         );
         console.log(
-          `     └─ Client-side: ${formatTestStatus(state.testStatus.production.realtimeClientSide)}`,
+          `  │  └─ Client-side: ${formatTestStatus(state.testStatus.production.realtimeClientSide)}`,
+        );
+        console.log(
+          `  └─ Server Render Check: ${formatTestStatus(state.testStatus.production.serverRenderCheck)}`,
         );
       } else {
         console.log(`  └─ Tests: ⏩ SKIPPED (release command failed)`);
@@ -358,6 +364,7 @@ export function initializeTestStatus(): void {
   state.testStatus.dev.realtimeUpgrade = "DID_NOT_RUN";
   state.testStatus.dev.realtimeServerSide = "DID_NOT_RUN";
   state.testStatus.dev.realtimeClientSide = "DID_NOT_RUN";
+  state.testStatus.dev.serverRenderCheck = "DID_NOT_RUN";
 
   // Production tests
   state.testStatus.production.overall = "DID_NOT_RUN";
@@ -367,6 +374,7 @@ export function initializeTestStatus(): void {
   state.testStatus.production.realtimeUpgrade = "DID_NOT_RUN";
   state.testStatus.production.realtimeServerSide = "DID_NOT_RUN";
   state.testStatus.production.realtimeClientSide = "DID_NOT_RUN";
+  state.testStatus.production.serverRenderCheck = "DID_NOT_RUN";
 
   // Now override with specific statuses based on options
 
@@ -378,6 +386,7 @@ export function initializeTestStatus(): void {
     state.testStatus.dev.realtimeUpgrade = "SKIPPED";
     state.testStatus.dev.realtimeServerSide = "SKIPPED";
     state.testStatus.dev.realtimeClientSide = "SKIPPED";
+    state.testStatus.dev.serverRenderCheck = "SKIPPED";
   }
 
   if (state.options.skipRelease) {
@@ -388,6 +397,7 @@ export function initializeTestStatus(): void {
     state.testStatus.production.realtimeUpgrade = "SKIPPED";
     state.testStatus.production.realtimeServerSide = "SKIPPED";
     state.testStatus.production.realtimeClientSide = "SKIPPED";
+    state.testStatus.production.serverRenderCheck = "SKIPPED";
   }
 
   if (state.options.skipClient) {
@@ -395,6 +405,8 @@ export function initializeTestStatus(): void {
     state.testStatus.dev.realtimeClientSide = "SKIPPED";
     state.testStatus.production.initialClientSide = "SKIPPED";
     state.testStatus.production.realtimeClientSide = "SKIPPED";
+    state.testStatus.dev.serverRenderCheck = "SKIPPED";
+    state.testStatus.production.serverRenderCheck = "SKIPPED";
   }
 
   // Handle realtime option which skips initial tests

--- a/sdk/src/lib/smokeTests/reporting.mts
+++ b/sdk/src/lib/smokeTests/reporting.mts
@@ -2,7 +2,7 @@ import { join, basename } from "path";
 import { writeFile } from "fs/promises";
 import { mkdirp } from "fs-extra";
 import { log } from "./constants.mjs";
-import { state, TestStatusValue } from "./state.mjs";
+import { state, TestStatusValue, TestStatus } from "./state.mjs";
 import { SmokeTestResult } from "./types.mjs";
 
 /**
@@ -158,20 +158,23 @@ export async function generateFinalReport(): Promise<void> {
         `  │  ├─ Server-side: ${formatTestStatus(state.testStatus.dev.initialServerSide)}`,
       );
       console.log(
-        `  │  └─ Client-side: ${formatTestStatus(state.testStatus.dev.initialClientSide)}`,
-      );
-      console.log(`  ├─ Realtime Tests:`);
-      console.log(
-        `  │  ├─ Upgrade: ${formatTestStatus(state.testStatus.dev.realtimeUpgrade)}`,
+        `  │  ├─ Client-side: ${formatTestStatus(state.testStatus.dev.initialClientSide)}`,
       );
       console.log(
-        `  │  ├─ Server-side: ${formatTestStatus(state.testStatus.dev.realtimeServerSide)}`,
+        `  │  └─ Server Render Check: ${formatTestStatus(state.testStatus.dev.initialServerRenderCheck)}`,
+      );
+      console.log(`  └─ Realtime Tests:`);
+      console.log(
+        `     ├─ Upgrade: ${formatTestStatus(state.testStatus.dev.realtimeUpgrade)}`,
       );
       console.log(
-        `  │  └─ Client-side: ${formatTestStatus(state.testStatus.dev.realtimeClientSide)}`,
+        `     ├─ Server-side: ${formatTestStatus(state.testStatus.dev.realtimeServerSide)}`,
       );
       console.log(
-        `  └─ Server Render Check: ${formatTestStatus(state.testStatus.dev.serverRenderCheck)}`,
+        `     ├─ Client-side: ${formatTestStatus(state.testStatus.dev.realtimeClientSide)}`,
+      );
+      console.log(
+        `     └─ Server Render Check: ${formatTestStatus(state.testStatus.dev.realtimeServerRenderCheck)}`,
       );
     }
 
@@ -196,20 +199,23 @@ export async function generateFinalReport(): Promise<void> {
           `  │  ├─ Server-side: ${formatTestStatus(state.testStatus.production.initialServerSide)}`,
         );
         console.log(
-          `  │  └─ Client-side: ${formatTestStatus(state.testStatus.production.initialClientSide)}`,
-        );
-        console.log(`  ├─ Realtime Tests:`);
-        console.log(
-          `  │  ├─ Upgrade: ${formatTestStatus(state.testStatus.production.realtimeUpgrade)}`,
+          `  │  ├─ Client-side: ${formatTestStatus(state.testStatus.production.initialClientSide)}`,
         );
         console.log(
-          `  │  ├─ Server-side: ${formatTestStatus(state.testStatus.production.realtimeServerSide)}`,
+          `  │  └─ Server Render Check: ${formatTestStatus(state.testStatus.production.initialServerRenderCheck)}`,
+        );
+        console.log(`  └─ Realtime Tests:`);
+        console.log(
+          `     ├─ Upgrade: ${formatTestStatus(state.testStatus.production.realtimeUpgrade)}`,
         );
         console.log(
-          `  │  └─ Client-side: ${formatTestStatus(state.testStatus.production.realtimeClientSide)}`,
+          `     ├─ Server-side: ${formatTestStatus(state.testStatus.production.realtimeServerSide)}`,
         );
         console.log(
-          `  └─ Server Render Check: ${formatTestStatus(state.testStatus.production.serverRenderCheck)}`,
+          `     ├─ Client-side: ${formatTestStatus(state.testStatus.production.realtimeClientSide)}`,
+        );
+        console.log(
+          `     └─ Server Render Check: ${formatTestStatus(state.testStatus.production.realtimeServerRenderCheck)}`,
         );
       } else {
         console.log(`  └─ Tests: ⏩ SKIPPED (release command failed)`);
@@ -361,20 +367,22 @@ export function initializeTestStatus(): void {
   state.testStatus.dev.overall = "DID_NOT_RUN";
   state.testStatus.dev.initialServerSide = "DID_NOT_RUN";
   state.testStatus.dev.initialClientSide = "DID_NOT_RUN";
+  state.testStatus.dev.initialServerRenderCheck = "DID_NOT_RUN";
   state.testStatus.dev.realtimeUpgrade = "DID_NOT_RUN";
   state.testStatus.dev.realtimeServerSide = "DID_NOT_RUN";
   state.testStatus.dev.realtimeClientSide = "DID_NOT_RUN";
-  state.testStatus.dev.serverRenderCheck = "DID_NOT_RUN";
+  state.testStatus.dev.realtimeServerRenderCheck = "DID_NOT_RUN";
 
   // Production tests
   state.testStatus.production.overall = "DID_NOT_RUN";
   state.testStatus.production.releaseCommand = "DID_NOT_RUN";
   state.testStatus.production.initialServerSide = "DID_NOT_RUN";
   state.testStatus.production.initialClientSide = "DID_NOT_RUN";
+  state.testStatus.production.initialServerRenderCheck = "DID_NOT_RUN";
   state.testStatus.production.realtimeUpgrade = "DID_NOT_RUN";
   state.testStatus.production.realtimeServerSide = "DID_NOT_RUN";
   state.testStatus.production.realtimeClientSide = "DID_NOT_RUN";
-  state.testStatus.production.serverRenderCheck = "DID_NOT_RUN";
+  state.testStatus.production.realtimeServerRenderCheck = "DID_NOT_RUN";
 
   // Now override with specific statuses based on options
 
@@ -383,10 +391,11 @@ export function initializeTestStatus(): void {
     state.testStatus.dev.overall = "SKIPPED";
     state.testStatus.dev.initialServerSide = "SKIPPED";
     state.testStatus.dev.initialClientSide = "SKIPPED";
+    state.testStatus.dev.initialServerRenderCheck = "SKIPPED";
     state.testStatus.dev.realtimeUpgrade = "SKIPPED";
     state.testStatus.dev.realtimeServerSide = "SKIPPED";
     state.testStatus.dev.realtimeClientSide = "SKIPPED";
-    state.testStatus.dev.serverRenderCheck = "SKIPPED";
+    state.testStatus.dev.realtimeServerRenderCheck = "SKIPPED";
   }
 
   if (state.options.skipRelease) {
@@ -394,10 +403,11 @@ export function initializeTestStatus(): void {
     state.testStatus.production.releaseCommand = "SKIPPED";
     state.testStatus.production.initialServerSide = "SKIPPED";
     state.testStatus.production.initialClientSide = "SKIPPED";
+    state.testStatus.production.initialServerRenderCheck = "SKIPPED";
     state.testStatus.production.realtimeUpgrade = "SKIPPED";
     state.testStatus.production.realtimeServerSide = "SKIPPED";
     state.testStatus.production.realtimeClientSide = "SKIPPED";
-    state.testStatus.production.serverRenderCheck = "SKIPPED";
+    state.testStatus.production.realtimeServerRenderCheck = "SKIPPED";
   }
 
   if (state.options.skipClient) {
@@ -405,8 +415,10 @@ export function initializeTestStatus(): void {
     state.testStatus.dev.realtimeClientSide = "SKIPPED";
     state.testStatus.production.initialClientSide = "SKIPPED";
     state.testStatus.production.realtimeClientSide = "SKIPPED";
-    state.testStatus.dev.serverRenderCheck = "SKIPPED";
-    state.testStatus.production.serverRenderCheck = "SKIPPED";
+    state.testStatus.dev.initialServerRenderCheck = "SKIPPED";
+    state.testStatus.dev.realtimeServerRenderCheck = "SKIPPED";
+    state.testStatus.production.initialServerRenderCheck = "SKIPPED";
+    state.testStatus.production.realtimeServerRenderCheck = "SKIPPED";
   }
 
   // Handle realtime option which skips initial tests
@@ -415,6 +427,7 @@ export function initializeTestStatus(): void {
     if (!state.options.skipDev) {
       state.testStatus.dev.initialServerSide = "SKIPPED";
       state.testStatus.dev.initialClientSide = "SKIPPED";
+      state.testStatus.dev.initialServerRenderCheck = "SKIPPED";
       // Set the upgrade test to PASSED as it's implicitly run for realtime mode
       state.testStatus.dev.realtimeUpgrade = "PASSED";
     }
@@ -422,6 +435,7 @@ export function initializeTestStatus(): void {
     if (!state.options.skipRelease) {
       state.testStatus.production.initialServerSide = "SKIPPED";
       state.testStatus.production.initialClientSide = "SKIPPED";
+      state.testStatus.production.initialServerRenderCheck = "SKIPPED";
       // Set release command to PASSED since it must have succeeded for realtime tests to run
       state.testStatus.production.releaseCommand = "PASSED";
       // Set the upgrade test to PASSED as it's implicitly run for realtime mode

--- a/sdk/src/lib/smokeTests/state.mts
+++ b/sdk/src/lib/smokeTests/state.mts
@@ -13,6 +13,7 @@ export interface TestStatus {
     realtimeUpgrade: TestStatusValue;
     realtimeServerSide: TestStatusValue;
     realtimeClientSide: TestStatusValue;
+    serverRenderCheck: TestStatusValue;
   };
   // Production environment tests
   production: {
@@ -23,6 +24,7 @@ export interface TestStatus {
     realtimeUpgrade: TestStatusValue;
     realtimeServerSide: TestStatusValue;
     realtimeClientSide: TestStatusValue;
+    serverRenderCheck: TestStatusValue;
   };
 }
 
@@ -53,6 +55,7 @@ export const state = {
       realtimeUpgrade: "DID_NOT_RUN",
       realtimeServerSide: "DID_NOT_RUN",
       realtimeClientSide: "DID_NOT_RUN",
+      serverRenderCheck: "DID_NOT_RUN",
     },
     production: {
       overall: "DID_NOT_RUN",
@@ -62,6 +65,7 @@ export const state = {
       realtimeUpgrade: "DID_NOT_RUN",
       realtimeServerSide: "DID_NOT_RUN",
       realtimeClientSide: "DID_NOT_RUN",
+      serverRenderCheck: "DID_NOT_RUN",
     },
   } as TestStatus,
 };

--- a/sdk/src/lib/smokeTests/state.mts
+++ b/sdk/src/lib/smokeTests/state.mts
@@ -10,10 +10,11 @@ export interface TestStatus {
     overall: TestStatusValue;
     initialServerSide: TestStatusValue;
     initialClientSide: TestStatusValue;
+    initialServerRenderCheck: TestStatusValue; // Server render check for initial tests
     realtimeUpgrade: TestStatusValue;
     realtimeServerSide: TestStatusValue;
     realtimeClientSide: TestStatusValue;
-    serverRenderCheck: TestStatusValue;
+    realtimeServerRenderCheck: TestStatusValue; // Server render check for realtime tests
   };
   // Production environment tests
   production: {
@@ -21,10 +22,11 @@ export interface TestStatus {
     releaseCommand: TestStatusValue;
     initialServerSide: TestStatusValue;
     initialClientSide: TestStatusValue;
+    initialServerRenderCheck: TestStatusValue; // Server render check for initial tests
     realtimeUpgrade: TestStatusValue;
     realtimeServerSide: TestStatusValue;
     realtimeClientSide: TestStatusValue;
-    serverRenderCheck: TestStatusValue;
+    realtimeServerRenderCheck: TestStatusValue; // Server render check for realtime tests
   };
 }
 
@@ -52,20 +54,22 @@ export const state = {
       overall: "DID_NOT_RUN",
       initialServerSide: "DID_NOT_RUN",
       initialClientSide: "DID_NOT_RUN",
+      initialServerRenderCheck: "DID_NOT_RUN",
       realtimeUpgrade: "DID_NOT_RUN",
       realtimeServerSide: "DID_NOT_RUN",
       realtimeClientSide: "DID_NOT_RUN",
-      serverRenderCheck: "DID_NOT_RUN",
+      realtimeServerRenderCheck: "DID_NOT_RUN",
     },
     production: {
       overall: "DID_NOT_RUN",
       releaseCommand: "DID_NOT_RUN",
       initialServerSide: "DID_NOT_RUN",
       initialClientSide: "DID_NOT_RUN",
+      initialServerRenderCheck: "DID_NOT_RUN",
       realtimeUpgrade: "DID_NOT_RUN",
       realtimeServerSide: "DID_NOT_RUN",
       realtimeClientSide: "DID_NOT_RUN",
-      serverRenderCheck: "DID_NOT_RUN",
+      realtimeServerRenderCheck: "DID_NOT_RUN",
     },
   } as TestStatus,
 };

--- a/sdk/src/lib/smokeTests/templates/SmokeTest.template.tsx
+++ b/sdk/src/lib/smokeTests/templates/SmokeTest.template.tsx
@@ -3,22 +3,20 @@ export function getSmokeTestTemplate(skipClient: boolean = false): string {
 import React from "react";
 import { RequestInfo } from "rwsdk/worker";
 ${skipClient ? "" : 'import { SmokeTestClient } from "./__SmokeTestClient";'}
-import { smokeTestAction } from "./__smokeTestFunctions";
+import { getSmokeTestTimestamp } from "./__smokeTestFunctions";
 
 export const SmokeTestInfo: React.FC = async () => {
-  const timestamp = Date.now();
+  const currentTime = Date.now();
   let status = "error";
-  let verificationPassed = false;
-  let result: any = null;
+  let timestamp = 0;
 
   try {
-    result = await smokeTestAction(timestamp);
+    const result = await getSmokeTestTimestamp();
     status = result.status || "error";
-    verificationPassed = result.timestamp === timestamp;
+    timestamp = result.timestamp;
   } catch (error) {
     console.error("Smoke test failed:", error);
     status = "error";
-    result = { error: error instanceof Error ? error.message : String(error) };
   }
 
   return (
@@ -27,8 +25,7 @@ export const SmokeTestInfo: React.FC = async () => {
       data-testid="health-status"
       data-status={status}
       data-timestamp={timestamp}
-      data-server-timestamp={Date.now()}
-      data-verified={verificationPassed ? "true" : "false"}
+      data-server-timestamp={currentTime}
       style={{
         fontFamily: "system-ui, -apple-system, sans-serif",
         margin: "20px",
@@ -49,9 +46,7 @@ export const SmokeTestInfo: React.FC = async () => {
       <div
         id="smoke-test-result"
       >
-        {verificationPassed
-          ? "Timestamp verification passed ✅"
-          : "Timestamp verification failed ⚠️"}
+        Server Timestamp: {timestamp}
       </div>
       <details style={{ marginTop: "10px" }}>
         <summary>Details</summary>
@@ -64,7 +59,7 @@ export const SmokeTestInfo: React.FC = async () => {
             overflow: "auto",
           }}
         >
-          {JSON.stringify({ timestamp, result, verificationPassed }, null, 2)}
+          {JSON.stringify({ currentTime, serverTimestamp: timestamp, status }, null, 2)}
         </pre>
       </details>
 

--- a/sdk/src/lib/smokeTests/templates/SmokeTestClient.template.tsx
+++ b/sdk/src/lib/smokeTests/templates/SmokeTestClient.template.tsx
@@ -24,25 +24,25 @@ export const SmokeTestClient: React.FC = () => {
 
   const runSmokeTest = async () => {
     setLoading(true);
-    const timestamp = Date.now();
+    const clientTimestamp = Date.now();
 
     try {
-      // Get current timestamp to verify round-trip
-      const result = await smokeTestAction(timestamp);
+      // Update the server timestamp with our client timestamp
+      const result = await smokeTestAction(clientTimestamp);
       const status = result.status || "error";
-      const verificationPassed = result.timestamp === timestamp;
+      const verificationPassed = result.timestamp === clientTimestamp;
 
       setLastCheck({
         status,
         verificationPassed,
-        timestamp,
+        timestamp: clientTimestamp,
         rawResult: result,
       });
     } catch (error) {
       setLastCheck({
         status: "error",
         verificationPassed: false,
-        timestamp,
+        timestamp: clientTimestamp,
         error: error instanceof Error ? error.message : String(error),
       });
     } finally {
@@ -100,6 +100,9 @@ export const SmokeTestClient: React.FC = () => {
             >
               Status: {lastCheck.status}
             </h4>
+            <p>
+              Server timestamp updated to: {lastCheck.timestamp}
+            </p>
             <p>
               Timestamp verification:{" "}
               {lastCheck.verificationPassed ? "Passed ✅" : "Failed ⚠️"}

--- a/sdk/src/lib/smokeTests/templates/smokeTestFunctions.template.ts
+++ b/sdk/src/lib/smokeTests/templates/smokeTestFunctions.template.ts
@@ -1,10 +1,25 @@
 export function getSmokeTestFunctionsTemplate(): string {
   return `"use server";
 
+// Module-level variable to store the timestamp set by client
+// Initialize with a fixed value to verify initial server render
+let serverTimestamp: number = 23;
+
+// Function to retrieve the current server timestamp
+export async function getSmokeTestTimestamp(): Promise<{ timestamp: number, status: string }> {
+  return { timestamp: serverTimestamp, status: "ok" };
+}
+
 export async function smokeTestAction(
   timestamp?: number,
 ): Promise<unknown> {
   await new Promise((resolve) => setTimeout(resolve, 0));
+  
+  // Update the module-level timestamp if provided
+  if (timestamp) {
+    serverTimestamp = timestamp;
+  }
+  
   return { status: "ok", timestamp };
 }
 `;


### PR DESCRIPTION
## Previously
Our smoke tests verified initial server rendering and client-side functionality separately, but did not verify that server components would re-render in response to client-side actions.

## This PR changes:
We now implement a complete verification flow that:
1. Checks the initial rendered server component state
2. Invokes a client-side action that updates shared state
3. Verifies both the client-side result AND that the server component has properly re-rendered with the updated state