### PR TITLE
Feat: Typesafe ctx

### DIFF
--- a/sdk/src/runtime/requestInfo/types.ts
+++ b/sdk/src/runtime/requestInfo/types.ts
@@ -1,6 +1,6 @@
 import { RwContext } from "../lib/router";
 
-export interface DefaultAppContext {}
+export interface DefaultAppContext { }
 
 export interface RequestInfo<Params = any, AppContext = DefaultAppContext> {
   request: Request;

--- a/sdk/src/runtime/worker.tsx
+++ b/sdk/src/runtime/worker.tsx
@@ -173,7 +173,7 @@ export const defineApp = <T extends RequestInfo = RequestInfo<any, DefaultAppCon
                   await router.handle({
                     request,
                     renderPage,
-                    getRequestInfo,
+                    getRequestInfo: getRequestInfo as () => T,
                     runWithRequestInfoOverrides,
                     onError: reject,
                   }),

--- a/starters/minimal/src/worker.tsx
+++ b/starters/minimal/src/worker.tsx
@@ -1,17 +1,21 @@
-import { defineApp } from "rwsdk/worker";
-import { index, render } from "rwsdk/router";
+import { defineApp, type RequestInfo } from "rwsdk/worker";
+import { render, route } from "rwsdk/router";
 
 import { Document } from "@/app/Document";
 import { Home } from "@/app/pages/Home";
 import { setCommonHeaders } from "@/app/headers";
 
-export type AppContext = {};
+export type AppContext = {
+  dog: string,
+};
 
 export default defineApp([
   setCommonHeaders(),
   ({ ctx }) => {
     // setup ctx here
-    ctx;
+
   },
-  render(Document, [index([Home])]),
+  render(Document, [
+    route('/', Home)
+  ])
 ]);

--- a/starters/minimal/src/worker.tsx
+++ b/starters/minimal/src/worker.tsx
@@ -1,19 +1,17 @@
-import { defineApp, type RequestInfo } from "rwsdk/worker";
+import { defineApp } from "rwsdk/worker";
 import { render, route } from "rwsdk/router";
 
 import { Document } from "@/app/Document";
 import { Home } from "@/app/pages/Home";
 import { setCommonHeaders } from "@/app/headers";
 
-export type AppContext = {
-  dog: string,
-};
+export type AppContext = {};
 
 export default defineApp([
   setCommonHeaders(),
   ({ ctx }) => {
     // setup ctx here
-
+    ctx
   },
   render(Document, [
     route('/', Home)


### PR DESCRIPTION
Added on all routing options the ability to have typesafe ctx via workers.tsx and router.ts and requestInfo

ie ```typescript
type MyCustomContext = {
  foo: string;
  bar: Array<number>;
  baz: Record<string, number>;
}
const r = defineApp<RequestInfo<any, MyCustomContext>>([
  route("/", ({ ctx }) => {
    console.log(ctx.baz);
    return new Response(ctx.foo);
  }),
]);
```

![nvim ~_d_o_rwsdk 2025-06-11 10_25_20 AM](https://github.com/user-attachments/assets/0f09fbb2-8aca-4d8e-97ae-0407077977a7)
