### PR TITLE
docs: remove note

### DIFF
--- a/docs/src/content/docs/core/authentication.mdx
+++ b/docs/src/content/docs/core/authentication.mdx
@@ -16,12 +16,6 @@ import importedCodeStandardLogin from "../../../../../starters/standard/src/app/
 
 We've baked authentication right into the [**standard starter**](https://github.com/redwoodjs/sdk/tree/main/starters/standard), giving you everything you need to handle users, sessions, and logins out of the box. The standard starter uses **passkeys ([WebAuthn](https://webauthn.guide/))** for passwordless authentication (keys can be shared on multiple devices), **session persistence via [Cloudflare Durable Objects](https://developers.cloudflare.com/durable-objects/)**, and **bot protection with [Cloudflare Turnstile](https://developers.cloudflare.com/turnstile/)**. The database layer is powered by **[Cloudflare D1](https://developers.cloudflare.com/d1/)** and **[Prisma](https://www.prisma.io/)**.
 
-<Aside type="caution">
-  The [Quick Start Guide](/getting-started/quick-start) uses the **minimal
-  starter**, you should use the **standard starter** to get you set up and ready
-  for using Database, Queues, Sessions and Authentication.
-</Aside>
-
 ## Setup
 
 Below covers the steps needed to getting authentication working in your **deployments**.


### PR DESCRIPTION
# Removes Quick Start Note in Authentication Section

![image](https://github.com/user-attachments/assets/fb6658c3-113d-4d2a-86ed-45eb8e7ec16f)

Removes the note about Quick Start using the minimal template from the _Authentication_ section. According to[ create-rwsdk](https://docs.rwsdk.com/reference/create-rwsdk/), the default command uses standard template.

> The [Quick Start Guide](https://docs.rwsdk.com/getting-started/quick-start) uses the minimal starter, you should use the standard starter to get you set up and ready for using Database, Queues, Sessions and Authentication.

## Thought: 
**Caveat:** check if the standard starter still uses: Database, Queues, Sessions and Authentication. 👀 

If no, modify the note or the doc vs remove altogther.
