### PR TITLE
fix: Support packages with only node import condition and no workerd condition

### DIFF
--- a/sdk/src/vite/configPlugin.mts
+++ b/sdk/src/vite/configPlugin.mts
@@ -78,7 +78,20 @@ export const configPlugin = ({
         },
         ssr: {
           resolve: {
-            conditions: ["workerd"],
+            conditions: [
+              "workerd",
+              // context(justinvdm, 11 Jun 2025): Some packages meant for cloudflare workers, yet
+              // their deps have only node import conditions, e.g. `agents` package (meant for CF),
+              // has `pkce-challenge` package as a dep, which has only node import conditions.
+              // https://github.com/crouchcd/pkce-challenge/blob/master/package.json#L17
+              //
+              // Once the transformed code for this environment is in turn processed in the `worker` environment,
+              // @cloudflare/vite-plugin should take care of any relevant polyfills for deps with
+              // node builtins imports that can be polyfilled though, so it is worth us including this condition here.
+              // However, it does mean we will try to run packages meant for node that cannot be run on cloudflare workers.
+              // That's the trade-off, but arguably worth it. (context(justinvdm, 11 Jun 2025))
+              "node",
+            ],
             noExternal: true,
           },
           define: {
@@ -112,7 +125,20 @@ export const configPlugin = ({
         },
         worker: {
           resolve: {
-            conditions: ["workerd", "react-server"],
+            conditions: [
+              "workerd",
+              "react-server",
+              // context(justinvdm, 11 Jun 2025): Some packages meant for cloudflare workers, yet
+              // their deps have only node import conditions, e.g. `agents` package (meant for CF),
+              // has `pkce-challenge` package as a dep, which has only node import conditions.
+              // https://github.com/crouchcd/pkce-challenge/blob/master/package.json#L17
+              //
+              // @cloudflare/vite-plugin should take care of any relevant polyfills for deps with
+              // node builtins imports that can be polyfilled though, so it is worth us including this condition here.
+              // However, it does mean we will try to run packages meant for node that cannot be run on cloudflare workers.
+              // That's the trade-off, but arguably worth it.
+              "node",
+            ],
             noExternal: true,
           },
           define: {


### PR DESCRIPTION
## Problem

Some Cloudflare Worker-targeted packages depend on modules that only specify Node import conditions, causing resolution failures or runtime issues in the worker environment. For example, the `agents` package depends on `pkce-challenge`, which only provides `node` conditions.

## Solution

Add `"node"` as a fallback import condition in both the `ssr` and `worker` resolve configurations in Vite. This allows dependencies with only Node conditions to resolve correctly in the worker environment. The Cloudflare Vite plugin will then handle polyfills for Node builtins where possible. This approach trades off some risk of including Node-only packages that cannot run on workers but improves compatibility overall.