### PR TITLE
RSC directives, support default exports in server components.

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,9 +92,6 @@ importers:
       enhanced-resolve:
         specifier: ^5.18.1
         version: 5.18.1
-      es-module-lexer:
-        specifier: ^1.5.4
-        version: 1.6.0
       eventsource-parser:
         specifier: ^3.0.0
         version: 3.0.0

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -109,7 +109,6 @@
     "@vitejs/plugin-react": "^4.3.4",
     "debug": "^4.4.0",
     "enhanced-resolve": "^5.18.1",
-    "es-module-lexer": "^1.5.4",
     "eventsource-parser": "^3.0.0",
     "execa": "^9.5.2",
     "fs-extra": "^11.3.0",

--- a/sdk/src/vite/__snapshots__/useServerPlugin.test.mts.snap
+++ b/sdk/src/vite/__snapshots__/useServerPlugin.test.mts.snap
@@ -1,0 +1,146 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`useServerPlugin > TRANSFORMS > ARROW_FUNCTION_EXPORT_CODE > CLIENT 1`] = `
+"import { createServerReference } from "rwsdk/client";
+
+export let sum = createServerReference("/test.tsx", "sum");
+"
+`;
+
+exports[`useServerPlugin > TRANSFORMS > ARROW_FUNCTION_EXPORT_CODE > WORKER 1`] = `
+"import { registerServerReference } from "rwsdk/worker";
+
+export const sum = () => {
+  return 1 + 1
+}
+registerServerReference(sum, "/test.tsx", "sum")
+"
+`;
+
+exports[`useServerPlugin > TRANSFORMS > ASYNC_FUNCTION_EXPORT_CODE > CLIENT 1`] = `
+"import { createServerReference } from "rwsdk/client";
+
+export let sum = createServerReference("/test.tsx", "sum");
+"
+`;
+
+exports[`useServerPlugin > TRANSFORMS > ASYNC_FUNCTION_EXPORT_CODE > WORKER 1`] = `
+"import { registerServerReference } from "rwsdk/worker";
+
+export async function sum() {
+  return 1 + 1
+}
+registerServerReference(sum, "/test.tsx", "sum")
+"
+`;
+
+exports[`useServerPlugin > TRANSFORMS > COMMENT_BLOCK_CODE > CLIENT 1`] = `
+"import { createServerReference } from "rwsdk/client";
+
+export let sum = createServerReference("/test.tsx", "sum");
+"
+`;
+
+exports[`useServerPlugin > TRANSFORMS > COMMENT_BLOCK_CODE > WORKER 1`] = `
+"
+/* Giant
+ * Comment
+ * Block
+ */
+import { registerServerReference } from "rwsdk/worker";
+
+export function sum() {
+  return 1 + 1
+}
+registerServerReference(sum, "/test.tsx", "sum")
+"
+`;
+
+exports[`useServerPlugin > TRANSFORMS > COMMENT_CODE > CLIENT 1`] = `
+"import { createServerReference } from "rwsdk/client";
+
+export let sum = createServerReference("/test.tsx", "sum");
+"
+`;
+
+exports[`useServerPlugin > TRANSFORMS > COMMENT_CODE > WORKER 1`] = `
+"import { registerServerReference } from "rwsdk/worker";
+
+// Comment
+
+
+export function sum() {
+  return 1 + 1;
+}
+registerServerReference(sum, "/test.tsx", "sum")
+"
+`;
+
+exports[`useServerPlugin > TRANSFORMS > DEFAULT_EXPORT_CODE > CLIENT 1`] = `
+"import { createServerReference } from "rwsdk/client";
+
+export let sum = createServerReference("/test.tsx", "sum");
+"
+`;
+
+exports[`useServerPlugin > TRANSFORMS > DEFAULT_EXPORT_CODE > WORKER 1`] = `
+"import { registerServerReference } from "rwsdk/worker";
+
+export function sum() {
+  return 1 + 1;
+}
+
+export default sum;
+registerServerReference(sum, "/test.tsx", "sum")
+"
+`;
+
+exports[`useServerPlugin > TRANSFORMS > IGNORE_NON_FUNCTION_EXPORT_CODE > CLIENT 1`] = `
+"import { createServerReference } from "rwsdk/client";
+"
+`;
+
+exports[`useServerPlugin > TRANSFORMS > IGNORE_NON_FUNCTION_EXPORT_CODE > WORKER 1`] = `
+"import { registerServerReference } from "rwsdk/worker";
+
+export const a = "string";
+"
+`;
+
+exports[`useServerPlugin > TRANSFORMS > MULTI_LINE_COMMENT_CODE > CLIENT 1`] = `
+"import { createServerReference } from "rwsdk/client";
+
+export let sum = createServerReference("/test.tsx", "sum");
+"
+`;
+
+exports[`useServerPlugin > TRANSFORMS > MULTI_LINE_COMMENT_CODE > WORKER 1`] = `
+"import { registerServerReference } from "rwsdk/worker";
+
+// Multi-line
+// Comment
+
+
+export function sum() {
+  return 1 + 1
+}
+registerServerReference(sum, "/test.tsx", "sum")
+"
+`;
+
+exports[`useServerPlugin > TRANSFORMS > NAMED_EXPORT_CODE > CLIENT 1`] = `
+"import { createServerReference } from "rwsdk/client";
+
+export let sum = createServerReference("/test.tsx", "sum");
+"
+`;
+
+exports[`useServerPlugin > TRANSFORMS > NAMED_EXPORT_CODE > WORKER 1`] = `
+"import { registerServerReference } from "rwsdk/worker";
+
+export function sum() {
+  return 1 + 1
+}
+registerServerReference(sum, "/test.tsx", "sum")
+"
+`;

--- a/sdk/src/vite/__snapshots__/useServerPlugin.test.mts.snap
+++ b/sdk/src/vite/__snapshots__/useServerPlugin.test.mts.snap
@@ -76,22 +76,50 @@ registerServerReference(sum, "/test.tsx", "sum")
 "
 `;
 
-exports[`useServerPlugin > TRANSFORMS > DEFAULT_EXPORT_CODE > CLIENT 1`] = `
+exports[`useServerPlugin > TRANSFORMS > DEFAULT_AND_NAMED_EXPORTS_CODE > CLIENT 1`] = `
 "import { createServerReference } from "rwsdk/client";
 
 export let sum = createServerReference("/test.tsx", "sum");
+
+export default createServerReference("/test.tsx", "default");
 "
 `;
 
-exports[`useServerPlugin > TRANSFORMS > DEFAULT_EXPORT_CODE > WORKER 1`] = `
+exports[`useServerPlugin > TRANSFORMS > DEFAULT_AND_NAMED_EXPORTS_CODE > WORKER 1`] = `
 "import { registerServerReference } from "rwsdk/worker";
 
 export function sum() {
   return 1 + 1;
 }
 
-export default sum;
+function __defaultServerFunction__() {
+  return 1 + 2;
+}
+
+export default __defaultServerFunction__;
+registerServerReference(__defaultServerFunction__, "/test.tsx", "default")
 registerServerReference(sum, "/test.tsx", "sum")
+"
+`;
+
+exports[`useServerPlugin > TRANSFORMS > DEFAULT_EXPORT_CODE > CLIENT 1`] = `
+"import { createServerReference } from "rwsdk/client";
+
+export let sum = createServerReference("/test.tsx", "sum");
+
+export default createServerReference("/test.tsx", "default");
+"
+`;
+
+exports[`useServerPlugin > TRANSFORMS > DEFAULT_EXPORT_CODE > WORKER 1`] = `
+"import { registerServerReference } from "rwsdk/worker";
+
+function __defaultServerFunction__() {
+  return 1 + 1;
+}
+
+export default __defaultServerFunction__;
+registerServerReference(__defaultServerFunction__, "/test.tsx", "default")
 "
 `;
 

--- a/sdk/src/vite/useClientPlugin.mts
+++ b/sdk/src/vite/useClientPlugin.mts
@@ -35,12 +35,7 @@ export async function transformUseClientCode(
   code: string,
   relativeId: string,
 ): Promise<TransformResult | undefined> {
-  const cleanCode = code.trimStart();
-
-  if (
-    !cleanCode.startsWith('"use client"') &&
-    !cleanCode.startsWith("'use client'")
-  ) {
+  if (code.indexOf("use client") === -1) {
     return;
   }
 
@@ -54,6 +49,15 @@ export async function transformUseClientCode(
     },
   });
   const sourceFile = project.createSourceFile("temp.tsx", code);
+  const firstString = sourceFile.getFirstDescendantByKind(
+    SyntaxKind.StringLiteral,
+  );
+  if (
+    firstString?.getText().indexOf("use client") === -1 &&
+    firstString?.getStart() !== sourceFile.getStart() // `getStart` does not include the leading comments + whitespace
+  ) {
+    return;
+  }
 
   // Add import declaration properly through the AST
   sourceFile.addImportDeclaration({

--- a/sdk/src/vite/useClientPlugin.test.mts
+++ b/sdk/src/vite/useClientPlugin.test.mts
@@ -14,7 +14,14 @@ describe("transformUseClientCode", () => {
 export const Component = () => {
   return jsx('div', { children: 'Hello' });
 }`),
-    ).toMatchInlineSnapshot(`undefined`);
+    ).toMatchInlineSnapshot(`
+      "import { registerClientReference } from "rwsdk/worker";
+      const ComponentSSR = () => {
+        return jsx('div', { children: 'Hello' });
+      }
+      const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
+      export { ComponentSSR, Component };"
+    `);
   });
 
   it("does nothing for irrelevant exports", async () => {
@@ -24,7 +31,12 @@ export const Component = () => {
 export const foo = "bar"
 export const baz = 23
 }`),
-    ).toMatchInlineSnapshot(`undefined`);
+    ).toMatchInlineSnapshot(`
+      "import { registerClientReference } from "rwsdk/worker";
+      export const foo = "bar"
+      export const baz = 23
+      }"
+    `);
   });
 
   it("transforms async arrow function component", async () => {
@@ -34,7 +46,14 @@ export const baz = 23
 export const Component = async () => {
   return jsx('div', { children: 'Hello' });
 }`),
