### PR TITLE
📝 docs: Adjusted the Tailwind install formatting

### DIFF
--- a/docs/src/content/docs/guides/frontend/tailwind.mdx
+++ b/docs/src/content/docs/guides/frontend/tailwind.mdx
@@ -19,7 +19,7 @@ Since the RedwoodSDK is based on React and Vite, we can work through the ["Using
     />
 
 2. Configure the Vite Plugin
-    ```ts ins="import tailwindcss from '@tailwindcss/vite'" ins="tailwindcss()," {3, 7-9, 12}
+    ```ts ins="import tailwindcss from '@tailwindcss/vite'" ins="tailwindcss()," {3, 12} ins={7-9}
     // vite.config.mts
     import { defineConfig } from "vite";
     import tailwindcss from '@tailwindcss/vite'

--- a/docs/src/content/docs/tutorial/full-stack-app/2-create-app.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/2-create-app.mdx
@@ -126,7 +126,7 @@ Since the RedwoodSDK is based on React and Vite, we can work through the ["Using
     />
 
 2. Configure the Vite Plugin
-    ```ts ins="import tailwindcss from '@tailwindcss/vite'" ins="tailwindcss()," title="vite.config.mts" ins="environments: {" ins="ssr: {}," ins="}," {2, 6-8, 11}
+    ```ts ins="import tailwindcss from '@tailwindcss/vite'" ins="tailwindcss()," title="vite.config.mts" ins={6-8} {2, 11}
     import { defineConfig } from "vite";
     import tailwindcss from '@tailwindcss/vite'
     import { redwood } from "rwsdk/vite";


### PR DESCRIPTION
The Tailwind install directions had highlighted the `environment` addition, but they weren't green, making it easy to overlook:

![CleanShot 2025-05-17 at 07 44 47@2x](https://github.com/user-attachments/assets/7476bf84-5a6d-476c-b63d-15d271f31d78)

I changed the lines to be green:

![CleanShot 2025-05-17 at 07 42 29@2x](https://github.com/user-attachments/assets/834ec8a6-53bc-4b6d-8f6d-11f0cc2a562a)

The Tutorial, Tailwind install had green lines, 

![CleanShot 2025-05-17 at 07 42 47@2x](https://github.com/user-attachments/assets/49f397c7-00f6-4751-99d4-2c3285fe6745)

but, I updated so that the two examples match.
