### PR TITLE
Ensure prisma client initialized after wasm engine initialized

### DIFF
--- a/starters/standard/src/db.ts
+++ b/starters/standard/src/db.ts
@@ -4,6 +4,10 @@ import { env } from "cloudflare:workers";
 
 export let db: PrismaClient;
 
+// context(justinvdm, 21-05-2025): For prisma-generator-js or cases where there
+// are dynamic import to the prisma wasm modules, we need to make sure we are
+// instantiating the prisma client later in the flow when the wasm would have
+// been initialized.
 export const setupDb = async () => {
   const db = new PrismaClient({
     adapter: new PrismaD1(env.DB),

--- a/starters/standard/src/db.ts
+++ b/starters/standard/src/db.ts
@@ -2,6 +2,13 @@ import { PrismaClient } from "@prisma/client";
 import { PrismaD1 } from "@prisma/adapter-d1";
 import { env } from "cloudflare:workers";
 
-export const db = new PrismaClient({
-  adapter: new PrismaD1(env.DB),
-});
+export let db: PrismaClient;
+
+export const setupDb = async () => {
+  const db = new PrismaClient({
+    adapter: new PrismaD1(env.DB),
+  });
+
+  // context(justinvdm, 21-05-2025): https://github.com/cloudflare/workers-sdk/pull/8283
+  await db.$queryRaw`SELECT 1`;
+};

--- a/starters/standard/src/db.ts
+++ b/starters/standard/src/db.ts
@@ -4,10 +4,10 @@ import { env } from "cloudflare:workers";
 
 export let db: PrismaClient;
 
-// context(justinvdm, 21-05-2025): For prisma-generator-js or cases where there
-// are dynamic import to the prisma wasm modules, we need to make sure we are
-// instantiating the prisma client later in the flow when the wasm would have
-// been initialized.
+// context(justinvdm, 21-05-2025): For prisma-client-js generator or cases where
+// there are dynamic import to the prisma wasm modules, we need to make sure we
+// are instantiating the prisma client later in the flow when the wasm would
+// have been initialized.
 export const setupDb = async () => {
   const db = new PrismaClient({
     adapter: new PrismaD1(env.DB),

--- a/starters/standard/src/worker.tsx
+++ b/starters/standard/src/worker.tsx
@@ -6,7 +6,7 @@ import { setCommonHeaders } from "@/app/headers";
 import { userRoutes } from "@/app/pages/user/routes";
 import { sessions, setupSessionStore } from "./session/store";
 import { Session } from "./session/durableObject";
-import { db } from "./db";
+import { db, setupDb } from "./db";
 import type { User } from "@prisma/client";
 import { env } from "cloudflare:workers";
 export { SessionDurableObject } from "./session/durableObject";
@@ -20,6 +20,7 @@ export default defineApp([
   setCommonHeaders(),
   async ({ ctx, request, headers }) => {
     setupSessionStore(env);
+    await setupDb();
 
     try {
       ctx.session = await sessions.load(request);


### PR DESCRIPTION
For prisma-client-js generator or cases where there are dynamic import to the prisma wasm modules, we need to make sure we are instantiating the prisma client later in the flow when the wasm would have been initialized.

Fixes regression introduced in #443 that appears when querying in a deployed app

```
ReferenceError: Cannot access 'UL' before initialization
```