-    ).toMatchInlineSnapshot(`undefined`);
+    ).toMatchInlineSnapshot(`
+      "import { registerClientReference } from "rwsdk/worker";
+      const ComponentSSR = async () => {
+        return jsx('div', { children: 'Hello' });
+      }
+      const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
+      export { ComponentSSR, Component };"
+    `);
   });
 
   it("transforms function declaration component", async () => {
@@ -44,7 +63,15 @@ export const Component = async () => {
 export function Component() {
   return jsx('div', { children: 'Hello' });
 }`),
-    ).toMatchInlineSnapshot(`undefined`);
+    ).toMatchInlineSnapshot(`
+      "import { registerClientReference } from "rwsdk/worker";
+
+      function ComponentSSR() {
+        return jsx('div', { children: 'Hello' });
+      }
+      const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
+      export { ComponentSSR, Component };"
+    `);
   });
 
   it("transforms async function declaration component", async () => {
@@ -54,7 +81,15 @@ export function Component() {
 export async function Component() {
   return jsx('div', { children: 'Hello' });
 }`),
-    ).toMatchInlineSnapshot(`undefined`);
+    ).toMatchInlineSnapshot(`
+      "import { registerClientReference } from "rwsdk/worker";
+
+      async function ComponentSSR() {
+        return jsx('div', { children: 'Hello' });
+      }
+      const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
+      export { ComponentSSR, Component };"
+    `);
   });
 
   it("transforms multiple arrow function components", async () => {
@@ -68,7 +103,20 @@ export const First = () => {
 export const Second = () => {
   return jsx('div', { children: 'Second' });
 }`),
-    ).toMatchInlineSnapshot(`undefined`);
+    ).toMatchInlineSnapshot(`
+      "import { registerClientReference } from "rwsdk/worker";
+      const FirstSSR = () => {
+        return jsx('div', { children: 'First' });
+      }
+
+      const SecondSSR = () => {
+        return jsx('div', { children: 'Second' });
+      }
+      const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
+      const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
+      export { FirstSSR, First };
+      export { SecondSSR, Second };"
+    `);
   });
 
   it("transforms multiple async arrow function components", async () => {
@@ -82,7 +130,20 @@ export const First = async () => {
 export const Second = async () => {
   return jsx('div', { children: 'Second' });
 }`),
-    ).toMatchInlineSnapshot(`undefined`);
+    ).toMatchInlineSnapshot(`
+      "import { registerClientReference } from "rwsdk/worker";
+      const FirstSSR = async () => {
+        return jsx('div', { children: 'First' });
+      }
+
+      const SecondSSR = async () => {
+        return jsx('div', { children: 'Second' });
+      }
+      const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
+      const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
+      export { FirstSSR, First };
+      export { SecondSSR, Second };"
+    `);
   });
 
   it("transforms multiple function declaration components", async () => {
@@ -96,7 +157,21 @@ export function First() {
 export function Second() {
   return jsx('div', { children: 'Second' });
 }`),
-    ).toMatchInlineSnapshot(`undefined`);
+    ).toMatchInlineSnapshot(`
+      "import { registerClientReference } from "rwsdk/worker";
+
+      function FirstSSR() {
+        return jsx('div', { children: 'First' });
+      }
+
+      function SecondSSR() {
+        return jsx('div', { children: 'Second' });
+      }
+      const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
+      const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
+      export { FirstSSR, First };
+      export { SecondSSR, Second };"
+    `);
   });
 
   it("transforms multiple async function declaration components", async () => {
@@ -110,7 +185,21 @@ export async function First() {
 export async function Second() {
   return jsx('div', { children: 'Second' });
 }`),
-    ).toMatchInlineSnapshot(`undefined`);
+    ).toMatchInlineSnapshot(`
+      "import { registerClientReference } from "rwsdk/worker";
+
+      async function FirstSSR() {
+        return jsx('div', { children: 'First' });
+      }
+
+      async function SecondSSR() {
+        return jsx('div', { children: 'Second' });
+      }
+      const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
+      const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
+      export { FirstSSR, First };
+      export { SecondSSR, Second };"
+    `);
   });
 
   it("transforms components with grouped exports (arrow functions)", async () => {
@@ -126,7 +215,20 @@ const Second = () => {
 }
 
 export { First, Second }`),
-    ).toMatchInlineSnapshot(`undefined`);
+    ).toMatchInlineSnapshot(`
+      "import { registerClientReference } from "rwsdk/worker";
+      const FirstSSR = () => {
+        return jsx('div', { children: 'First' });
+      }
+
+      const SecondSSR = () => {
+        return jsx('div', { children: 'Second' });
+      }
+      const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
+      const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
+      export { FirstSSR, First };
+      export { SecondSSR, Second };"
+    `);
   });
 
   it("transforms complex grouped export cases", async () => {
@@ -196,7 +298,74 @@ function Button({
 
 export { Button, buttonVariants }
 `),
-    ).toMatchInlineSnapshot(`undefined`);
+    ).toMatchInlineSnapshot(`
+      "
+      import * as React from "react"
+      import { Slot } from "@radix-ui/react-slot"
+      import { cva, type VariantProps } from "class-variance-authority"
+      import { jsx, jsxs } from "react/jsx-runtime"
+
+      import { cn } from "@/lib/utils"
+      import { registerClientReference } from "rwsdk/worker";
+
+      const buttonVariants = cva(
+        "font-bold inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        {
+          variants: {
+            variant: {
+              default:
+                "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+              destructive:
+                "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+              outline:
+                "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+              secondary:
+                "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+              ghost:
+                "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+              link: "text-primary underline-offset-4 hover:underline",
+            },
+            size: {
+              default: "h-9 px-4 py-2 has-[>svg]:px-3",
+              sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+              lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+              icon: "size-9",
+            },
+          },
+          defaultVariants: {
+            variant: "default",
+            size: "default",
+          },
+        }
+      )
+
+      function ButtonSSR({
+        className,
+        variant,
+        size,
+        asChild = false,
+        ...props
+      }: React.ComponentProps<"button"> &
+        VariantProps<typeof buttonVariants> & {
+          asChild?: boolean
+        }) {
+        const Comp = asChild ? Slot : "button"
+
+        return jsx(
+          Comp,
+          {
+            "data-slot": "button",
+            className: cn(buttonVariants({ variant, size, className })),
+            ...props
+          }
+        )
+      }
+
+      export { buttonVariants };
+      const Button = registerClientReference("/test/file.tsx", "Button", ButtonSSR);
+      export { ButtonSSR, Button };
+      "
+    `);
   });
 
   it("transforms components with grouped exports (async arrow functions)", async () => {
@@ -212,7 +381,20 @@ const Second = async () => {
 }
 
 export { First, Second }`),
-    ).toMatchInlineSnapshot(`undefined`);
+    ).toMatchInlineSnapshot(`
+      "import { registerClientReference } from "rwsdk/worker";
+      const FirstSSR = async () => {
+        return jsx('div', { children: 'First' });
+      }
+
+      const SecondSSR = async () => {
+        return jsx('div', { children: 'Second' });
+      }
+      const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
+      const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
+      export { FirstSSR, First };
+      export { SecondSSR, Second };"
+    `);
   });
 
   it("transforms components with grouped exports (function declarations)", async () => {
@@ -228,7 +410,21 @@ function Second() {
 }
 
 export { First, Second }`),
-    ).toMatchInlineSnapshot(`undefined`);
+    ).toMatchInlineSnapshot(`
+      "import { registerClientReference } from "rwsdk/worker";
+
+      function FirstSSR() {
+        return jsx('div', { children: 'First' });
+      }
+
+      function SecondSSR() {
+        return jsx('div', { children: 'Second' });
+      }
+      const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
+      const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
+      export { FirstSSR, First };
+      export { SecondSSR, Second };"
+    `);
   });
 
   it("transforms components with grouped exports (async function declarations)", async () => {
@@ -244,7 +440,21 @@ async function Second() {
 }
 
 export { First, Second }`),
-    ).toMatchInlineSnapshot(`undefined`);
+    ).toMatchInlineSnapshot(`
+      "import { registerClientReference } from "rwsdk/worker";
+
+      async function FirstSSR() {
+        return jsx('div', { children: 'First' });
+      }
+
+      async function SecondSSR() {
+        return jsx('div', { children: 'Second' });
+      }
+      const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
+      const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
+      export { FirstSSR, First };
+      export { SecondSSR, Second };"
+    `);
   });
 
   it("transforms default export arrow function component", async () => {
@@ -254,7 +464,14 @@ export { First, Second }`),
 export default () => {
   return jsx('div', { children: 'Hello' });
 }`),
-    ).toMatchInlineSnapshot(`undefined`);
+    ).toMatchInlineSnapshot(`
+      "import { registerClientReference } from "rwsdk/worker";
+      const DefaultComponent0SSR = () => {
+        return jsx('div', { children: 'Hello' });
+      }
+      const DefaultComponent0 = registerClientReference("/test/file.tsx", "default", DefaultComponent0SSR);
+      export { DefaultComponent0 as default, DefaultComponent0SSR };"
+    `);
   });
 
   it("transforms default export async arrow function component", async () => {
@@ -264,7 +481,14 @@ export default () => {
 export default async () => {
   return jsx('div', { children: 'Hello' });
 }`),
