### PR TITLE
fix: 'use server' should support re-exports

### DIFF
--- a/sdk/src/vite/__snapshots__/transformServerFunctions.test.mts.snap
+++ b/sdk/src/vite/__snapshots__/transformServerFunctions.test.mts.snap
@@ -165,6 +165,7 @@ function __defaultServerFunction__() {
 
 export default __defaultServerFunction__;
 registerServerReference(__defaultServerFunction__, "/test.tsx", "default")
+registerServerReference(sum, "/test.tsx", "sum")
 "
 `;
 
@@ -233,5 +234,34 @@ export function sum() {
   return 1 + 1
 }
 registerServerReference(sum, "/test.tsx", "sum")
+"
+`;
+
+exports[`useServerPlugin > TRANSFORMS > RE_EXPORT_CODE > CLIENT 1`] = `
+"import { createServerReference } from "rwsdk/client";
+
+export let sum = createServerReference("/test.tsx", "sum");
+export let multiply = createServerReference("/test.tsx", "multiply");
+"
+`;
+
+exports[`useServerPlugin > TRANSFORMS > RE_EXPORT_CODE > SSR 1`] = `
+"import { createServerReference } from "rwsdk/__ssr";
+
+export let sum = createServerReference("/test.tsx", "sum");
+export let multiply = createServerReference("/test.tsx", "multiply");
+"
+`;
+
+exports[`useServerPlugin > TRANSFORMS > RE_EXPORT_CODE > WORKER 1`] = `
+"import { sum } from "./math";
+import { default as multiply } from "./multiply";
+import { registerServerReference } from "rwsdk/worker";
+
+export { sum } from './math';
+export { default as multiply } from './multiply';
+export * from './utils';
+registerServerReference(sum, "/test.tsx", "sum")
+registerServerReference(multiply, "/test.tsx", "multiply")
 "
 `;

--- a/sdk/src/vite/transformServerFunctions.test.mts
+++ b/sdk/src/vite/transformServerFunctions.test.mts
@@ -83,6 +83,14 @@ export async function sum() {
 export const a = "string";
 `;
 
+  let RE_EXPORT_CODE = `
+"use server";
+
+export { sum } from './math';
+export { default as multiply } from './multiply';
+export * from './utils';
+`;
+
   const TEST_CASES = {
     COMMENT_CODE,
     MULTI_LINE_COMMENT_CODE,
@@ -93,6 +101,7 @@ export const a = "string";
     ASYNC_FUNCTION_EXPORT_CODE,
     IGNORE_NON_FUNCTION_EXPORT_CODE,
     DEFAULT_AND_NAMED_EXPORTS_CODE,
+    RE_EXPORT_CODE,
   };
 
   describe("TRANSFORMS", () => {


### PR DESCRIPTION
Cases like this:

```tsx
"use server";

export { sum } from './math';
export { default as multiply } from './multiply';
export * from './utils';
```

... currently won't get server references created for them in the case of client and SSR.