### PR TITLE
fix: Aliased exports to already exported component for "use client"

### DIFF
--- a/sdk/src/vite/directivesPlugin.mts
+++ b/sdk/src/vite/directivesPlugin.mts
@@ -7,7 +7,7 @@ import { normalizeModulePath } from "./normalizeModulePath.mjs";
 const log = debug("rwsdk:vite:rsc-directives-plugin");
 const verboseLog = debug("verbose:rwsdk:vite:rsc-directives-plugin");
 
-export const rscDirectivesPlugin = ({
+export const directivesPlugin = ({
   projectRootDir,
   clientFiles,
   serverFiles,

--- a/sdk/src/vite/redwoodPlugin.mts
+++ b/sdk/src/vite/redwoodPlugin.mts
@@ -5,7 +5,7 @@ import reactPlugin from "@vitejs/plugin-react";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 import { transformJsxScriptTagsPlugin } from "./transformJsxScriptTagsPlugin.mjs";
-import { rscDirectivesPlugin } from "./rscDirectivesPlugin.mjs";
+import { directivesPlugin } from "./directivesPlugin.mjs";
 import { useClientLookupPlugin } from "./useClientLookupPlugin.mjs";
 import { useServerLookupPlugin } from "./useServerLookupPlugin.mjs";
 import { miniflarePlugin } from "./miniflarePlugin.mjs";
@@ -87,7 +87,7 @@ export const redwoodPlugin = async (
         options.configPath ?? (await findWranglerConfig(projectRootDir)),
     }),
     reactPlugin(),
-    rscDirectivesPlugin({
+    directivesPlugin({
       projectRootDir,
       clientFiles,
       serverFiles,

--- a/sdk/src/vite/transformClientComponents.test.mts
+++ b/sdk/src/vite/transformClientComponents.test.mts
@@ -116,8 +116,8 @@ export { Fourth as AnotherName }`)) ?? "",
 const First = registerClientReference("/test/file.tsx", "First");
 const Second = registerClientReference("/test/file.tsx", "Second");
 const Third = registerClientReference("/test/file.tsx", "Third");
-const Fourth = registerClientReference("/test/file.tsx", "AnotherName");
-export { First, Second, Third, Fourth as AnotherName };
+const Fourth_AnotherName = registerClientReference("/test/file.tsx", "AnotherName");
+export { First, Second, Third, Fourth_AnotherName as AnotherName };
 export default registerClientReference("/test/file.tsx", "default");
 `,
     );
@@ -246,8 +246,8 @@ const MyComponent = () => {
 export { MyComponent as CustomName }`)) ?? "",
     ).toEqual(
       `import { registerClientReference } from "rwsdk/worker";
-const MyComponent = registerClientReference("/test/file.tsx", "CustomName");
-export { MyComponent as CustomName };
+const MyComponent_CustomName = registerClientReference("/test/file.tsx", "CustomName");
+export { MyComponent_CustomName as CustomName };
 `,
     );
   });
@@ -286,6 +286,25 @@ const Component = registerClientReference("/test/file.tsx", "Component");
 const data = registerClientReference("/test/file.tsx", "data");
 const helper = registerClientReference("/test/file.tsx", "helper");
 export { Component, data, helper };
+`,
+    );
+  });
+
+  it("transforms multiple exports aliases for the same component", async () => {
+    expect(
+      (await transform(`"use client"
+
+export const Slot = () => {
+  return jsx('div', { children: 'Slot' });
+}
+
+export { Slot, Slot as Root }
+`)) ?? "",
+    ).toEqual(
+      `import { registerClientReference } from "rwsdk/worker";
+const Slot = registerClientReference("/test/file.tsx", "Slot");
+const Slot_Root = registerClientReference("/test/file.tsx", "Root");
+export { Slot, Slot_Root as Root };
 `,
     );
   });


### PR DESCRIPTION
For the `worker` environment, when transforming `"use client"` modules that export a component with both its original name and an aliased name:

```
"use client"

export const Slot = () => {
  return jsx('div', { children: 'Slot' });
}

export { Slot, Slot as Root }
```

... the result looked like this - note the const that appears twice:

```
import { registerClientReference } from "rwsdk/worker";

const Slot = registerClientReference("/test/file.tsx", "Slot");
const Slot = registerClientReference("/test/file.tsx", "Root");  // same const as line above!

export { Slot, Slot as Root };
```

This PR fix this so that we correctly qualify the names for the alias case:

```
import { registerClientReference } from "rwsdk/worker";

const Slot = registerClientReference("/test/file.tsx", "Slot");
const Slot_Root = registerClientReference("/test/file.tsx", "Root");

export { Slot, Slot_Root as Root };
```