### PR TITLE
docs: Remove unneccessary word "is" in the email-templates doc"

### DIFF
--- a/docs/src/content/docs/guides/email/2-email-templates.mdx
+++ b/docs/src/content/docs/guides/email/2-email-templates.mdx
@@ -6,7 +6,7 @@ slug: guides/email/email-templates
 
 import { Aside, Steps, FileTree } from "@astrojs/starlight/components";
 
-The [React Email](https://react.email/) project is makes it easy to create email templates. It includes unstyled components and the Tailwind CSS support.
+The [React Email](https://react.email/) project makes it easy to create email templates. It includes unstyled components and the Tailwind CSS support.
 
 ## Installation
 


### PR DESCRIPTION
This PR fixes a small typo in the documentation file:

docs/src/content/docs/guides/email/2-email-templates.mdx

