### PR TITLE
Expose hydrateRoot options.

### DIFF
--- a/sdk/src/runtime/client.tsx
+++ b/sdk/src/runtime/client.tsx
@@ -1,5 +1,6 @@
 import { clientWebpackRequire } from "./imports/client";
 import { type CallServerCallback } from "react-server-dom-webpack/client.browser";
+import { type HydrationOptions } from "react-dom/client";
 
 // NOTE: `react-server-dom-webpack` uses this global to load modules,
 // so we need to define it here before importing "react-server-dom-webpack."
@@ -54,8 +55,10 @@ export const fetchTransport: Transport = (transportContext) => {
 
 export const initClient = async ({
   transport = fetchTransport,
+  hydrateRootOptions,
 }: {
   transport?: Transport;
+  hydrateRootOptions?: HydrationOptions;
 } = {}) => {
   const transportContext: TransportContext = {
     setRscPayload: () => {},
@@ -79,7 +82,6 @@ export const initClient = async ({
   };
 
   const rootEl = document.getElementById("root");
-
   if (!rootEl) {
     throw new Error('no element with id "root"');
   }
@@ -104,7 +106,7 @@ export const initClient = async ({
     return <>{React.use<{ node: React.ReactNode }>(streamData).node}</>;
   }
 
-  hydrateRoot(rootEl, <Content />);
+  hydrateRoot(rootEl, <Content />, hydrateRootOptions);
 
   if (import.meta.hot) {
     import.meta.hot.on("rsc:update", (e) => {


### PR DESCRIPTION
This exposes `hydrationOptions` from `hydrateRoot`. This is required to turn off errors that occur when HTML rendering is disable. 

```tsx
import { initClient } from 'rwsdk/client'

initClient({ hydrationOtions: {...} })
```

cc: @jldec 