### PR TITLE
fix: Only check for directives for {js,mjs,cjs} in node_modules

### DIFF
--- a/sdk/src/vite/createDirectiveLookupPlugin.mts
+++ b/sdk/src/vite/createDirectiveLookupPlugin.mts
@@ -36,10 +36,24 @@ export const findFilesContainingDirective = async ({
     projectRootDir,
   );
 
-  const allFiles = await glob("**/*.{ts,tsx,js,jsx,mjs,mts}", {
-    cwd: projectRootDir,
-    absolute: true,
-  });
+  const filesOutsideNodeModules = await glob(
+    "**/*.{ts,tsx,js,jsx,mjs,mts,cjs}",
+    {
+      cwd: projectRootDir,
+      absolute: true,
+      ignore: ["**/node_modules/**"],
+    },
+  );
+
+  const filesInsideNodeModules = await glob(
+    "**/node_modules/**/*.{js,mjs,cjs}",
+    {
+      cwd: projectRootDir,
+      absolute: true,
+    },
+  );
+
+  const allFiles = [...filesOutsideNodeModules, ...filesInsideNodeModules];
 
   log("Found %d files to scan for '%s' directive", allFiles.length, directive);
 


### PR DESCRIPTION
When searching for `use client` and `use server` in node modules, we also include ts, tsx and jsx in the search. If its in `node_modules`, we should just be checking for `{js,mjs,cjs}` - transpilation should have happened for code in packages.