### PR TITLE
standard-starter: Initialise Prisma using env import

### DIFF
--- a/starters/standard/src/db.ts
+++ b/starters/standard/src/db.ts
@@ -1,23 +1,7 @@
 import { PrismaClient } from "@prisma/client";
 import { PrismaD1 } from "@prisma/adapter-d1";
+import { env } from "cloudflare:workers";
 
-export let db: PrismaClient;
-
-export const createDbClient = (env: Env) =>
-  new PrismaClient({ adapter: new PrismaD1(env.DB) });
-
-export const setupDb = async (env: Env) => {
-  db = createDbClient(env);
-  // todo(justinvdm, 30 Jan 2025): Figure out how to avoid this.
-  //
-  // ## Context:
-  // Vite sends an initial request to the worker when running the dev server,
-  // at which point the Prisma WASM is imported. Using the Prisma for the first time _after_ this initial request
-  // (e.g. if we only run the db for a request to /some/subpath) causes vite to not try import the WASM module
-  // at all, and ultimately the request ends up hanging indefinetely.
-  // * However, once the WASM has been imported, it is cached in some way that persists on the file system
-  // (from experimentation, it is not in node_modules/.vite). This means that if you were to subsequently
-  // change the code to _not_ have Prisma used after the initial request, the WASM will still be cached and
-  // the request will not hang. This makes this issue particularly hard to debug.
-  await db.$queryRaw`SELECT 1`;
-};
+export const db = new PrismaClient({
+  adapter: new PrismaD1(env.DB),
+});

--- a/starters/standard/src/scripts/seed.ts
+++ b/starters/standard/src/scripts/seed.ts
@@ -1,9 +1,7 @@
 import { defineScript } from "rwsdk/worker";
-import { db, setupDb } from "@/db";
+import { db } from "@/db";
 
-export default defineScript(async ({ env }) => {
-  setupDb(env);
-
+export default defineScript(async () => {
   await db.$executeRawUnsafe(`\
     DELETE FROM User;
     DELETE FROM sqlite_sequence;

--- a/starters/standard/src/worker.tsx
+++ b/starters/standard/src/worker.tsx
@@ -6,7 +6,7 @@ import { setCommonHeaders } from "@/app/headers";
 import { userRoutes } from "@/app/pages/user/routes";
 import { sessions, setupSessionStore } from "./session/store";
 import { Session } from "./session/durableObject";
-import { db, setupDb } from "./db";
+import { db } from "./db";
 import type { User } from "@prisma/client";
 import { env } from "cloudflare:workers";
 export { SessionDurableObject } from "./session/durableObject";
@@ -19,7 +19,6 @@ export type AppContext = {
 export default defineApp([
   setCommonHeaders(),
   async ({ ctx, request, headers }) => {
-    await setupDb(env);
     setupSessionStore(env);
 
     try {


### PR DESCRIPTION
In March, the [Cloudflare team added support](https://developers.cloudflare.com/changelog/2025-03-17-importable-env/) for importing bindings like `env` directly.

This allows us to initialise `PrismaClient` at the module level, making the Prisma WASM immediately available when the worker starts. That prevents the first request from hanging (as noted by @justinvdm).

This change tripped me up while integrating Better-Auth, since I used this starter as the base.
