### PR TITLE
Fix https to http for localhost in full stack docs

### DIFF
--- a/docs/src/content/docs/tutorial/full-stack-app/2-create-app.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/2-create-app.mdx
@@ -381,7 +381,7 @@ Let's test to make sure our custom colors are working. On the `Login.tsx` file, 
 }
 ```
 
-When you visit https://localhost:5173/user/login, you should see a beige background color:
+When you visit http://localhost:5173/user/login, you should see a beige background color:
 
 ![](./images/testing-custom-tailwind-colors.png)
 

--- a/docs/src/content/docs/tutorial/full-stack-app/2-create-app.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/2-create-app.mdx
@@ -623,7 +623,7 @@ return (
 );
 ```
 
-Now, when you visit https://localhost:5173/user/login, you should see styled buttons:
+Now, when you visit http://localhost:5173/user/login, you should see styled buttons:
 
 ![](./images/shadcn-working.png)
 


### PR DESCRIPTION
This is a small fix to the full stack tutorial which mistakenly uses https rather than http for localhost links. If you click the existing links you'll experience an error locally 