### PR TITLE
feat: Warmup DO DB

### DIFF
--- a/sdk/src/runtime/lib/db/SqliteDurableObject.ts
+++ b/sdk/src/runtime/lib/db/SqliteDurableObject.ts
@@ -29,7 +29,7 @@ export class SqliteDurableObject<T = any> extends DurableObject {
     });
   }
 
-  private async initialize(): Promise<void> {
+  public async initialize(): Promise<void> {
     if (this.initialized) {
       log("Database already initialized, skipping");
       return;

--- a/sdk/src/runtime/lib/db/createDb.ts
+++ b/sdk/src/runtime/lib/db/createDb.ts
@@ -1,13 +1,16 @@
 import { Kysely } from "kysely";
 import { requestInfo } from "../../requestInfo/worker.js";
 import { DOWorkerDialect } from "./DOWorkerDialect.js";
+import { type SqliteDurableObject } from "./index.js";
 
 const createDurableObjectDb = <T>(
-  durableObjectBinding: any,
+  durableObjectBinding: DurableObjectNamespace<SqliteDurableObject>,
   name = "main",
 ): Kysely<T> => {
   const durableObjectId = durableObjectBinding.idFromName(name);
   const stub = durableObjectBinding.get(durableObjectId);
+  stub.initialize();
+
   return new Kysely<T>({
     dialect: new DOWorkerDialect({ stub }) as any,
   });
@@ -19,15 +22,20 @@ export function createDb<T>(
 ): Kysely<T> {
   const cacheKey = `${durableObjectBinding}_${name}`;
 
+  const doCreateDb = () => {
+    let db = requestInfo.rw.databases.get(cacheKey);
+
+    if (!db) {
+      db = createDurableObjectDb<T>(durableObjectBinding, name);
+      requestInfo.rw.databases.set(cacheKey, db);
+    }
+
+    return db;
+  };
+
   return new Proxy({} as Kysely<T>, {
     get(target, prop, receiver) {
-      let db = requestInfo.rw.databases.get(cacheKey);
-
-      if (!db) {
-        db = createDurableObjectDb<T>(durableObjectBinding, name);
-        requestInfo.rw.databases.set(cacheKey, db);
-      }
-
+      const db = doCreateDb();
       const value = db[prop as keyof Kysely<T>];
 
       if (typeof value === "function") {

--- a/sdk/src/runtime/lib/db/createDb.ts
+++ b/sdk/src/runtime/lib/db/createDb.ts
@@ -33,6 +33,8 @@ export function createDb<T>(
     return db;
   };
 
+  doCreateDb();
+
   return new Proxy({} as Kysely<T>, {
     get(target, prop, receiver) {
       const db = doCreateDb();


### PR DESCRIPTION
Changes `createDb()` to start a warmup of the relevant durable object instance on first call. This allows us to run migrations as soon as possible for the DO, such that by the time DB interaction needs to happen, the DB is up and ready.

More context on what this DO db thing is all about coming soon!