### PR TITLE
fix: Skip dirs with .js extensions

### DIFF
--- a/sdk/src/lib/getSrcPaths.ts
+++ b/sdk/src/lib/getSrcPaths.ts
@@ -48,6 +48,7 @@ export async function getSrcPaths(
     const files = await glob(globPattern, {
       ignore: ["**/node_modules/**", "**/dist/**", "**/*.d.ts"],
       absolute: true,
+      nodir: true,
     });
     return files;
   } catch (error) {

--- a/sdk/src/vite/createDirectiveLookupPlugin.mts
+++ b/sdk/src/vite/createDirectiveLookupPlugin.mts
@@ -7,6 +7,7 @@ import debug from "debug";
 import { normalizeModulePath } from "./normalizeModulePath.mjs";
 import { ensureAliasArray } from "./ensureAliasArray.mjs";
 import { pathExists } from "fs-extra";
+import { stat } from "fs/promises";
 import { getSrcPaths } from "../lib/getSrcPaths.js";
 
 interface DirectiveLookupConfig {
@@ -44,6 +45,7 @@ export const findFilesContainingDirective = async ({
     {
       cwd: projectRootDir,
       absolute: true,
+      nodir: true,
     },
   );
 
@@ -53,6 +55,13 @@ export const findFilesContainingDirective = async ({
 
   for (const file of allFiles) {
     try {
+      const stats = await stat(file);
+
+      if (!stats.isFile()) {
+        verboseLog("Skipping %s (not a file)", file);
+        continue;
+      }
+
       verboseLog("Scanning file: %s", file);
       const content = await readFile(file, "utf-8");
       const lines = content.split("\n");


### PR DESCRIPTION
We were accidentally picking up dirs with .js extensions when scanning for directives.

Support thread: https://discord.com/channels/679514959968993311/1382098756081680464/1382098756081680464