### PR TITLE
fix: Exclude cloudflare builtins from SSR environment

### DIFF
--- a/sdk/src/vite/configPlugin.mts
+++ b/sdk/src/vite/configPlugin.mts
@@ -5,6 +5,21 @@ import enhancedResolve from "enhanced-resolve";
 import { SSR_BRIDGE_PATH } from "../lib/constants.mjs";
 import { builtinModules } from "node:module";
 
+// port(justinvdm, 09 Jun 2025):
+// https://github.com/cloudflare/workers-sdk/blob/d533f5ee7da69c205d8d5e2a5f264d2370fc612b/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts#L123-L128
+export const cloudflareBuiltInModules = [
+  "cloudflare:email",
+  "cloudflare:sockets",
+  "cloudflare:workers",
+  "cloudflare:workflows",
+];
+
+export const externalModules = [
+  ...cloudflareBuiltInModules,
+  ...builtinModules,
+  ...builtinModules.map((m) => `node:${m}`),
+];
+
 export const configPlugin = ({
   mode,
   silent,
@@ -72,7 +87,7 @@ export const configPlugin = ({
           optimizeDeps: {
             noDiscovery: false,
             entries: [workerEntryPathname],
-            exclude: ["cloudflare:workers", ...builtinModules],
+            exclude: externalModules,
             include: ["rwsdk/__ssr_bridge"],
             esbuildOptions: {
               jsx: "automatic",
@@ -155,7 +170,7 @@ export const configPlugin = ({
           worker: {
             build: {
               rollupOptions: {
-                external: ["cloudflare:workers", "node:stream"],
+                external: externalModules,
               },
             },
           },


### PR DESCRIPTION
Excludes modules such as `cloudflare:email` in SSR environment's `optimizeDeps` config.

`@cloudflare/vite-plugin` already does this for the worker environment, but we also need to do this for the new SSR environment we've defined since the 0.1.0-alpha builds.