### PR TITLE
fix: Prevent serialization errors when route components are client components

### DIFF
--- a/sdk/src/runtime/lib/router.ts
+++ b/sdk/src/runtime/lib/router.ts
@@ -273,6 +273,9 @@ function wrapWithLayouts(
     return Component;
   }
 
+  // Check if the final route component is a client component
+  const isRouteClientComponent = Object.prototype.hasOwnProperty.call(Component, "$$isClientReference");
+
   // Create nested layout structure - layouts[0] should be outermost, so use reduceRight
   return layouts.reduceRight((WrappedComponent, Layout) => {
     const Wrapped: React.FC = (props) => {
@@ -282,7 +285,7 @@ function wrapWithLayouts(
       );
 
       return React.createElement(Layout, {
-        children: React.createElement(WrappedComponent, props),
+        children: React.createElement(WrappedComponent, isRouteClientComponent ? {} : props),
         // Only pass requestInfo to server components to avoid serialization issues
         ...(isClientComponent ? {} : { requestInfo }),
       });


### PR DESCRIPTION
## Problem

When using the `layout()` function with route components marked as `"use client"`, the application would throw a serialization error as per this issue #484 

```
Only plain objects, and a few built-ins, can be passed to Client Components from Server Components. Classes or null prototypes are not supported.
<... request={{}} headers={{...}} cf=... params=... ctx=... rw=...>
```

This occurred because the layout wrapping logic was attempting to pass the `RequestInfo` object (containing non-serializable objects like `Request`, `Headers`, etc.) to client components, which violates React's RSC serialization constraints.

## Root Cause

The `wrapWithLayouts` function was only checking if **layout components** were client components, but not checking if the **route component itself** was a client component. 

When a route component was marked with `"use client"`:

```tsx
// This would fail:
"use client";
export function HomePage({ request, params }: RequestInfo) {
  // Client component receiving non-serializable RequestInfo
  return <div>Home</div>;
}
```

The layout wrapping process would still try to pass the full `props` (which includes `RequestInfo`) to the client route component, causing the serialization error.

## Solution

Enhanced the `wrapWithLayouts` function to detect client route components and handle them appropriately:

1. **Check route component**: Detect if the final route component has the `$$isClientReference` property
2. **Conditional props passing**: Pass empty props `{}` to client route components instead of the full `RequestInfo`
3. **Preserve existing logic**: Layout components continue to work as before

```tsx
function wrapWithLayouts(Component, layouts, requestInfo) {
  // NEW: Check if the route component is a client component
  const isRouteClientComponent = Object.prototype.hasOwnProperty.call(
    Component, 
    "$$isClientReference"
  );

  return layouts.reduceRight((WrappedComponent, Layout) => {
    const Wrapped = (props) => {
      const isClientComponent = Object.prototype.hasOwnProperty.call(
        Layout,
        "$$isClientReference",
      );

      return React.createElement(Layout, {
        // Pass empty props to client route components to avoid serialization
        children: React.createElement(
          WrappedComponent, 
          isRouteClientComponent ? {} : props  // ← Key fix
        ),
        ...(isClientComponent ? {} : { requestInfo }),
      });
    };
    return Wrapped;
  }, Component);
}
```

## Result

Now all combinations work correctly:

- ✅ **Server route + Server layout**: Route gets `RequestInfo`, layout gets `requestInfo`
- ✅ **Server route + Client layout**: Route gets `RequestInfo`, layout gets no `requestInfo`  
- ✅ **Client route + Server layout**: Route gets no props, layout gets `requestInfo`
- ✅ **Client route + Client layout**: Route gets no props, layout gets no `requestInfo`

Client route components that need data must obtain it through other means (client-side fetching, context, props from parent layouts, etc.), which is the expected pattern for client components in RSC applications.

## Testing

This fix maintains backward compatibility - existing server route components continue to receive `RequestInfo` as expected, while client route components now work without serialization errors.

## Related

- Fixes #484 