### PR TITLE
Doc typos

### DIFF
--- a/docs/src/content/docs/core/database.mdx
+++ b/docs/src/content/docs/core/database.mdx
@@ -20,7 +20,7 @@ RedwoodSDK is built to work on the Cloudflare Developer Platform. D1 is Cloudfla
 
 ## Setup
 
-You'll need to "bind" your database to your worker (`./src/worker.tsx`). "Binding" implies that the an external service, like the database, is made available via the `env` object in your worker. You can also bind other services, like KV, Storage, and queues.
+You'll need to "bind" your database to your worker (`./src/worker.tsx`). "Binding" implies that there is an external service, like the database, is made available via the `env` object in your worker. You can also bind other services, like KV, Storage, and queues.
 
 In order to bind a database to your worker you'll need to create a D1 database, and save it's configuration details in your `wrangler.jsonc` file.
 

--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -34,7 +34,7 @@ Create a new project by running the following command, replacing `<project-name>
 
 <Tabs syncKey="starlight-package-managers-pkg">
   <TabItem label="npm" icon="seti:npm">
-    ```bash frame="none" showLineNumbers=false  
+    ```bash frame="none" showLineNumbers=false
     cd <project-name>
     npm install
     ```
@@ -130,6 +130,10 @@ RedwoodSDK is built for the Cloudflare Development Platform. You can deploy your
   type="run"
   args="release"
 />
+
+The first time you run the command it might fail and ask you to create a workers.dev subdomain. Do as indicated and go to the dashboard and open the
+  Workers menu. Opening the Workers landing page for the first time will create a workers.dev
+  subdomain automatically
 
 <LinkCard
   title="What's next?"

--- a/docs/src/content/docs/tutorial/full-stack-app/2-create-app.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/2-create-app.mdx
@@ -120,10 +120,7 @@ Since the RedwoodSDK is based on React and Vite, we can work through the ["Using
 
 <Steps>
 1. Install Tailwind CSS
-    <PackageManagers
-      type="install"
-      pkg="tailwindcss @tailwindcss/vite"
-    />
+    <PackageManagers pkg="tailwindcss @tailwindcss/vite" />
 
 2. Configure the Vite Plugin
     ```ts ins="import tailwindcss from '@tailwindcss/vite'" ins="tailwindcss()," title="vite.config.mts" ins={6-8} {2, 11}


### PR DESCRIPTION
`type="install"` gives `yarn install` instead of `yarn add`, not putting any type shows the correct default install command for each package manager