### PR TITLE
feat: Avoid ts-morph parse for non-"use server" cases

### DIFF
--- a/sdk/src/vite/createDirectiveLookupPlugin.mts
+++ b/sdk/src/vite/createDirectiveLookupPlugin.mts
@@ -9,6 +9,7 @@ import { ensureAliasArray } from "./ensureAliasArray.mjs";
 import { pathExists } from "fs-extra";
 import { stat } from "fs/promises";
 import { getSrcPaths } from "../lib/getSrcPaths.js";
+import { hasDirective } from "./hasDirective.mjs";
 
 interface DirectiveLookupConfig {
   directive: "use client" | "use server";
@@ -56,31 +57,16 @@ export const findFilesContainingDirective = async ({
 
       verboseLog("Scanning file: %s", file);
       const content = await readFile(file, "utf-8");
-      const lines = content.split("\n");
 
-      for (const line of lines) {
-        const trimmedLine = line.trim();
-        if (trimmedLine.length > 0) {
-          if (
-            trimmedLine.startsWith(`"${directive}"`) ||
-            trimmedLine.startsWith(`'${directive}'`)
-          ) {
-            const normalizedPath = normalizeModulePath(projectRootDir, file);
-            log(
-              "Found '%s' directive in file: %s -> %s",
-              directive,
-              file,
-              normalizedPath,
-            );
-            files.add(normalizedPath);
-          } else if (
-            trimmedLine.startsWith("'use strict'") ||
-            trimmedLine.startsWith('"use strict"')
-          ) {
-            continue;
-          }
-          break;
-        }
+      if (hasDirective(content, directive)) {
+        const normalizedPath = normalizeModulePath(projectRootDir, file);
+        log(
+          "Found '%s' directive in file: %s -> %s",
+          directive,
+          file,
+          normalizedPath,
+        );
+        files.add(normalizedPath);
       }
     } catch (error) {
       console.error(`Error reading file ${file}:`, error);

--- a/sdk/src/vite/hasDirective.mts
+++ b/sdk/src/vite/hasDirective.mts
@@ -1,0 +1,68 @@
+/**
+ * Efficiently checks if a React directive (e.g., "use server", "use client")
+ * is present in the code. Optimized for performance with a two-step approach:
+ * 1. Quick string search to see if directive exists anywhere
+ * 2. Line-by-line check only if the directive might be present
+ */
+export function hasDirective(code: string, directive: string): boolean {
+  // Quick performance check: if directive doesn't exist anywhere, skip line checking
+  const singleQuoteDirective = `'${directive}'`;
+  const doubleQuoteDirective = `"${directive}"`;
+
+  if (
+    !code.includes(singleQuoteDirective) &&
+    !code.includes(doubleQuoteDirective)
+  ) {
+    return false;
+  }
+
+  // Split into lines and check each one
+  const lines = code.split("\n");
+  let inMultiLineComment = false;
+
+  for (const line of lines) {
+    const trimmedLine = line.trim();
+
+    // Skip empty lines
+    if (trimmedLine.length === 0) {
+      continue;
+    }
+
+    // Handle multi-line comments
+    if (trimmedLine.startsWith("/*")) {
+      inMultiLineComment = true;
+      // Check if the comment ends on the same line
+      if (trimmedLine.includes("*/")) {
+        inMultiLineComment = false;
+      }
+      continue;
+    }
+
+    if (inMultiLineComment) {
+      // Check if this line ends the multi-line comment
+      if (trimmedLine.includes("*/")) {
+        inMultiLineComment = false;
+      }
+      continue;
+    }
+
+    // Skip single-line comments
+    if (trimmedLine.startsWith("//")) {
+      continue;
+    }
+
+    // Check if this line starts with the directive
+    if (
+      trimmedLine.startsWith(doubleQuoteDirective) ||
+      trimmedLine.startsWith(singleQuoteDirective)
+    ) {
+      return true;
+    }
+
+    // If we hit a non-empty, non-comment line that's not a directive, we can stop
+    // (directives must be at the top of the file/scope, after comments)
+    break;
+  }
+
+  return false;
+}

--- a/sdk/src/vite/transformClientComponents.mts
+++ b/sdk/src/vite/transformClientComponents.mts
@@ -34,6 +34,22 @@ export async function transformClientComponents(
     ctx,
   );
 
+  const cleanCode = code.trimStart();
+  const hasUseClient =
+    cleanCode.startsWith('"use client"') ||
+    cleanCode.startsWith("'use client'");
+  if (!hasUseClient) {
+    log("Skipping: no 'use client' directive in id=%s", normalizedId);
+    verboseLog(
+      ":VERBOSE: Returning code unchanged for id=%s:\n%s",
+      normalizedId,
+      code,
+    );
+    return;
+  }
+
+  log("Processing 'use client' module: id=%s", normalizedId);
+
   function extractSourceMapFromEmit(sourceFile: any): any {
     const emitOutput = sourceFile.getEmitOutput();
     let sourceMap: any;
@@ -60,22 +76,6 @@ export async function transformClientComponents(
     }
     return sourceMap;
   }
-
-  // 2. Only transform files that start with 'use client'
-  const cleanCode = code.trimStart();
-  const hasUseClient =
-    cleanCode.startsWith('"use client"') ||
-    cleanCode.startsWith("'use client'");
-  if (!hasUseClient) {
-    log("Skipping: no 'use client' directive in id=%s", normalizedId);
-    verboseLog(
-      ":VERBOSE: Returning code unchanged for id=%s:\n%s",
-      normalizedId,
-      code,
-    );
-    return;
-  }
-  log("Processing 'use client' module: id=%s", normalizedId);
 
   ctx.clientFiles?.add(normalizedId);
 

--- a/sdk/src/vite/transformClientComponents.mts
+++ b/sdk/src/vite/transformClientComponents.mts
@@ -1,5 +1,6 @@
 import { Project, SyntaxKind, Node } from "ts-morph";
 import debug from "debug";
+import { hasDirective } from "./hasDirective.mjs";
 
 interface TransformContext {
   environmentName: string;
@@ -34,11 +35,7 @@ export async function transformClientComponents(
     ctx,
   );
 
-  const cleanCode = code.trimStart();
-  const hasUseClient =
-    cleanCode.startsWith('"use client"') ||
-    cleanCode.startsWith("'use client'");
-  if (!hasUseClient) {
+  if (!hasDirective(code, "use client")) {
     log("Skipping: no 'use client' directive in id=%s", normalizedId);
     verboseLog(
       ":VERBOSE: Returning code unchanged for id=%s:\n%s",

--- a/sdk/src/vite/transformServerFunctions.mts
+++ b/sdk/src/vite/transformServerFunctions.mts
@@ -1,5 +1,6 @@
 import { Project, SyntaxKind, Node, SourceFile } from "ts-morph";
 import debug from "debug";
+import { hasDirective } from "./hasDirective.mjs";
 
 const log = debug("rwsdk:vite:transform-server-functions");
 const verboseLog = debug("verbose:rwsdk:vite:transform-server-functions");
@@ -145,11 +146,7 @@ export const transformServerFunctions = (
     environment,
   );
 
-  const cleanCode = code.trimStart();
-  const hasUseServer =
-    cleanCode.startsWith('"use server"') ||
-    cleanCode.startsWith("'use server'");
-  if (!hasUseServer) {
+  if (!hasDirective(code, "use server")) {
     log("Skipping: no 'use server' directive in id=%s", normalizedId);
     verboseLog(
       ":VERBOSE: Returning code unchanged for id=%s:\n%s",

--- a/sdk/src/vite/transformServerFunctions.mts
+++ b/sdk/src/vite/transformServerFunctions.mts
@@ -145,6 +145,20 @@ export const transformServerFunctions = (
     environment,
   );
 
+  const cleanCode = code.trimStart();
+  const hasUseServer =
+    cleanCode.startsWith('"use server"') ||
+    cleanCode.startsWith("'use server'");
+  if (!hasUseServer) {
+    log("Skipping: no 'use server' directive in id=%s", normalizedId);
+    verboseLog(
+      ":VERBOSE: Returning code unchanged for id=%s:\n%s",
+      normalizedId,
+      code,
+    );
+    return;
+  }
+
   const project = new Project({
     useInMemoryFileSystem: true,
     compilerOptions: {


### PR DESCRIPTION
In order to support RSC for the full module graph (including `node_modules`), we need to run the entire module graph through the `"use client"` and `"use server"` transformations. That said, we can still skip transformations as soon as we can tell that the given module has not "use server" or "use client" directive.

At the moment we exit early this way for "use client" - we first do a simple string check that the code starts with "use client" before parsing the code with ts-morph.

We currently do not do the same for "use server", which means every module in the graph (whether it is app code or code in node_modules) is first parsed with ts-morph.

This PR does the same as "use client" in the "use server" transform: first do a simple string check to test whether the code starts with "use server", if it does then parse with ts-morph, otherwise skip.