### PR TITLE
fix: Include client and server lookups in optimize dep entries

### DIFF
--- a/sdk/src/vite/createDirectiveLookupPlugin.mts
+++ b/sdk/src/vite/createDirectiveLookupPlugin.mts
@@ -253,6 +253,15 @@ export const createDirectiveLookupPlugin = async ({
               file,
               actualFilePath,
             );
+          } else {
+            verboseLog("Adding to optimizeDeps.entries: %s", actualFilePath);
+
+            const entries = Array.isArray(viteConfig.optimizeDeps.entries)
+              ? viteConfig.optimizeDeps.entries
+              : ([] as string[]).concat(viteConfig.optimizeDeps.entries ?? []);
+
+            viteConfig.optimizeDeps.entries = entries;
+            entries.push(actualFilePath);
           }
         }
 


### PR DESCRIPTION
## Problem
Since #511, we're now (correctly) also looking at our own sourcecode for optimizeDeps (with the relevant "use client" and "use server" directive transformation logic applied) in order to identify the correct deps.

However, this surfaced another bug: we were not including the "use server" and "use client" modules as entries for optimizeDeps, so we would never discovery any deps imported from them, unless there were other imports to these modules in the app code, but that is very often not the case - they are essentially entry points in their own right. For example, often the only imports to "use server" modules are from "use client" modules, so there's no guaranteed import chain from the worker.tsx entry point to these functions.

## Solution
Include server and client modules as optimize dep entries in their respective environments.