-    ).toMatchInlineSnapshot(`undefined`);
+    ).toMatchInlineSnapshot(`
+      "import { registerClientReference } from "rwsdk/worker";
+      const DefaultComponent0SSR = async () => {
+        return jsx('div', { children: 'Hello' });
+      }
+      const DefaultComponent0 = registerClientReference("/test/file.tsx", "default", DefaultComponent0SSR);
+      export { DefaultComponent0 as default, DefaultComponent0SSR };"
+    `);
   });
 
   it("transforms complex default export cases", async () => {
@@ -432,7 +656,174 @@ export const MovieSelector = ({
 };
 
 `),
-    ).toMatchInlineSnapshot(`undefined`);
+    ).toMatchInlineSnapshot(`
+      "
+      import { jsxDEV } from "react/jsx-dev-runtime";
+      import { useState, useEffect, useRef } from "react";
+      import { ChevronDownIcon, CheckIcon } from "./icons";
+      import { registerClientReference } from "rwsdk/worker";
+
+      const MovieSelectorSSR = ({
+        label,
+        selectedMovie,
+        onSelect,
+        otherSelectedMovie,
+        movies,
+        error
+      }) => {
+        const [isOpen, setIsOpen] = useState(false);
+        const dropdownRef = useRef(null);
+        useEffect(() => {
+          const handleClickOutside = (event) => {
+            if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+              setIsOpen(false);
+            }
+          };
+          document.addEventListener("mousedown", handleClickOutside);
+          return () => {
+            document.removeEventListener("mousedown", handleClickOutside);
+          };
+        }, []);
+        const selectedMovieObj = movies.find((movie) => movie.id === selectedMovie);
+        const availableMovies = movies.filter(
+          (movie) => !otherSelectedMovie || movie.id !== otherSelectedMovie
+        );
+        return /* @__PURE__ */ jsxDEV("div", { className: "relative", ref: dropdownRef, children: [
+          /* @__PURE__ */ jsxDEV("label", { className: "font-banner block text-sm font-medium text-gray-700 mb-1", children: label === "First Movie" ? "Mash ..." : "With ..." }, void 0, false, {
+            fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
+            lineNumber: 49,
+            columnNumber: 7
+          }, this),
+          /* @__PURE__ */ jsxDEV(
+            "button",
+            {
+              type: "button",
+              className: "w-full p-2 border border-gray-300 rounded-md bg-white text-left flex items-center justify-between disabled:opacity-50 disabled:cursor-not-allowed",
+              onClick: () => setIsOpen(!isOpen),
+              disabled: !!error,
+              children: [
+                error ? /* @__PURE__ */ jsxDEV("span", { className: "text-red-500", children: "Error loading movies" }, void 0, false, {
+                  fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
+                  lineNumber: 59,
+                  columnNumber: 11
+                }, this) : selectedMovieObj ? /* @__PURE__ */ jsxDEV("div", { className: "flex items-center", children: [
+                  /* @__PURE__ */ jsxDEV(
+                    "img",
+                    {
+                      src: \`https://image.tmdb.org/t/p/w500/\${selectedMovieObj.photo}\`,
+                      alt: selectedMovieObj.title,
+                      className: "size-6 shrink-0 rounded-sm mr-2"
+                    },
+                    void 0,
+                    false,
+                    {
+                      fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
+                      lineNumber: 62,
+                      columnNumber: 13
+                    },
+                    this
+                  ),
+                  /* @__PURE__ */ jsxDEV("span", { children: selectedMovieObj.title }, void 0, false, {
+                    fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
+                    lineNumber: 67,
+                    columnNumber: 13
+                  }, this)
+                ] }, void 0, true, {
+                  fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
+                  lineNumber: 61,
+                  columnNumber: 11
+                }, this) : /* @__PURE__ */ jsxDEV("span", { className: "text-gray-500", children: label }, void 0, false, {
+                  fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
+                  lineNumber: 70,
+                  columnNumber: 11
+                }, this),
+                /* @__PURE__ */ jsxDEV(ChevronDownIcon, { isOpen }, void 0, false, {
+                  fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
+                  lineNumber: 72,
+                  columnNumber: 9
+                }, this)
+              ]
+            },
+            void 0,
+            true,
+            {
+              fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
+              lineNumber: 52,
+              columnNumber: 7
+            },
+            this
+          ),
+          isOpen && !error && /* @__PURE__ */ jsxDEV("div", { className: "absolute z-10 mt-1 w-full bg-white shadow-lg max-h-60 rounded-md py-1 text-base overflow-auto focus:outline-none sm:text-sm", children: availableMovies.map((movie) => /* @__PURE__ */ jsxDEV(
+            "div",
+            {
+              className: "cursor-pointer select-none relative py-2 pl-3 pr-9 hover:bg-purple-50",
+              onClick: () => {
+                onSelect(movie.id);
+                setIsOpen(false);
+              },
+              children: [
+                /* @__PURE__ */ jsxDEV("div", { className: "flex items-center", children: [
+                  /* @__PURE__ */ jsxDEV(
+                    "img",
+                    {
+                      src: \`https://image.tmdb.org/t/p/w500/\${movie.photo}\`,
+                      alt: movie.title,
+                      className: "size-10 shrink-0 rounded-sm mr-2"
+                    },
+                    void 0,
+                    false,
+                    {
+                      fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
+                      lineNumber: 87,
+                      columnNumber: 17
+                    },
+                    this
+                  ),
+                  /* @__PURE__ */ jsxDEV("span", { className: "block truncate text-base font-medium", children: movie.title }, void 0, false, {
+                    fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
+                    lineNumber: 92,
+                    columnNumber: 17
+                  }, this)
+                ] }, void 0, true, {
+                  fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
+                  lineNumber: 86,
+                  columnNumber: 15
+                }, this),
+                selectedMovie === movie.id && /* @__PURE__ */ jsxDEV("span", { className: "absolute inset-y-0 right-0 flex items-center pr-4 text-purple-600", children: /* @__PURE__ */ jsxDEV(CheckIcon, {}, void 0, false, {
+                  fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
+                  lineNumber: 99,
+                  columnNumber: 19
+                }, this) }, void 0, false, {
+                  fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
+                  lineNumber: 98,
+                  columnNumber: 17
+                }, this)
+              ]
+            },
+            movie.id,
+            true,
+            {
+              fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
+              lineNumber: 78,
+              columnNumber: 13
+            },
+            this
+          )) }, void 0, false, {
+            fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
+            lineNumber: 76,
+            columnNumber: 9
+          }, this)
+        ] }, void 0, true, {
+          fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
+          lineNumber: 48,
+          columnNumber: 5
+        }, this);
+      };
+      const MovieSelector = registerClientReference("/test/file.tsx", "MovieSelector", MovieSelectorSSR);
+      export { MovieSelectorSSR, MovieSelector };
+
+      "
+    `);
   });
 
   it("transforms default export function declaration component", async () => {
@@ -442,7 +833,15 @@ export const MovieSelector = ({
 export default function Component({ prop1, prop2 }) {
   return jsx('div', { children: 'Hello' });
 }`),
-    ).toMatchInlineSnapshot(`undefined`);
+    ).toMatchInlineSnapshot(`
+      "import { registerClientReference } from "rwsdk/worker";
+
+      function ComponentSSR({ prop1, prop2 }) {
+        return jsx('div', { children: 'Hello' });
+      }
+      const Component = registerClientReference("/test/file.tsx", "default", ComponentSSR);
+      export { Component as default, ComponentSSR };"
+    `);
   });
 
   it("transforms default export async function declaration component", async () => {
@@ -452,7 +851,15 @@ export default function Component({ prop1, prop2 }) {
 export default async function Component() {
   return jsx('div', { children: 'Hello' });
 }`),
-    ).toMatchInlineSnapshot(`undefined`);
+    ).toMatchInlineSnapshot(`
+      "import { registerClientReference } from "rwsdk/worker";
+
+      async function ComponentSSR() {
+        return jsx('div', { children: 'Hello' });
+      }
+      const Component = registerClientReference("/test/file.tsx", "default", ComponentSSR);
+      export { Component as default, ComponentSSR };"
+    `);
   });
 
   it("transforms complex component with multiple computations", async () => {
@@ -531,7 +938,84 @@ export function ComplexComponent({ initialCount = 0 }) {
     ]
   });
 }`),
-    ).toMatchInlineSnapshot(`undefined`);
+    ).toMatchInlineSnapshot(`
+      "import { registerClientReference } from "rwsdk/worker";
+
+      function ComplexComponentSSR({ initialCount = 0 }) {
+        const [count, setCount] = useState(initialCount);
+        const [items, setItems] = useState([]);
+        const doubledCount = useMemo(() => count * 2, [count]);
+        
+        useEffect(() => {
+          const timer = setInterval(() => {
+            setCount(c => c + 1);
+          }, 1000);
+          return () => clearInterval(timer);
+        }, []);
+
+        const handleAddItem = useCallback(() => {
+          const newItem = {
+            id: Math.random().toString(36),
+            value: Math.floor(Math.random() * 100)
+          };
+          setItems(prev => [...prev, newItem]);
+        }, []);
+
+        const filteredItems = items.filter(item => item.value > 50);
+        const total = filteredItems.reduce((sum, item) => sum + item.value, 0);
+
+        if (items.length === 0) {
+          return jsx('div', { children: 'No items yet' });
+        }
+
+        return jsxs('div', {
+          className: 'complex-component',
+          children: [
+            jsxs('div', {
+              className: 'counter-section',
+              children: [
+                jsx('h2', { children: 'Counter' }),
+                jsxs('p', { 
+                  children: [
+                    'Count: ',
+                    jsx('span', { children: count }),
+                    ' (Doubled: ',
+                    jsx('span', { children: doubledCount }),
+                    ')'
+                  ]
+                })
+              ]
+            }),
+            jsxs('div', {
+              className: 'items-section',
+              children: [
+                jsx('h2', { children: 'Items' }),
+                jsx('button', {
+                  onClick: handleAddItem,
+                  children: 'Add Random Item'
+                }),
+                jsxs('div', {
+                  children: [
+                    'Total value of filtered items: ',
+                    jsx('span', { children: total })
+                  ]
+                }),
+                jsx('ul', {
+                  children: filteredItems.map(item => 
+                    jsx('li', {
+                      key: item.id,
+                      children: \`Item \${item.id}: \${item.value}\`
+                    })
+                  )
+                })
+              ]
+            })
+          ]
+        });
+      }
+      const ComplexComponent = registerClientReference("/test/file.tsx", "ComplexComponent", ComplexComponentSSR);
+      export { ComplexComponentSSR, ComplexComponent };"
+    `);
   });
 
   it("transforms mixed export styles (inline, grouped, and default)", async () => {
@@ -560,7 +1044,38 @@ export default function Main() {
 
 export { Second, Third }
 export { Fourth as AnotherName }`),
-    ).toMatchInlineSnapshot(`undefined`);
+    ).toMatchInlineSnapshot(`
+      "import { registerClientReference } from "rwsdk/worker";
+      const FirstSSR = () => {
+        return jsx('div', { children: 'First' });
+      }
+
+      const SecondSSR = () => {
+        return jsx('div', { children: 'Second' });
+      }
+
+      function ThirdSSR() {
+        return jsx('div', { children: 'Third' });
+      }
+
+      const FourthSSR = () => {
+        return jsx('div', { children: 'Fourth' });
+      }
+
+      function MainSSR() {
+        return jsx('div', { children: 'Main' });
+      }
+      const Third = registerClientReference("/test/file.tsx", "Third", ThirdSSR);
+      const Main = registerClientReference("/test/file.tsx", "default", MainSSR);
+      const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
+      const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
+      const Fourth = registerClientReference("/test/file.tsx", "Fourth", FourthSSR);
+      export { ThirdSSR, Third };
+      export { Main as default, MainSSR };
+      export { FirstSSR, First };
+      export { SecondSSR, Second };
+      export { FourthSSR, Fourth };"
+    `);
   });
 
   it("transforms function declaration that is exported default separately", async () => {
@@ -573,7 +1088,15 @@ function Component({ prop1, prop2 }) {
 }
 
 export default Component;`),
-    ).toMatchInlineSnapshot(`undefined`);
+    ).toMatchInlineSnapshot(`
+      "import { registerClientReference } from "rwsdk/worker";
+
+      function ComponentSSR({ prop1, prop2 }) {
+        return jsx('div', { children: 'Hello' });
+      }
+      const Component = registerClientReference("/test/file.tsx", "default", ComponentSSR);
+      export { Component as default, ComponentSSR };"
+    `);
   });
 
   it("Works in dev", async () => {
@@ -659,13 +1182,101 @@ export function Chat() {
   }, this);
 }
 `),
-    ).toMatchInlineSnapshot(`undefined`);
+    ).toMatchInlineSnapshot(`
+      "import { jsxDEV } from "react/jsx-dev-runtime";
+      import { sendMessage } from "./functions";
+      import { useState } from "react";
+      import { consumeEventStream } from "rwsdk/client";
+      import { registerClientReference } from "rwsdk/worker";
+
+      function ChatSSR() {
+        const [message, setMessage] = useState("");
+        const [reply, setReply] = useState("");
+        const onClick = async () => {
+          setReply("");
+          (await sendMessage(message)).pipeTo(
+            consumeEventStream({
+              onChunk: (event) => {
+                setReply(
+                  (prev) => prev + (event.data === "[DONE]" ? "" : JSON.parse(event.data).response)
+                );
+              }
+            })
+          );
+        };
+        return /* @__PURE__ */ jsxDEV("div", { children: [
+          /* @__PURE__ */ jsxDEV(
+            "input",
+            {
+              type: "text",
+              value: message,
+              placeholder: "Type a message...",
+              onChange: (e) => setMessage(e.target.value),
+              style: {
+                width: "80%",
+                padding: "10px",
+                marginRight: "8px",
+                borderRadius: "4px",
+                border: "1px solid #ccc"
+              }
+            },
+            void 0,
+            false,
+            {
+              fileName: "/Users/justin/rw/sdk/experiments/ai-stream/src/app/pages/Chat/Chat.tsx",
+              lineNumber: 28,
+              columnNumber: 7
+            },
+            this
+          ),
+          /* @__PURE__ */ jsxDEV(
+            "button",
+            {
+              onClick,
+              style: {
+                padding: "10px 20px",
+                borderRadius: "4px",
+                border: "none",
+                backgroundColor: "#007bff",
+                color: "white",
+                cursor: "pointer"
+              },
+              children: "Send"
+            },
+            void 0,
+            false,
+            {
+              fileName: "/Users/justin/rw/sdk/experiments/ai-stream/src/app/pages/Chat/Chat.tsx",
+              lineNumber: 41,
+              columnNumber: 7
+            },
+            this
+          ),
+          /* @__PURE__ */ jsxDEV("div", { children: reply }, void 0, false, {
+            fileName: "/Users/justin/rw/sdk/experiments/ai-stream/src/app/pages/Chat/Chat.tsx",
+            lineNumber: 54,
+            columnNumber: 7
+          }, this)
+        ] }, void 0, true, {
+          fileName: "/Users/justin/rw/sdk/experiments/ai-stream/src/app/pages/Chat/Chat.tsx",
+          lineNumber: 27,
+          columnNumber: 5
+        }, this);
+      }
+      const Chat = registerClientReference("/test/file.tsx", "Chat", ChatSSR);
+      export { ChatSSR, Chat };
+      "
+    `);
   });
 
   it("Does not transform when 'use client' is not directive", async () => {
     expect(
       await transform(`const message = "use client";`),
-    ).toMatchInlineSnapshot(`undefined`);
+    ).toMatchInlineSnapshot(`
+      "import { registerClientReference } from "rwsdk/worker";
+
+      const message = "use client";"
+    `);
   });
 
   it("Comments are allowed in front of 'use client'", async () => {

--- a/sdk/src/vite/useClientPlugin.test.mts
+++ b/sdk/src/vite/useClientPlugin.test.mts
@@ -14,14 +14,7 @@ describe("transformUseClientCode", () => {
 export const Component = () => {
   return jsx('div', { children: 'Hello' });
 }`),
-    ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "rwsdk/worker";
-      const ComponentSSR = () => {
-        return jsx('div', { children: 'Hello' });
-      }
-      const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
-      export { ComponentSSR, Component };"
-    `);
+    ).toMatchInlineSnapshot(`undefined`);
   });
 
   it("does nothing for irrelevant exports", async () => {
@@ -31,12 +24,7 @@ export const Component = () => {
 export const foo = "bar"
 export const baz = 23
 }`),
-    ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "rwsdk/worker";
-      export const foo = "bar"
-      export const baz = 23
-      }"
-    `);
+    ).toMatchInlineSnapshot(`undefined`);
   });
 
   it("transforms async arrow function component", async () => {
@@ -46,14 +34,7 @@ export const baz = 23
 export const Component = async () => {
   return jsx('div', { children: 'Hello' });
 }`),
-    ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "rwsdk/worker";
-      const ComponentSSR = async () => {
-        return jsx('div', { children: 'Hello' });
-      }
-      const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
-      export { ComponentSSR, Component };"
-    `);
+    ).toMatchInlineSnapshot(`undefined`);
   });
 
   it("transforms function declaration component", async () => {
@@ -63,15 +44,7 @@ export const Component = async () => {
 export function Component() {
   return jsx('div', { children: 'Hello' });
 }`),
-    ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "rwsdk/worker";
-
-      function ComponentSSR() {
-        return jsx('div', { children: 'Hello' });
-      }
-      const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
-      export { ComponentSSR, Component };"
-    `);
+    ).toMatchInlineSnapshot(`undefined`);
   });
 
   it("transforms async function declaration component", async () => {
@@ -81,15 +54,7 @@ export function Component() {
 export async function Component() {
   return jsx('div', { children: 'Hello' });
 }`),
-    ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "rwsdk/worker";
-
-      async function ComponentSSR() {
-        return jsx('div', { children: 'Hello' });
-      }
-      const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
-      export { ComponentSSR, Component };"
-    `);
+    ).toMatchInlineSnapshot(`undefined`);
   });
 
   it("transforms multiple arrow function components", async () => {
@@ -103,20 +68,7 @@ export const First = () => {
 export const Second = () => {
   return jsx('div', { children: 'Second' });
 }`),
-    ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "rwsdk/worker";
-      const FirstSSR = () => {
-        return jsx('div', { children: 'First' });
-      }
-
-      const SecondSSR = () => {
-        return jsx('div', { children: 'Second' });
-      }
-      const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
-      const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-      export { FirstSSR, First };
-      export { SecondSSR, Second };"
-    `);
+    ).toMatchInlineSnapshot(`undefined`);
   });
 
   it("transforms multiple async arrow function components", async () => {
@@ -130,20 +82,7 @@ export const First = async () => {
 export const Second = async () => {
   return jsx('div', { children: 'Second' });
 }`),
-    ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "rwsdk/worker";
-      const FirstSSR = async () => {
-        return jsx('div', { children: 'First' });
-      }
-
-      const SecondSSR = async () => {
-        return jsx('div', { children: 'Second' });
-      }
-      const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
-      const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-      export { FirstSSR, First };
-      export { SecondSSR, Second };"
-    `);
+    ).toMatchInlineSnapshot(`undefined`);
   });
 
   it("transforms multiple function declaration components", async () => {
@@ -157,21 +96,7 @@ export function First() {
 export function Second() {
   return jsx('div', { children: 'Second' });
 }`),
-    ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "rwsdk/worker";
-
-      function FirstSSR() {
-        return jsx('div', { children: 'First' });
-      }
-
-      function SecondSSR() {
-        return jsx('div', { children: 'Second' });
-      }
-      const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
-      const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-      export { FirstSSR, First };
-      export { SecondSSR, Second };"
-    `);
+    ).toMatchInlineSnapshot(`undefined`);
   });
 
   it("transforms multiple async function declaration components", async () => {
@@ -185,21 +110,7 @@ export async function First() {
 export async function Second() {
   return jsx('div', { children: 'Second' });
 }`),
-    ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "rwsdk/worker";
-
-      async function FirstSSR() {
-        return jsx('div', { children: 'First' });
-      }
-
-      async function SecondSSR() {
-        return jsx('div', { children: 'Second' });
-      }
-      const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
-      const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-      export { FirstSSR, First };
-      export { SecondSSR, Second };"
-    `);
+    ).toMatchInlineSnapshot(`undefined`);
   });
 
   it("transforms components with grouped exports (arrow functions)", async () => {
@@ -215,20 +126,7 @@ const Second = () => {
 }
 
 export { First, Second }`),
-    ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "rwsdk/worker";
-      const FirstSSR = () => {
-        return jsx('div', { children: 'First' });
-      }
-
-      const SecondSSR = () => {
-        return jsx('div', { children: 'Second' });
-      }
-      const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
-      const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-      export { FirstSSR, First };
-      export { SecondSSR, Second };"
-    `);
+    ).toMatchInlineSnapshot(`undefined`);
   });
 
   it("transforms complex grouped export cases", async () => {
@@ -298,74 +196,7 @@ function Button({
 
 export { Button, buttonVariants }
 `),
-    ).toMatchInlineSnapshot(`
-      "
-      import * as React from "react"
-      import { Slot } from "@radix-ui/react-slot"
-      import { cva, type VariantProps } from "class-variance-authority"
-      import { jsx, jsxs } from "react/jsx-runtime"
-
-      import { cn } from "@/lib/utils"
-      import { registerClientReference } from "rwsdk/worker";
-
-      const buttonVariants = cva(
-        "font-bold inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-        {
-          variants: {
-            variant: {
-              default:
-                "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
-              destructive:
-                "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
-              outline:
-                "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
-              secondary:
-                "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
-              ghost:
-                "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-              link: "text-primary underline-offset-4 hover:underline",
-            },
-            size: {
-              default: "h-9 px-4 py-2 has-[>svg]:px-3",
-              sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-              lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-              icon: "size-9",
-            },
-          },
-          defaultVariants: {
-            variant: "default",
-            size: "default",
-          },
-        }
-      )
-
-      function ButtonSSR({
-        className,
-        variant,
-        size,
-        asChild = false,
-        ...props
-      }: React.ComponentProps<"button"> &
-        VariantProps<typeof buttonVariants> & {
-          asChild?: boolean
-        }) {
-        const Comp = asChild ? Slot : "button"
-
-        return jsx(
-          Comp,
-          {
-            "data-slot": "button",
-            className: cn(buttonVariants({ variant, size, className })),
-            ...props
-          }
-        )
-      }
-
-      export { buttonVariants };
-      const Button = registerClientReference("/test/file.tsx", "Button", ButtonSSR);
-      export { ButtonSSR, Button };
-      "
-    `);
+    ).toMatchInlineSnapshot(`undefined`);
   });
 
   it("transforms components with grouped exports (async arrow functions)", async () => {
@@ -381,20 +212,7 @@ const Second = async () => {
 }
 
 export { First, Second }`),
-    ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "rwsdk/worker";
-      const FirstSSR = async () => {
-        return jsx('div', { children: 'First' });
-      }
-
-      const SecondSSR = async () => {
-        return jsx('div', { children: 'Second' });
-      }
-      const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
-      const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-      export { FirstSSR, First };
-      export { SecondSSR, Second };"
-    `);
+    ).toMatchInlineSnapshot(`undefined`);
   });
 
   it("transforms components with grouped exports (function declarations)", async () => {
@@ -410,21 +228,7 @@ function Second() {
 }
 
 export { First, Second }`),
-    ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "rwsdk/worker";
-
-      function FirstSSR() {
-        return jsx('div', { children: 'First' });
-      }
-
-      function SecondSSR() {
-        return jsx('div', { children: 'Second' });
-      }
-      const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
-      const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-      export { FirstSSR, First };
-      export { SecondSSR, Second };"
-    `);
+    ).toMatchInlineSnapshot(`undefined`);
   });
 
   it("transforms components with grouped exports (async function declarations)", async () => {
@@ -440,21 +244,7 @@ async function Second() {
 }
 
 export { First, Second }`),
-    ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "rwsdk/worker";
-
-      async function FirstSSR() {
-        return jsx('div', { children: 'First' });
-      }
-
-      async function SecondSSR() {
-        return jsx('div', { children: 'Second' });
-      }
-      const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
-      const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-      export { FirstSSR, First };
-      export { SecondSSR, Second };"
-    `);
+    ).toMatchInlineSnapshot(`undefined`);
   });
 
   it("transforms default export arrow function component", async () => {
@@ -464,14 +254,7 @@ export { First, Second }`),
 export default () => {
   return jsx('div', { children: 'Hello' });
 }`),
-    ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "rwsdk/worker";
-      const DefaultComponent0SSR = () => {
-        return jsx('div', { children: 'Hello' });
-      }
-      const DefaultComponent0 = registerClientReference("/test/file.tsx", "default", DefaultComponent0SSR);
-      export { DefaultComponent0 as default, DefaultComponent0SSR };"
-    `);
+    ).toMatchInlineSnapshot(`undefined`);
   });
 
   it("transforms default export async arrow function component", async () => {
@@ -481,14 +264,7 @@ export default () => {
 export default async () => {
   return jsx('div', { children: 'Hello' });
 }`),
