### PR TITLE
fix: Include 'module' import condition in resolve.conditions

### DIFF
--- a/sdk/src/vite/configPlugin.mts
+++ b/sdk/src/vite/configPlugin.mts
@@ -76,11 +76,15 @@ export const configPlugin = ({
               },
             },
           },
+          resolve: {
+            conditions: ["browser", "module"],
+          },
         },
         ssr: {
           resolve: {
             conditions: [
               "workerd",
+              "module",
               // context(justinvdm, 11 Jun 2025): Some packages meant for cloudflare workers, yet
               // their deps have only node import conditions, e.g. `agents` package (meant for CF),
               // has `pkce-challenge` package as a dep, which has only node import conditions.
@@ -106,7 +110,6 @@ export const configPlugin = ({
             esbuildOptions: {
               jsx: "automatic",
               jsxImportSource: "react",
-              conditions: ["workerd"],
               plugins: [],
             },
           },
@@ -129,6 +132,7 @@ export const configPlugin = ({
             conditions: [
               "workerd",
               "react-server",
+              "module",
               // context(justinvdm, 11 Jun 2025): Some packages meant for cloudflare workers, yet
               // their deps have only node import conditions, e.g. `agents` package (meant for CF),
               // has `pkce-challenge` package as a dep, which has only node import conditions.


### PR DESCRIPTION
## Change
Adds `module` import specifier to the `resolve.conditions` for all three environments (ssr, worker, client).

## Context
ShadCN users were running into this issue:

```TypeError: Cannot destructure property '__extends' of 'import_tslib.default' as it is undefined.```

This appears to happen because:

* tslib has various import specifiers, including
  * one that maps `node` import specifier to a wrapper that module that imports its cjs build, and reexports it as an esm via a default export ([code](https://github.com/microsoft/tslib/blob/main/modules/index.js))
  * one that maps `module` import specifier to an esm module ([code](https://github.com/microsoft/tslib/blob/main/package.json#L33))
  * Since #510, we added a `node` import condition to the worker and ssr import conditions, meaning it would resolve to tslibs esm wrapper around its cjs build
  * This would be fine, except esbuild adds a wrapper to convert the cjs build to an esm build
  * Since tslib's own esm wrapper imports the default import for the cjs build, it doesn't get the named exports created by esbuild's wrapper

## Links
* Discussion: https://discord.com/channels/679514959968993311/1383029083272646667/1383033401128255528
* https://github.com/microsoft/tslib/issues/161