### PR TITLE
fix: default export fixes for server

### DIFF
--- a/sdk/src/vite/__snapshots__/transformServerFunctions.test.mts.snap
+++ b/sdk/src/vite/__snapshots__/transformServerFunctions.test.mts.snap
@@ -1,5 +1,34 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`useServerPlugin > TRANSFORMS > ALREADY_DEFINED_DEFAULT_EXPORT_CODE > CLIENT 1`] = `
+"import { createServerReference } from "rwsdk/client";
+
+
+export default createServerReference("/test.tsx", "default");
+"
+`;
+
+exports[`useServerPlugin > TRANSFORMS > ALREADY_DEFINED_DEFAULT_EXPORT_CODE > SSR 1`] = `
+"import { createServerReference } from "rwsdk/__ssr";
+
+
+export default createServerReference("/test.tsx", "default");
+"
+`;
+
+exports[`useServerPlugin > TRANSFORMS > ALREADY_DEFINED_DEFAULT_EXPORT_CODE > WORKER 1`] = `
+"import { registerServerReference } from "rwsdk/worker";
+
+const sum = () => {
+  return 1 + 1;
+}
+
+export default sum;
+const __defaultServerFunction__ = sum;
+registerServerReference(__defaultServerFunction__, "/test.tsx", "default")
+"
+`;
+
 exports[`useServerPlugin > TRANSFORMS > ARROW_FUNCTION_EXPORT_CODE > CLIENT 1`] = `
 "import { createServerReference } from "rwsdk/client";
 

--- a/sdk/src/vite/__snapshots__/transformServerFunctions.test.mts.snap
+++ b/sdk/src/vite/__snapshots__/transformServerFunctions.test.mts.snap
@@ -106,7 +106,6 @@ registerServerReference(sum, "/test.tsx", "sum")
 exports[`useServerPlugin > TRANSFORMS > DEFAULT_AND_NAMED_EXPORTS_CODE > CLIENT 1`] = `
 "import { createServerReference } from "rwsdk/client";
 
-export let sum = createServerReference("/test.tsx", "sum");
 
 export default createServerReference("/test.tsx", "default");
 "
@@ -115,7 +114,6 @@ export default createServerReference("/test.tsx", "default");
 exports[`useServerPlugin > TRANSFORMS > DEFAULT_AND_NAMED_EXPORTS_CODE > SSR 1`] = `
 "import { createServerReference } from "rwsdk/__ssr";
 
-export let sum = createServerReference("/test.tsx", "sum");
 
 export default createServerReference("/test.tsx", "default");
 "
@@ -134,14 +132,12 @@ function __defaultServerFunction__() {
 
 export default __defaultServerFunction__;
 registerServerReference(__defaultServerFunction__, "/test.tsx", "default")
-registerServerReference(sum, "/test.tsx", "sum")
 "
 `;
 
 exports[`useServerPlugin > TRANSFORMS > DEFAULT_EXPORT_CODE > CLIENT 1`] = `
 "import { createServerReference } from "rwsdk/client";
 
-export let sum = createServerReference("/test.tsx", "sum");
 
 export default createServerReference("/test.tsx", "default");
 "
@@ -150,7 +146,6 @@ export default createServerReference("/test.tsx", "default");
 exports[`useServerPlugin > TRANSFORMS > DEFAULT_EXPORT_CODE > SSR 1`] = `
 "import { createServerReference } from "rwsdk/__ssr";
 
-export let sum = createServerReference("/test.tsx", "sum");
 
 export default createServerReference("/test.tsx", "default");
 "