-    ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "rwsdk/worker";
-      const DefaultComponent0SSR = async () => {
-        return jsx('div', { children: 'Hello' });
-      }
-      const DefaultComponent0 = registerClientReference("/test/file.tsx", "default", DefaultComponent0SSR);
-      export { DefaultComponent0 as default, DefaultComponent0SSR };"
-    `);
+    ).toMatchInlineSnapshot(`undefined`);
   });
 
   it("transforms complex default export cases", async () => {
@@ -656,174 +432,7 @@ export const MovieSelector = ({
 };
 
 `),
-    ).toMatchInlineSnapshot(`
-      "
-      import { jsxDEV } from "react/jsx-dev-runtime";
-      import { useState, useEffect, useRef } from "react";
-      import { ChevronDownIcon, CheckIcon } from "./icons";
-      import { registerClientReference } from "rwsdk/worker";
-
-      const MovieSelectorSSR = ({
-        label,
-        selectedMovie,
-        onSelect,
-        otherSelectedMovie,
-        movies,
-        error
-      }) => {
-        const [isOpen, setIsOpen] = useState(false);
-        const dropdownRef = useRef(null);
-        useEffect(() => {
-          const handleClickOutside = (event) => {
-            if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
-              setIsOpen(false);
-            }
-          };
-          document.addEventListener("mousedown", handleClickOutside);
-          return () => {
-            document.removeEventListener("mousedown", handleClickOutside);
-          };
-        }, []);
-        const selectedMovieObj = movies.find((movie) => movie.id === selectedMovie);
-        const availableMovies = movies.filter(
-          (movie) => !otherSelectedMovie || movie.id !== otherSelectedMovie
-        );
-        return /* @__PURE__ */ jsxDEV("div", { className: "relative", ref: dropdownRef, children: [
-          /* @__PURE__ */ jsxDEV("label", { className: "font-banner block text-sm font-medium text-gray-700 mb-1", children: label === "First Movie" ? "Mash ..." : "With ..." }, void 0, false, {
-            fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
-            lineNumber: 49,
-            columnNumber: 7
-          }, this),
-          /* @__PURE__ */ jsxDEV(
-            "button",
-            {
-              type: "button",
-              className: "w-full p-2 border border-gray-300 rounded-md bg-white text-left flex items-center justify-between disabled:opacity-50 disabled:cursor-not-allowed",
-              onClick: () => setIsOpen(!isOpen),
-              disabled: !!error,
-              children: [
-                error ? /* @__PURE__ */ jsxDEV("span", { className: "text-red-500", children: "Error loading movies" }, void 0, false, {
-                  fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
-                  lineNumber: 59,
-                  columnNumber: 11
-                }, this) : selectedMovieObj ? /* @__PURE__ */ jsxDEV("div", { className: "flex items-center", children: [
-                  /* @__PURE__ */ jsxDEV(
-                    "img",
-                    {
-                      src: \`https://image.tmdb.org/t/p/w500/\${selectedMovieObj.photo}\`,
-                      alt: selectedMovieObj.title,
-                      className: "size-6 shrink-0 rounded-sm mr-2"
-                    },
-                    void 0,
-                    false,
-                    {
-                      fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
-                      lineNumber: 62,
-                      columnNumber: 13
-                    },
-                    this
-                  ),
-                  /* @__PURE__ */ jsxDEV("span", { children: selectedMovieObj.title }, void 0, false, {
-                    fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
-                    lineNumber: 67,
-                    columnNumber: 13
-                  }, this)
-                ] }, void 0, true, {
-                  fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
-                  lineNumber: 61,
-                  columnNumber: 11
-                }, this) : /* @__PURE__ */ jsxDEV("span", { className: "text-gray-500", children: label }, void 0, false, {
-                  fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
-                  lineNumber: 70,
-                  columnNumber: 11
-                }, this),
-                /* @__PURE__ */ jsxDEV(ChevronDownIcon, { isOpen }, void 0, false, {
-                  fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
-                  lineNumber: 72,
-                  columnNumber: 9
-                }, this)
-              ]
-            },
-            void 0,
-            true,
-            {
-              fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
-              lineNumber: 52,
-              columnNumber: 7
-            },
-            this
-          ),
-          isOpen && !error && /* @__PURE__ */ jsxDEV("div", { className: "absolute z-10 mt-1 w-full bg-white shadow-lg max-h-60 rounded-md py-1 text-base overflow-auto focus:outline-none sm:text-sm", children: availableMovies.map((movie) => /* @__PURE__ */ jsxDEV(
-            "div",
-            {
-              className: "cursor-pointer select-none relative py-2 pl-3 pr-9 hover:bg-purple-50",
-              onClick: () => {
-                onSelect(movie.id);
-                setIsOpen(false);
-              },
-              children: [
-                /* @__PURE__ */ jsxDEV("div", { className: "flex items-center", children: [
-                  /* @__PURE__ */ jsxDEV(
-                    "img",
-                    {
-                      src: \`https://image.tmdb.org/t/p/w500/\${movie.photo}\`,
-                      alt: movie.title,
-                      className: "size-10 shrink-0 rounded-sm mr-2"
-                    },
-                    void 0,
-                    false,
-                    {
-                      fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
-                      lineNumber: 87,
-                      columnNumber: 17
-                    },
-                    this
-                  ),
-                  /* @__PURE__ */ jsxDEV("span", { className: "block truncate text-base font-medium", children: movie.title }, void 0, false, {
-                    fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
-                    lineNumber: 92,
-                    columnNumber: 17
-                  }, this)
-                ] }, void 0, true, {
-                  fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
-                  lineNumber: 86,
-                  columnNumber: 15
-                }, this),
-                selectedMovie === movie.id && /* @__PURE__ */ jsxDEV("span", { className: "absolute inset-y-0 right-0 flex items-center pr-4 text-purple-600", children: /* @__PURE__ */ jsxDEV(CheckIcon, {}, void 0, false, {
-                  fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
-                  lineNumber: 99,
-                  columnNumber: 19
-                }, this) }, void 0, false, {
-                  fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
-                  lineNumber: 98,
-                  columnNumber: 17
-                }, this)
-              ]
-            },
-            movie.id,
-            true,
-            {
-              fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
-              lineNumber: 78,
-              columnNumber: 13
-            },
-            this
-          )) }, void 0, false, {
-            fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
-            lineNumber: 76,
-            columnNumber: 9
-          }, this)
-        ] }, void 0, true, {
-          fileName: "/Users/justin/rw/blotter/ai-movie-mashup/src/app/pages/mashups/components/MovieSelector.tsx",
-          lineNumber: 48,
-          columnNumber: 5
-        }, this);
-      };
-      const MovieSelector = registerClientReference("/test/file.tsx", "MovieSelector", MovieSelectorSSR);
-      export { MovieSelectorSSR, MovieSelector };
-
-      "
-    `);
+    ).toMatchInlineSnapshot(`undefined`);
   });
 
   it("transforms default export function declaration component", async () => {
@@ -833,15 +442,7 @@ export const MovieSelector = ({
 export default function Component({ prop1, prop2 }) {
   return jsx('div', { children: 'Hello' });
 }`),
-    ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "rwsdk/worker";
-
-      function ComponentSSR({ prop1, prop2 }) {
-        return jsx('div', { children: 'Hello' });
-      }
-      const Component = registerClientReference("/test/file.tsx", "default", ComponentSSR);
-      export { Component as default, ComponentSSR };"
-    `);
+    ).toMatchInlineSnapshot(`undefined`);
   });
 
   it("transforms default export async function declaration component", async () => {
@@ -851,15 +452,7 @@ export default function Component({ prop1, prop2 }) {
 export default async function Component() {
   return jsx('div', { children: 'Hello' });
 }`),
-    ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "rwsdk/worker";
-
-      async function ComponentSSR() {
-        return jsx('div', { children: 'Hello' });
-      }
-      const Component = registerClientReference("/test/file.tsx", "default", ComponentSSR);
-      export { Component as default, ComponentSSR };"
-    `);
+    ).toMatchInlineSnapshot(`undefined`);
   });
 
   it("transforms complex component with multiple computations", async () => {
@@ -938,84 +531,7 @@ export function ComplexComponent({ initialCount = 0 }) {
     ]
   });
 }`),
-    ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "rwsdk/worker";
-
-      function ComplexComponentSSR({ initialCount = 0 }) {
-        const [count, setCount] = useState(initialCount);
-        const [items, setItems] = useState([]);
-        const doubledCount = useMemo(() => count * 2, [count]);
-        
-        useEffect(() => {
-          const timer = setInterval(() => {
-            setCount(c => c + 1);
-          }, 1000);
-          return () => clearInterval(timer);
-        }, []);
-
-        const handleAddItem = useCallback(() => {
-          const newItem = {
-            id: Math.random().toString(36),
-            value: Math.floor(Math.random() * 100)
-          };
-          setItems(prev => [...prev, newItem]);
-        }, []);
-
-        const filteredItems = items.filter(item => item.value > 50);
-        const total = filteredItems.reduce((sum, item) => sum + item.value, 0);
-
-        if (items.length === 0) {
-          return jsx('div', { children: 'No items yet' });
-        }
-
-        return jsxs('div', {
-          className: 'complex-component',
-          children: [
-            jsxs('div', {
-              className: 'counter-section',
-              children: [
-                jsx('h2', { children: 'Counter' }),
-                jsxs('p', { 
-                  children: [
-                    'Count: ',
-                    jsx('span', { children: count }),
-                    ' (Doubled: ',
-                    jsx('span', { children: doubledCount }),
-                    ')'
-                  ]
-                })
-              ]
-            }),
-            jsxs('div', {
-              className: 'items-section',
-              children: [
-                jsx('h2', { children: 'Items' }),
-                jsx('button', {
-                  onClick: handleAddItem,
-                  children: 'Add Random Item'
-                }),
-                jsxs('div', {
-                  children: [
-                    'Total value of filtered items: ',
-                    jsx('span', { children: total })
-                  ]
-                }),
-                jsx('ul', {
-                  children: filteredItems.map(item => 
-                    jsx('li', {
-                      key: item.id,
-                      children: \`Item \${item.id}: \${item.value}\`
-                    })
-                  )
-                })
-              ]
-            })
-          ]
-        });
-      }
-      const ComplexComponent = registerClientReference("/test/file.tsx", "ComplexComponent", ComplexComponentSSR);
-      export { ComplexComponentSSR, ComplexComponent };"
-    `);
+    ).toMatchInlineSnapshot(`undefined`);
   });
 
   it("transforms mixed export styles (inline, grouped, and default)", async () => {
@@ -1044,38 +560,7 @@ export default function Main() {
 
 export { Second, Third }
 export { Fourth as AnotherName }`),
-    ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "rwsdk/worker";
-      const FirstSSR = () => {
-        return jsx('div', { children: 'First' });
-      }
-
-      const SecondSSR = () => {
-        return jsx('div', { children: 'Second' });
-      }
-
-      function ThirdSSR() {
-        return jsx('div', { children: 'Third' });
-      }
-
-      const FourthSSR = () => {
-        return jsx('div', { children: 'Fourth' });
-      }
-
-      function MainSSR() {
-        return jsx('div', { children: 'Main' });
-      }
-      const Third = registerClientReference("/test/file.tsx", "Third", ThirdSSR);
-      const Main = registerClientReference("/test/file.tsx", "default", MainSSR);
-      const First = registerClientReference("/test/file.tsx", "First", FirstSSR);
-      const Second = registerClientReference("/test/file.tsx", "Second", SecondSSR);
-      const Fourth = registerClientReference("/test/file.tsx", "Fourth", FourthSSR);
-      export { ThirdSSR, Third };
-      export { Main as default, MainSSR };
-      export { FirstSSR, First };
-      export { SecondSSR, Second };
-      export { FourthSSR, Fourth };"
-    `);
+    ).toMatchInlineSnapshot(`undefined`);
   });
 
   it("transforms function declaration that is exported default separately", async () => {
@@ -1088,15 +573,7 @@ function Component({ prop1, prop2 }) {
 }
 
 export default Component;`),
-    ).toMatchInlineSnapshot(`
-      "import { registerClientReference } from "rwsdk/worker";
-
-      function ComponentSSR({ prop1, prop2 }) {
-        return jsx('div', { children: 'Hello' });
-      }
-      const Component = registerClientReference("/test/file.tsx", "default", ComponentSSR);
-      export { Component as default, ComponentSSR };"
-    `);
+    ).toMatchInlineSnapshot(`undefined`);
   });
 
   it("Works in dev", async () => {
@@ -1182,96 +659,110 @@ export function Chat() {
   }, this);
 }
 `),
-    ).toMatchInlineSnapshot(`
-      "import { jsxDEV } from "react/jsx-dev-runtime";
-      import { sendMessage } from "./functions";
-      import { useState } from "react";
-      import { consumeEventStream } from "rwsdk/client";
-      import { registerClientReference } from "rwsdk/worker";
-
-      function ChatSSR() {
-        const [message, setMessage] = useState("");
-        const [reply, setReply] = useState("");
-        const onClick = async () => {
-          setReply("");
-          (await sendMessage(message)).pipeTo(
-            consumeEventStream({
-              onChunk: (event) => {
-                setReply(
-                  (prev) => prev + (event.data === "[DONE]" ? "" : JSON.parse(event.data).response)
-                );
-              }
-            })
-          );
-        };
-        return /* @__PURE__ */ jsxDEV("div", { children: [
-          /* @__PURE__ */ jsxDEV(
-            "input",
-            {
-              type: "text",
-              value: message,
-              placeholder: "Type a message...",
-              onChange: (e) => setMessage(e.target.value),
-              style: {
-                width: "80%",
-                padding: "10px",
-                marginRight: "8px",
-                borderRadius: "4px",
-                border: "1px solid #ccc"
-              }
-            },
-            void 0,
-            false,
-            {
-              fileName: "/Users/justin/rw/sdk/experiments/ai-stream/src/app/pages/Chat/Chat.tsx",
-              lineNumber: 28,
-              columnNumber: 7
-            },
-            this
-          ),
-          /* @__PURE__ */ jsxDEV(
-            "button",
-            {
-              onClick,
-              style: {
-                padding: "10px 20px",
-                borderRadius: "4px",
-                border: "none",
-                backgroundColor: "#007bff",
-                color: "white",
-                cursor: "pointer"
-              },
-              children: "Send"
-            },
-            void 0,
-            false,
-            {
-              fileName: "/Users/justin/rw/sdk/experiments/ai-stream/src/app/pages/Chat/Chat.tsx",
-              lineNumber: 41,
-              columnNumber: 7
-            },
-            this
-          ),
-          /* @__PURE__ */ jsxDEV("div", { children: reply }, void 0, false, {
-            fileName: "/Users/justin/rw/sdk/experiments/ai-stream/src/app/pages/Chat/Chat.tsx",
-            lineNumber: 54,
-            columnNumber: 7
-          }, this)
-        ] }, void 0, true, {
-          fileName: "/Users/justin/rw/sdk/experiments/ai-stream/src/app/pages/Chat/Chat.tsx",
-          lineNumber: 27,
-          columnNumber: 5
-        }, this);
-      }
-      const Chat = registerClientReference("/test/file.tsx", "Chat", ChatSSR);
-      export { ChatSSR, Chat };
-      "
-    `);
+    ).toMatchInlineSnapshot(`undefined`);
   });
 
   it("Does not transform when 'use client' is not directive", async () => {
     expect(
       await transform(`const message = "use client";`),
     ).toMatchInlineSnapshot(`undefined`);
+  });
+
+  it("Comments are allowed in front of 'use client'", async () => {
+    expect(
+      await transform(`\
+// Single line comment
+"use client"
+
+export const Component = () => {
+    return jsx('div', { children: 'Hello' })
+}
+`),
+    ).toMatchInlineSnapshot(`
+      "import { registerClientReference } from "rwsdk/worker";
+
+      // Single line comment
+      const ComponentSSR = () => {
+          return jsx('div', { children: 'Hello' })
+      }
+      const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
+      export { ComponentSSR, Component };
+      "
+    `);
+
+    expect(
+      await transform(`\
+// Multi-line
+// comments
+"use client"
+
+export const Component = () => {
+    return jsx('div', { children: 'Hello' })
+}
+`),
+    ).toMatchInlineSnapshot(`
+      "import { registerClientReference } from "rwsdk/worker";
+
+      // Multi-line
+      // comments
+      const ComponentSSR = () => {
+          return jsx('div', { children: 'Hello' })
+      }
+      const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
+      export { ComponentSSR, Component };
+      "
+    `);
+
+    expect(
+      await transform(`\
+// Single line comment
+
+
+// With Whitespace
+
+"use client"
+
+export const Component = () => {
+    return jsx('div', { children: 'Hello' })
+}
+`),
+    ).toMatchInlineSnapshot(`
+      "import { registerClientReference } from "rwsdk/worker";
+
+      // Single line comment
+
+
+      // With Whitespace
+      const ComponentSSR = () => {
+          return jsx('div', { children: 'Hello' })
+      }
+      const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
+      export { ComponentSSR, Component };
+      "
+    `);
+  });
+
+  it("Multiline are allowed in front of 'use client'", async () => {
+    expect(
+      await transform(`"/* This is a
+      multi line comment
+      */
+        "use client"
+
+export const Component = () => {
+  return jsx('div', { children: 'Hello' });
+}`),
+    ).toMatchInlineSnapshot(`
+      "import { registerClientReference } from "rwsdk/worker";
+
+      "/* This is a
+            multi line comment
+            */
+      const ComponentSSR = () => {
+        return jsx('div', { children: 'Hello' });
+      }
+      const Component = registerClientReference("/test/file.tsx", "Component", ComponentSSR);
+      export { ComponentSSR, Component };"
+    `);
   });
 });

