### PR TITLE
docs: clarify ssr render flag

### DIFF
--- a/docs/src/content/docs/reference/sdk-router.mdx
+++ b/docs/src/content/docs/reference/sdk-router.mdx
@@ -55,7 +55,7 @@ The `render` function accepts an optional third parameter with the following opt
 
 - **`rscPayload`** (boolean, default: `true`) - Toggle the RSC payload that's appended to the Document. Disabling this will mean that interactivity can no longer work. Your document should not include any client side initialization.
 
-- **`ssr`** (boolean, default: `true`) - Enable or disable server-side rendering for these routes. When disabled, only client-side rendering is used, which requires `rscPayload` to be enabled. With SSR disabled, the server returns a minimal HTML shell with the RSC payload, allowing the client to hydrate the page.
+- **`ssr`** (boolean, default: `true`) - Enable or disable server-side rendering beyond the 'use client' boundary on these routes. When disabled, 'use client' components will render only on the client. This is useful for client components which only work in a browser environment. NOTE: disabling `ssr` requires `rscPayload` to be enabled.
 
 ```tsx
 import { render } from "rwsdk/router";


### PR DESCRIPTION
I liked @justinvdm's [loom](https://www.loom.com/share/0ba7ca7d375c403fb10959e28f7ede41?sid=131f0723-b1ec-4670-9aae-72a78d830e5a) so much that I thought including that detail in the docs might help other users understand the distinction between disabling server-side rendering of client components vs. server-side rendering of server-only components.

