### PR TITLE
fix: Separate entry point for rwsd/client during SSR

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -29,6 +29,7 @@
     },
     "./client": {
       "react-server": "./dist/runtime/entries/no-react-server.js",
+      "workerd": "./dist/runtime/entries/clientSSR.js",
       "types": "./dist/runtime/entries/client.d.ts",
       "default": "./dist/runtime/entries/client.js"
     },

--- a/sdk/src/runtime/entries/clientSSR.ts
+++ b/sdk/src/runtime/entries/clientSSR.ts
@@ -1,0 +1,1 @@
+export * from "../lib/streams/consumeEventStream";

--- a/sdk/src/vite/configPlugin.mts
+++ b/sdk/src/vite/configPlugin.mts
@@ -130,10 +130,6 @@ export const configPlugin = ({
       server: {
         hmr: true,
       },
-      resolve: {
-        conditions: ["workerd"],
-        alias: [],
-      },
       builder: {
         buildApp: async (builder) => {
           // note(justinvdm, 27 May 2025): **Ordering is important**:


### PR DESCRIPTION
## Problem
Currently, if `rwsdk/client` is imported in a `"use client"` component, this will cause us to evaluate code paths that were intended to only run in the browser in the cloudflare worker runtime environment too.

This plays out in unexpected ways. For example, `globalThis.__webpack_require__` (used for loading client components on both client side and SSR in worker) gets overridden to use the module loader meant for the browser.

## Solution
* Remove the global `workerd` import condition from vite config: this way, resolutions in `client` environment now (correctly) do not follow `workerd` import conditions, but `ssr` and `worker` environments still do
* Change our `rwsdk/client` export conditions to point to a different entry point in the `workerd` case, so that SSR can get its own entry point for this specifier that avoids code paths we only want to run client side