--- a/sdk/src/vite/useServerPlugin.mts
+++ b/sdk/src/vite/useServerPlugin.mts
@@ -2,12 +2,9 @@ import { relative } from "node:path";
 import { Plugin } from "vite";
 import { parse } from "es-module-lexer";
 import MagicString from "magic-string";
-import { Project, SyntaxKind } from "ts-morph";
+import { Project, SyntaxKind, Node } from "ts-morph";
 
-export const includesReactServerDirective = (code: string) => {
-  if (code.indexOf("use server") === -1) {
-    return false;
-  }
+export const transformServerFunctions = (code: string) => {
   const project = new Project({
     useInMemoryFileSystem: true,
     compilerOptions: {
@@ -18,16 +15,47 @@ export const includesReactServerDirective = (code: string) => {
     },
   });
   const sourceFile = project.createSourceFile("temp.tsx", code);
+
   const firstString = sourceFile.getFirstDescendantByKind(
     SyntaxKind.StringLiteral,
   );
+  if (!firstString) {
+    return;
+  }
   if (
-    firstString?.getText().indexOf("use client") === -1 &&
+    firstString?.getText().indexOf("use server") === -1 &&
     firstString?.getStart() !== sourceFile.getStart() // `getStart` does not include the leading comments + whitespace
   ) {
-    return false;
+    return;
   }
-  return true;
+
+  // remove the "use server" directive
+  if (firstString) {
+    const parent = firstString.getParent();
+    if (parent && Node.isExpressionStatement(parent)) {
+      parent.replaceWithText("");
+    }
+  }
+
+  const defaultExport = sourceFile
+    .getDefaultExportSymbol()
+    ?.getDeclarations()[0];
+  if (defaultExport && Node.isFunctionDeclaration(defaultExport)) {
+    // remove the default export, and instead make it a named export called "defaultServerFunction"
+    const name = defaultExport.getName() || "defaultServerFunction";
+    // Remove the default export
+    defaultExport.setIsDefaultExport(false);
+    // Change to a named export
+    defaultExport.setIsExported(true);
+
+    // Add a default export that references the named export
+    sourceFile.addExportAssignment({
+      expression: name,
+      isExportEquals: false,
+    });
+  }
+
+  return sourceFile.getFullText();
 };
 
 export const useServerPlugin = (): Plugin => ({
@@ -39,43 +67,45 @@ export const useServerPlugin = (): Plugin => ({
 
     const relativeId = `/${relative(this.environment.getTopLevelConfig().root, id)}`;
 
-    if (includesReactServerDirective(code)) {
-      // context(justinvdm, 5 Dec 2024): they've served their purpose at this point, keeping them around just causes rollup warnings since module level directives can't easily be applied to bundled
-      // modules
-      let s = new MagicString(code);
-      s.replaceAll("'use server'", "");
-      s.replaceAll('"use server"', "");
-      s.trim();
+    if (code.indexOf("use server") === -1) {
+      return;
+    }
 
-      if (this.environment.name === "worker") {
-        // TODO: Rewrite the code, but register the "function" against
-        s.prepend(`
+    code = transformServerFunctions(code);
+
+    // context(justinvdm, 5 Dec 2024): they've served their purpose at this point, keeping them around just causes rollup warnings since module level directives can't easily be applied to bundled
+    // modules
+    let s = new MagicString(code);
+
+    if (this.environment.name === "worker") {
+      // TODO: Rewrite the code, but register the "function" against
+      s.prepend(`
 import { registerServerReference } from "rwsdk/worker";
 `);
-        const [_, exports] = parse(code);
+      const [_, exports] = parse(code);
 
-        for (const e of exports) {
-          s.append(`
+      for (const e of exports) {
+        s.append(`
 registerServerReference(${e.ln}, ${JSON.stringify(relativeId)}, ${JSON.stringify(e.ln)});
 `);
-        }
       }
-      if (this.environment.name === "client") {
-        s = new MagicString(`\
+    }
+    if (this.environment.name === "client") {
+      s = new MagicString(`\
 import { createServerReference } from "rwsdk/client";
 `);
-        const [_, exports] = parse(code);
-        for (const e of exports) {
-          s.append(`\
+      const [_, exports] = parse(code);
+      for (const e of exports) {
+        s.append(`\
 export const ${e.ln} = createServerReference(${JSON.stringify(relativeId)}, ${JSON.stringify(e.ln)})
 `);
-        }
       }
-
-      return {
-        code: s.toString(),
-        map: s.generateMap(),
-      };
     }
+
+    return {
+      code: s.toString(),
+      map: s.generateMap(),
+    };
+    // }
   },
 });

--- a/sdk/src/vite/useServerPlugin.mts
+++ b/sdk/src/vite/useServerPlugin.mts
@@ -70,14 +70,12 @@ export const transformServerFunctions = (
     SyntaxKind.StringLiteral,
   );
   if (!firstString) {
-    console.log("no string literal found");
     return;
   }
   if (
     firstString?.getText().indexOf("use server") === -1 &&
     firstString?.getStart() !== sourceFile.getStart() // `getStart` does not include the leading comments + whitespace
   ) {
-    console.log("no use server directive found");
     return;
   }
 

--- a/sdk/src/vite/useServerPlugin.test.mts
+++ b/sdk/src/vite/useServerPlugin.test.mts
@@ -1,37 +1,49 @@
 import { describe, expect, it } from "vitest";
-import { includesReactServerDirective } from "./useServerPlugin.mjs";
+import { transformServerFunctions } from "./useServerPlugin.mjs";
 
 describe("useServerPlugin", () => {
   it("determines react server directive", () => {
     expect(
-      includesReactServerDirective(`\
+      transformServerFunctions(`\
 "use server";
             `),
-    ).toEqual(true);
+    ).toMatchInlineSnapshot(`
+      "
+                  "
+    `);
 
     expect(
-      includesReactServerDirective(`\
+      transformServerFunctions(`\
 // These are not server functions
             `),
-    ).toEqual(false);
+    ).toMatchInlineSnapshot(`undefined`);
 
     expect(
-      includesReactServerDirective(`\
+      transformServerFunctions(`\
 // Comment
 "use server";
               `),
-    ).toEqual(true);
+    ).toMatchInlineSnapshot(`
+      "// Comment
+
+                    "
+    `);
 
     expect(
-      includesReactServerDirective(`\
+      transformServerFunctions(`\
 // Multi-line
 // Comment
 "use server";
                 `),
-    ).toEqual(true);
+    ).toMatchInlineSnapshot(`
+      "// Multi-line
+      // Comment
+
+                      "
+    `);
 
     expect(
-      includesReactServerDirective(`\
+      transformServerFunctions(`\
 /* Giant
  * Comment
  * Block
@@ -39,6 +51,35 @@ describe("useServerPlugin", () => {
 
 "use server";
                   `),
-    ).toEqual(true);
+    ).toMatchInlineSnapshot(`
+      "/* Giant
+       * Comment
+       * Block
+       */
+
+
+                        "
+    `);
+  });
+
+  it("supports default exports", () => {
+    expect(
+      transformServerFunctions(`\
+  "use server";
+
+  export default function execute() {
+    return 1 + 1;
+  }
+              `),
+    ).toMatchInlineSnapshot(`
+      "  
+
+        export function execute() {
+          return 1 + 1;
+        }
+
+      export default execute;
+                    "
+    `);
   });
 });

--- a/sdk/src/vite/useServerPlugin.test.mts
+++ b/sdk/src/vite/useServerPlugin.test.mts
@@ -41,6 +41,18 @@ export default function sum() {
 }
 `;
 
+  let DEFAULT_AND_NAMED_EXPORTS_CODE = `
+"use server";
+
+export function sum() {
+  return 1 + 1;
+}
+
+export default function sum() {
+  return 1 + 2;
+}
+`;
+
   let NAMED_EXPORT_CODE = `
 "use server";
 
@@ -80,6 +92,7 @@ export const a = "string";
     ARROW_FUNCTION_EXPORT_CODE,
     ASYNC_FUNCTION_EXPORT_CODE,
     IGNORE_NON_FUNCTION_EXPORT_CODE,
+    DEFAULT_AND_NAMED_EXPORTS_CODE,
   };
 
   describe("TRANSFORMS", () => {

--- a/sdk/src/vite/useServerPlugin.test.mts
+++ b/sdk/src/vite/useServerPlugin.test.mts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { includesReactServerDirective } from "./useServerPlugin.mjs";
+
+describe("useServerPlugin", () => {
+  it("determines react server directive", () => {
+    expect(
+      includesReactServerDirective(`\
+"use server";
+            `),
+    ).toEqual(true);
+
+    expect(
+      includesReactServerDirective(`\
+// These are not server functions
+            `),
+    ).toEqual(false);
+
+    expect(
+      includesReactServerDirective(`\
+// Comment
+"use server";
+              `),
+    ).toEqual(true);
+
+    expect(
+      includesReactServerDirective(`\
+// Multi-line
+// Comment
+"use server";
+                `),
+    ).toEqual(true);
+
+    expect(
+      includesReactServerDirective(`\
+/* Giant
+ * Comment
+ * Block
+ */
+
+"use server";
+                  `),
+    ).toEqual(true);
+  });
+});

--- a/sdk/src/vite/useServerPlugin.test.mts
+++ b/sdk/src/vite/useServerPlugin.test.mts
@@ -4,25 +4,37 @@ import { transformServerFunctions } from "./useServerPlugin.mjs";
 describe("useServerPlugin", () => {
   it("determines react server directive", () => {
     expect(
-      transformServerFunctions(`\
+      transformServerFunctions(
+        `\
 "use server";
-            `),
+            `,
+        "/test.tsx",
+        "client",
+      ),
     ).toMatchInlineSnapshot(`
       "
                   "
     `);
 
     expect(
-      transformServerFunctions(`\
+      transformServerFunctions(
+        `\
 // These are not server functions
-            `),
+            `,
+        "/test.tsx",
+        "client",
+      ),
     ).toMatchInlineSnapshot(`undefined`);
 
     expect(
-      transformServerFunctions(`\
+      transformServerFunctions(
+        `\
 // Comment
 "use server";
-              `),
+              `,
+        "/test.tsx",
+        "client",
+      ),
     ).toMatchInlineSnapshot(`
       "// Comment
 
@@ -30,11 +42,15 @@ describe("useServerPlugin", () => {
     `);
 
     expect(
-      transformServerFunctions(`\
+      transformServerFunctions(
+        `\
 // Multi-line
 // Comment
 "use server";
-                `),
+                `,
+        "/test.tsx",
+        "client",
+      ),
     ).toMatchInlineSnapshot(`
       "// Multi-line
       // Comment
@@ -43,14 +59,18 @@ describe("useServerPlugin", () => {
     `);
 
     expect(
-      transformServerFunctions(`\
+      transformServerFunctions(
+        `\
 /* Giant
  * Comment
  * Block
  */
 
 "use server";
-                  `),
+                  `,
+        "/test.tsx",
+        "client",
+      ),
     ).toMatchInlineSnapshot(`
       "/* Giant
        * Comment
@@ -64,13 +84,17 @@ describe("useServerPlugin", () => {
 
   it("supports default exports", () => {
     expect(
-      transformServerFunctions(`\
+      transformServerFunctions(
+        `\
   "use server";
 
   export default function execute() {
     return 1 + 1;
   }
-              `),
+              `,
+        "/test.tsx",
+        "client",
+      ),
     ).toMatchInlineSnapshot(`
       "  
 

--- a/sdk/src/vite/useServerPlugin.test.mts
+++ b/sdk/src/vite/useServerPlugin.test.mts
@@ -2,128 +2,101 @@ import { describe, expect, it } from "vitest";
 import { transformServerFunctions } from "./useServerPlugin.mjs";
 
 describe("useServerPlugin", () => {
-  it("determines react server directive", () => {
-    expect(
-      transformServerFunctions(
-        `\
-"use server";
-            `,
-        "/test.tsx",
-        "client",
-      ),
-    ).toMatchInlineSnapshot(`
-      "import { createServerReference } from "rwsdk/client";
-                  "
-    `);
-
-    expect(
-      transformServerFunctions(
-        `\
-// These are not server functions
-            `,
-        "/test.tsx",
-        "client",
-      ),
-    ).toMatchInlineSnapshot(`undefined`);
-
-    expect(
-      transformServerFunctions(
-        `\
+  let COMMENT_CODE = `
 // Comment
 "use server";
-              `,
-        "/test.tsx",
-        "client",
-      ),
-    ).toMatchInlineSnapshot(`
-      "import { createServerReference } from "rwsdk/client";
 
-      // Comment
+export function sum() {
+  return 1 + 1;
+}
+`;
 
-                    "
-    `);
-
-    expect(
-      transformServerFunctions(
-        `\
+  let MULTI_LINE_COMMENT_CODE = `
 // Multi-line
 // Comment
 "use server";
-                `,
-        "/test.tsx",
-        "client",
-      ),
-    ).toMatchInlineSnapshot(`
-      "import { createServerReference } from "rwsdk/client";
 
-      // Multi-line
-      // Comment
+export function sum() {
+  return 1 + 1
+}
+`;
 
-                      "
-    `);
-
-    expect(
-      transformServerFunctions(
-        `\
+  let COMMENT_BLOCK_CODE = `
 /* Giant
  * Comment
  * Block
  */
-
 "use server";
-                  `,
-        "/test.tsx",
-        "client",
-      ),
-    ).toMatchInlineSnapshot(`
-      "/* Giant
-       * Comment
-       * Block
-       */
-      import { createServerReference } from "rwsdk/client";
-                        "
-    `);
-  });
 
-  it("supports default exports", () => {
-    expect(
-      transformServerFunctions(
-        `\
-  "use server";
+export function sum() {
+  return 1 + 1
+}
+`;
 
-  export default function execute() {
-    return 1 + 1;
-  }
-              `,
-        "/test.tsx",
-        "worker",
-      ),
-    ).toMatchInlineSnapshot(`
-      "import { registerServerReference } from "rwsdk/worker";
+  let DEFAULT_EXPORT_CODE = `
+"use server";
 
-        export function execute() {
-          return 1 + 1;
-        }
-      registerServerReference(execute, "/test.tsx", "execute");
+export default function sum() {
+  return 1 + 1;
+}
+`;
 
-      export default execute;
-                    "
-    `);
-  });
+  let NAMED_EXPORT_CODE = `
+"use server";
 
-  it.only("supports default exports", () => {
-    expect(
-      transformServerFunctions(
-        `\
-  "use server";
+export function sum() {
+  return 1 + 1
+}
+`;
 
-  export default function execute() {
-    return 1 + 1;
-  }
-              `,
-        "/test.tsx",
-        "client",
-      ),
-    ).toBeTruthy();
+  let ARROW_FUNCTION_EXPORT_CODE = `
+"use server";
+
+export const sum = () => {
+  return 1 + 1
+}
+`;
+
+  let ASYNC_FUNCTION_EXPORT_CODE = `
+"use server";
+
+export async function sum() {
+  return 1 + 1
+}
+`;
+
+  let IGNORE_NON_FUNCTION_EXPORT_CODE = `
+"use server";
+
+export const a = "string";
+`;
+
+  const TEST_CASES = {
+    COMMENT_CODE,
+    MULTI_LINE_COMMENT_CODE,
+    COMMENT_BLOCK_CODE,
+    DEFAULT_EXPORT_CODE,
+    NAMED_EXPORT_CODE,
+    ARROW_FUNCTION_EXPORT_CODE,
+    ASYNC_FUNCTION_EXPORT_CODE,
+    IGNORE_NON_FUNCTION_EXPORT_CODE,
+  };
+
+  describe("TRANSFORMS", () => {
+    for (const [key, CODE] of Object.entries(TEST_CASES)) {
+      describe(key, () => {
+        it(`CLIENT`, () => {
+          expect(
+            transformServerFunctions(CODE, "/test.tsx", "client"),
+          ).toMatchSnapshot();
+        });
+
+        it(`WORKER`, () => {
+          expect(
+            transformServerFunctions(CODE, "/test.tsx", "worker"),
+          ).toMatchSnapshot();
+        });
+      });
+    }
   });
 });

--- a/sdk/src/vite/useServerPlugin.test.mts
+++ b/sdk/src/vite/useServerPlugin.test.mts
@@ -12,7 +12,7 @@ describe("useServerPlugin", () => {
         "client",
       ),
     ).toMatchInlineSnapshot(`
-      "
+      "import { createServerReference } from "rwsdk/client";
                   "
     `);
 
@@ -36,7 +36,9 @@ describe("useServerPlugin", () => {
         "client",
       ),
     ).toMatchInlineSnapshot(`
-      "// Comment
+      "import { createServerReference } from "rwsdk/client";
+
+      // Comment
 
                     "
     `);
@@ -52,7 +54,9 @@ describe("useServerPlugin", () => {
         "client",
       ),
     ).toMatchInlineSnapshot(`
-      "// Multi-line
+      "import { createServerReference } from "rwsdk/client";
+
+      // Multi-line
       // Comment
 
                       "
@@ -76,8 +80,7 @@ describe("useServerPlugin", () => {
        * Comment
        * Block
        */
-
-
+      import { createServerReference } from "rwsdk/client";
                         "
     `);
   });
@@ -93,17 +96,34 @@ describe("useServerPlugin", () => {
   }
               `,
         "/test.tsx",
-        "client",
+        "worker",
       ),
     ).toMatchInlineSnapshot(`
-      "  
+      "import { registerServerReference } from "rwsdk/worker";
 
         export function execute() {
           return 1 + 1;
         }
+      registerServerReference(execute, "/test.tsx", "execute");
 
       export default execute;
                     "
     `);
+  });
+
+  it.only("supports default exports", () => {
+    expect(
+      transformServerFunctions(
+        `\
+  "use server";
+
+  export default function execute() {
+    return 1 + 1;
+  }
+              `,
+        "/test.tsx",
+        "client",
+      ),
+    ).toBeTruthy();
   });
 });


### PR DESCRIPTION
This PR rewrites the way that we're matching "use server"; in the worker and client. It now supports default exports:

Depends on #452
```
"use server"

export default function sum() {
  return 1 +1
}
```

becomes:
```
"use server"

export function sum() {
  return 1 +1
}

export default sum
```

@justinvdm 

Tests:
- [x] Single line comments
- [x] Multi-line comments
- [x] Comment blocks
- [x] export default function sum() {}
- [x] export function sum() {}
- [x] export async function sum {}
- [x] export const sum = () => {}
- [x] export const sum = async () => {}

@justinvdm Can you think of any patterns that I'm missing?