@@ -165,7 +160,34 @@ function __defaultServerFunction__() {
 
 export default __defaultServerFunction__;
 registerServerReference(__defaultServerFunction__, "/test.tsx", "default")
-registerServerReference(sum, "/test.tsx", "sum")
+"
+`;
+
+exports[`useServerPlugin > TRANSFORMS > EXPORT_DEFAULT_FUNCTION_CODE > CLIENT 1`] = `
+"import { createServerReference } from "rwsdk/client";
+
+
+export default createServerReference("/test.tsx", "default");
+"
+`;
+
+exports[`useServerPlugin > TRANSFORMS > EXPORT_DEFAULT_FUNCTION_CODE > SSR 1`] = `
+"import { createServerReference } from "rwsdk/__ssr";
+
+
+export default createServerReference("/test.tsx", "default");
+"
+`;
+
+exports[`useServerPlugin > TRANSFORMS > EXPORT_DEFAULT_FUNCTION_CODE > WORKER 1`] = `
+"import { registerServerReference } from "rwsdk/worker";
+
+function __defaultServerFunction__() {
+  return 1 + 1;
+}
+
+export default __defaultServerFunction__;
+registerServerReference(__defaultServerFunction__, "/test.tsx", "default")
 "
 `;
 

--- a/sdk/src/vite/__snapshots__/transformServerFunctions.test.mts.snap
+++ b/sdk/src/vite/__snapshots__/transformServerFunctions.test.mts.snap
@@ -1,34 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`useServerPlugin > TRANSFORMS > ALREADY_DEFINED_DEFAULT_EXPORT_CODE > CLIENT 1`] = `
-"import { createServerReference } from "rwsdk/client";
-
-
-export default createServerReference("/test.tsx", "default");
-"
-`;
-
-exports[`useServerPlugin > TRANSFORMS > ALREADY_DEFINED_DEFAULT_EXPORT_CODE > SSR 1`] = `
-"import { createServerReference } from "rwsdk/__ssr";
-
-
-export default createServerReference("/test.tsx", "default");
-"
-`;
-
-exports[`useServerPlugin > TRANSFORMS > ALREADY_DEFINED_DEFAULT_EXPORT_CODE > WORKER 1`] = `
-"import { registerServerReference } from "rwsdk/worker";
-
-const sum = () => {
-  return 1 + 1;
-}
-
-export default sum;
-const __defaultServerFunction__ = sum;
-registerServerReference(__defaultServerFunction__, "/test.tsx", "default")
-"
-`;
-
 exports[`useServerPlugin > TRANSFORMS > ARROW_FUNCTION_EXPORT_CODE > CLIENT 1`] = `
 "import { createServerReference } from "rwsdk/client";
 
@@ -246,6 +217,35 @@ export function sum() {
   return 1 + 1
 }
 registerServerReference(sum, "/test.tsx", "sum")
+"
+`;
+
+exports[`useServerPlugin > TRANSFORMS > PREDEFINED_DEFAULT_EXPORT_CODE > CLIENT 1`] = `
+"import { createServerReference } from "rwsdk/client";
+
+
+export default createServerReference("/test.tsx", "default");
+"
+`;
+
+exports[`useServerPlugin > TRANSFORMS > PREDEFINED_DEFAULT_EXPORT_CODE > SSR 1`] = `
+"import { createServerReference } from "rwsdk/__ssr";
+
+
+export default createServerReference("/test.tsx", "default");
+"
+`;
+
+exports[`useServerPlugin > TRANSFORMS > PREDEFINED_DEFAULT_EXPORT_CODE > WORKER 1`] = `
+"import { registerServerReference } from "rwsdk/worker";
+
+const sum = () => {
+  return 1 + 1;
+}
+
+export default sum;
+const __defaultServerFunction__ = sum;
+registerServerReference(__defaultServerFunction__, "/test.tsx", "default")
 "
 `;
 

--- a/sdk/src/vite/transformServerFunctions.mts
+++ b/sdk/src/vite/transformServerFunctions.mts
@@ -334,6 +334,17 @@ export const transformServerFunctions = (
               );
             s.overwrite(range.start.index, range.end.index, newText);
             s.append("\nexport default __defaultServerFunction__;\n");
+          } else {
+            const predefinedMatches = root
+              .root()
+              .findAll("export default $NAME");
+            if (predefinedMatches.length > 0) {
+              const match = predefinedMatches[0];
+              const nameCapture = match.getMatch("NAME")?.text();
+              if (nameCapture) {
+                s.append(`const __defaultServerFunction__ = ${nameCapture};\n`);
+              }
+            }
           }
         }
       } catch (err) {

--- a/sdk/src/vite/transformServerFunctions.mts
+++ b/sdk/src/vite/transformServerFunctions.mts
@@ -164,8 +164,11 @@ export const transformServerFunctions = (
 
   addServerModule?.(environment, normalizedId);
 
-  if (environment === "ssr") {
-    log("Transforming for SSR environment: normalizedId=%s", normalizedId);
+  if (environment === "ssr" || environment === "client") {
+    log(
+      `Transforming for ${environment} environment: normalizedId=%s`,
+      normalizedId,
+    );
 
     const exportInfo = findExportInfo(code, normalizedId);
     const allExports = new Set([
@@ -181,15 +184,19 @@ export const transformServerFunctions = (
 
     // Generate completely new code for SSR
     const s = new MagicString("");
-    s.append('import { createServerReference } from "rwsdk/__ssr";\n\n');
+    if (environment === "ssr") {
+      s.append('import { createServerReference } from "rwsdk/__ssr";\n\n');
+    } else {
+      s.append('import { createServerReference } from "rwsdk/client";\n\n');
+    }
 
     for (const name of allExports) {
-      if (name !== "default") {
+      if (name !== "default" && name !== defaultFunctionName) {
         s.append(
           `export let ${name} = createServerReference(${JSON.stringify(normalizedId)}, ${JSON.stringify(name)});\n`,
         );
         log(
-          "Added SSR server reference for function: %s in normalizedId=%s",
+          `Added ${environment} server reference for function: %s in normalizedId=%s`,
           name,
           normalizedId,
         );
@@ -202,12 +209,15 @@ export const transformServerFunctions = (
         `\nexport default createServerReference(${JSON.stringify(normalizedId)}, "default");\n`,
       );
       log(
-        "Added SSR server reference for default export in normalizedId=%s",
+        `Added ${environment} server reference for default export in normalizedId=%s`,
         normalizedId,
       );
     }
 
-    log("SSR transformation complete for normalizedId=%s", normalizedId);
+    log(
+      `${environment} transformation complete for normalizedId=%s`,
+      normalizedId,
+    );
     return {
       code: s.toString(),
       map: s.generateMap({
@@ -370,7 +380,12 @@ export const transformServerFunctions = (
     // Register local functions
     const defaultFunctionName = findDefaultFunctionName(code, normalizedId);
     for (const name of exportInfo.localFunctions) {
-      if (name === "__defaultServerFunction__" || name === "default") continue;
+      if (
+        name === "__defaultServerFunction__" ||
+        name === "default" ||
+        name === defaultFunctionName
+      )
+        continue;
       // Skip if already registered
       if (registeredFunctions.has(name)) continue;
 
@@ -406,58 +421,6 @@ export const transformServerFunctions = (
     }
 
     log("Worker transformation complete for normalizedId=%s", normalizedId);
-    return {
-      code: s.toString(),
-      map: s.generateMap({
-        source: normalizedId,
-        includeContent: true,
-        hires: true,
-      }),
-    };
-  } else if (environment === "client") {
-    log("Transforming for client environment: normalizedId=%s", normalizedId);
-
-    const exportInfo = findExportInfo(code, normalizedId);
-    const allExports = new Set([
-      ...exportInfo.localFunctions,
-      ...exportInfo.reExports.map((r) => r.localName),
-    ]);
-
-    // Check for default function exports that should also be named exports
-    const defaultFunctionName = findDefaultFunctionName(code, normalizedId);
-    if (defaultFunctionName) {
-      allExports.add(defaultFunctionName);
-    }
-
-    // Generate completely new code for client
-    const s = new MagicString("");
-    s.append('import { createServerReference } from "rwsdk/client";\n\n');
-
-    for (const name of allExports) {
-      if (name !== "default") {
-        s.append(
-          `export let ${name} = createServerReference(${JSON.stringify(normalizedId)}, ${JSON.stringify(name)});\n`,
-        );
-        log(
-          "Added client server reference for function: %s in normalizedId=%s",
-          name,
-          normalizedId,
-        );
-      }
-    }
-
-    // Check for default export in the actual module (not re-exports)
-    if (hasDefaultExport(code, normalizedId)) {
-      s.append(
-        `\nexport default createServerReference(${JSON.stringify(normalizedId)}, "default");\n`,
-      );
-      log(
-        "Added client server reference for default export in normalizedId=%s",
-        normalizedId,
-      );
-    }
-
-    log("Client transformation complete for normalizedId=%s", normalizedId);
     return {
       code: s.toString(),
       map: s.generateMap({

--- a/sdk/src/vite/transformServerFunctions.test.mts
+++ b/sdk/src/vite/transformServerFunctions.test.mts
@@ -53,6 +53,16 @@ export default function sum() {
 }
 `;
 
+  let ALREADY_DEFINED_DEFAULT_EXPORT_CODE = `
+"use server";
+
+const sum = () => {
+  return 1 + 1;
+}
+
+export default sum;
+`;
+
   let NAMED_EXPORT_CODE = `
 "use server";
 
@@ -95,6 +105,7 @@ export * from './utils';
     ASYNC_FUNCTION_EXPORT_CODE,
     DEFAULT_AND_NAMED_EXPORTS_CODE,
     RE_EXPORT_CODE,
+    ALREADY_DEFINED_DEFAULT_EXPORT_CODE,
   };
 
   describe("TRANSFORMS", () => {

--- a/sdk/src/vite/transformServerFunctions.test.mts
+++ b/sdk/src/vite/transformServerFunctions.test.mts
@@ -53,7 +53,7 @@ export default function sum() {
 }
 `;
 
-  let ALREADY_DEFINED_DEFAULT_EXPORT_CODE = `
+  let PREDEFINED_DEFAULT_EXPORT_CODE = `
 "use server";
 
 const sum = () => {
@@ -105,7 +105,7 @@ export * from './utils';
     ASYNC_FUNCTION_EXPORT_CODE,
     DEFAULT_AND_NAMED_EXPORTS_CODE,
     RE_EXPORT_CODE,
-    ALREADY_DEFINED_DEFAULT_EXPORT_CODE,
+    PREDEFINED_DEFAULT_EXPORT_CODE,
   };
 
   describe("TRANSFORMS", () => {

--- a/sdk/src/vite/transformServerFunctions.test.mts
+++ b/sdk/src/vite/transformServerFunctions.test.mts
@@ -63,6 +63,13 @@ const sum = () => {
 export default sum;
 `;
 
+  let EXPORT_DEFAULT_FUNCTION_CODE = `
+"use server";
+export default function sum() {
+  return 1 + 1;
+}
+`;
+
   let NAMED_EXPORT_CODE = `
 "use server";
 
@@ -106,6 +113,7 @@ export * from './utils';
     DEFAULT_AND_NAMED_EXPORTS_CODE,
     RE_EXPORT_CODE,
     PREDEFINED_DEFAULT_EXPORT_CODE,
+    EXPORT_DEFAULT_FUNCTION_CODE,
   };
 
   describe("TRANSFORMS", () => {


### PR DESCRIPTION
Since #521, there've been some issues with default exports in "use server" case:

```
// case 1: in this case, we were referencing `__defaultServerFunction__` even though it was not declared

const foo = () => 2 + 3;
export default foo;

// case 2: in this case
// * we were ending up with an unnecessary reference to `foo`
// * we were accidentally also re-exporting this as `foo` for worker case after transformation

export default function foo() {
   return 2 + 3;
}
```

We also had redundant logic between client and ssr cases, and client logic was incomplete.