### PR TITLE
fix: Ensure .js extension when resolving ssr bridge in builds

### DIFF
--- a/sdk/src/vite/configPlugin.mts
+++ b/sdk/src/vite/configPlugin.mts
@@ -90,6 +90,7 @@ export const configPlugin = ({
                 ) as string,
               },
               formats: ["es"],
+              fileName: () => path.basename(SSR_BRIDGE_PATH),
             },
             outDir: path.dirname(SSR_BRIDGE_PATH),
           },


### PR DESCRIPTION
During builds, vite was building the SSR bridge module to a `.mjs` extension if the package.json of the project did not include `"type": "module"`, yet the RSC environment was looking for a .js extension for this module.

This PR fixes this by being explicit about the .js file extension.