### PR TITLE
feat: Support renderToStream()

### DIFF
--- a/docs/src/content/docs/core/react-server-components.mdx
+++ b/docs/src/content/docs/core/react-server-components.mdx
@@ -100,3 +100,46 @@ export default function AddTodo() {
 ### Context
 
 Context is a way to share data globally between server components on a per-request basis. The context is populated by middleware, and is available to all React Server Components Pages and Server Functions via the `ctx` prop or `requestInfo.ctx`.
+
+
+## Advanced usage
+
+### Manual rendering
+
+RedwoodSDK also provides a way to render your React Server Components imperatively with `renderToStream()` and `renderToString()`.
+
+To render your component tree to a [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream)
+
+
+### `renderToStream(element[, options]): Promise<ReadableStream>`
+
+Takes in a React Server Component (can be a client component or server component), and returns a stream that decodes to html.
+
+```tsx
+const stream = await renderToStream(<NotFound />, { Document })
+
+const response = new Response(stream, {
+  status: 404,
+});
+```
+
+#### Options
+* `Document`: The [document](/core/routing/#documents) component to wrap around the React Server Component `element`. If not given, will return the rendered React Server Component without any wrapping.
+* `injectRSCPayload = false`: Whether to inject the corresponding RSC payload for the React Server Component to use for client-side hydration
+* `onError`: A callback function called with the relevant error as the only paramter if any errors happen during rendering
+
+### `renderToString(element[, options]): Promise<string>`
+
+Takes in a React Server Component (can be a client component or server component), and returns an html string.
+
+```tsx
+const html = await renderToString(<NotFound />, { Document })
+
+const response = new Response(html, {
+  status: 404,
+});
+```
+
+#### Options
+* `Document`: The [document](/core/routing/#documents) component to wrap around the React Server Component `element`. If not given, will return the rendered React Server Component without any wrapping.
+* `injectRSCPayload = false`: Whether to inject the corresponding RSC payload for the React Server Component to use for client-side hydration

--- a/sdk/src/runtime/entries/worker.ts
+++ b/sdk/src/runtime/entries/worker.ts
@@ -5,3 +5,5 @@ export * from "../script";
 export * from "../lib/utils";
 export * from "../requestInfo/types";
 export * from "../requestInfo/worker";
+export * from "../render/renderToString";
+export * from "../render/renderToStream";

--- a/sdk/src/runtime/register/worker.ts
+++ b/sdk/src/runtime/register/worker.ts
@@ -23,9 +23,15 @@ export function registerServerReference(
 export function registerClientReference<Target extends Record<string, any>>(
   id: string,
   exportName: string,
+  value: any,
 ) {
+  const wrappedValue =
+    (value && typeof value === "function") || typeof value === "object"
+      ? value
+      : () => null;
+
   const reference = baseRegisterClientReference({}, id, exportName);
-  return Object.defineProperties(() => null, {
+  return Object.defineProperties(wrappedValue, {
     ...Object.getOwnPropertyDescriptors(reference),
     $$async: { value: true },
     $$isClientReference: { value: true },

--- a/sdk/src/runtime/render/renderToStream.tsx
+++ b/sdk/src/runtime/render/renderToStream.tsx
@@ -1,0 +1,50 @@
+import { ReactElement, FC } from "react";
+import { DocumentProps } from "../lib/router";
+import { renderToRscStream } from "./renderToRscStream";
+import { transformRscToHtmlStream } from "./transformRscToHtmlStream";
+import { requestInfo } from "../requestInfo/worker";
+import { injectRSCPayload } from "rsc-html-stream/server";
+
+export interface RenderToStreamOptions {
+  Document?: FC<DocumentProps>;
+  injectRSCPayload?: boolean;
+  onError?: (error: unknown) => void;
+}
+
+export const IdentityDocument: FC<DocumentProps> = ({ children }) => (
+  <>{children}</>
+);
+
+export const renderToStream = async (
+  element: ReactElement,
+  {
+    Document = IdentityDocument,
+    injectRSCPayload: shouldInjectRSCPayload = false,
+    onError,
+  }: RenderToStreamOptions = {},
+): Promise<ReadableStream> => {
+  let rscStream = renderToRscStream({
+    node: element,
+    actionResult: null,
+    onError,
+  });
+
+  if (shouldInjectRSCPayload) {
+    const [rscPayloadStream1, rscPayloadStream2] = rscStream.tee();
+    rscStream = rscPayloadStream1;
+
+    rscStream = rscStream.pipeThrough(
+      injectRSCPayload(rscPayloadStream2, {
+        nonce: requestInfo.rw.nonce,
+      }),
+    );
+  }
+
+  const htmlStream = await transformRscToHtmlStream({
+    stream: rscStream,
+    Document,
+    requestInfo,
+  });
+
+  return htmlStream;
+};

--- a/sdk/src/runtime/render/renderToString.tsx
+++ b/sdk/src/runtime/render/renderToString.tsx
@@ -1,0 +1,39 @@
+import { FC, ReactElement } from "react";
+import { renderToStream } from "./renderToStream";
+import { DocumentProps } from "../lib/router";
+
+export interface RenderToStringOptions {
+  Document?: FC<DocumentProps>;
+  injectRSCPayload?: boolean;
+}
+
+export const renderToString = async (
+  element: ReactElement,
+  options?: RenderToStringOptions,
+): Promise<string> => {
+  const stream = await new Promise<ReadableStream>((resolve, reject) =>
+    renderToStream(element, {
+      ...options,
+      onError: reject,
+    })
+      .then(resolve)
+      .catch(reject),
+  );
+
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let result = "";
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      result += decoder.decode(value, { stream: true });
+    }
+    // Flush any remaining bytes
+    result += decoder.decode();
+    return result;
+  } finally {
+    reader.releaseLock();
+  }
+};

--- a/sdk/src/runtime/worker.tsx
+++ b/sdk/src/runtime/worker.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { transformRscToHtmlStream } from "./render/transformRscToHtmlStream";
 import { renderToRscStream } from "./render/renderToRscStream";
 
-import { ssrLoadModule, ssrWebpackRequire } from "rwsdk/__ssr_bridge";
+import { ssrWebpackRequire } from "rwsdk/__ssr_bridge";
 import { rscActionHandler } from "./register/worker";
 import { injectRSCPayload } from "rsc-html-stream/server";
 import { ErrorResponse } from "./error";


### PR DESCRIPTION
### `renderToStream(element[, options]): Promise<ReadableStream>`

Takes in a React Server Component (can be a client component or server component), and returns a stream that decodes to html.

```tsx
const stream = await renderToStream(<NotFound />, { Document })

const response = new Response(stream, {
  status: 404,
});
```

#### Options
* `Document`: The [document](/core/routing/#documents) component to wrap around the React Server Component `element`. If not given, will return the rendered React Server Component without any wrapping.
* `injectRSCPayload = false`: Whether to inject the corresponding RSC payload for the React Server Component to use for client-side hydration
* `onError`: A callback function called with the relevant error as the only paramter if any errors happen during rendering

### `renderToString(element[, options]): Promise<string>`

Takes in a React Server Component (can be a client component or server component), and returns an html string.

```tsx
const html = await renderToString(<NotFound />, { Document })

const response = new Response(html, {
  status: 404,
});
```

#### Options
* `Document`: The [document](/core/routing/#documents) component to wrap around the React Server Component `element`. If not given, will return the rendered React Server Component without any wrapping.
* `injectRSCPayload = false`: Whether to inject the corresponding RSC payload for the React Server Component to use for client-side hydration

Fixes #422 
