### PR TITLE
feat: Support multiple client entry points

### DIFF
--- a/sdk/src/vite/configPlugin.mts
+++ b/sdk/src/vite/configPlugin.mts
@@ -24,13 +24,13 @@ export const configPlugin = ({
   mode,
   silent,
   projectRootDir,
-  clientEntryPathname,
+  clientEntryPathnames,
   workerEntryPathname,
 }: {
   mode: "development" | "production";
   silent: boolean;
   projectRootDir: string;
-  clientEntryPathname: string;
+  clientEntryPathnames: string[];
   workerEntryPathname: string;
 }): Plugin => ({
   name: "rwsdk:config",
@@ -56,9 +56,7 @@ export const configPlugin = ({
             outDir: resolve(projectRootDir, "dist", "client"),
             manifest: true,
             rollupOptions: {
-              input: {
-                client: clientEntryPathname,
-              },
+              input: clientEntryPathnames,
             },
           },
           define: {

--- a/sdk/src/vite/injectVitePreamblePlugin.mts
+++ b/sdk/src/vite/injectVitePreamblePlugin.mts
@@ -2,16 +2,20 @@ import { type Plugin } from "vite";
 import MagicString from "magic-string";
 
 export const injectVitePreamble = ({
-  clientEntryPathname,
+  clientEntryPathnames,
   mode,
 }: {
-  clientEntryPathname: string;
+  clientEntryPathnames: string[];
   mode: "development" | "production";
 }): Plugin => ({
   name: "rwsdk:inject-vite-preamble",
   apply: "serve",
   transform(code: string, id: string) {
-    if (id !== clientEntryPathname) {
+    if (this.environment.name !== "client") {
+      return;
+    }
+
+    if (!clientEntryPathnames.includes(id)) {
       return;
     }
 

--- a/sdk/src/vite/redwoodPlugin.mts
+++ b/sdk/src/vite/redwoodPlugin.mts
@@ -31,7 +31,7 @@ export type RedwoodPluginOptions = {
   includeCloudflarePlugin?: boolean;
   configPath?: string;
   entry?: {
-    client?: string;
+    client?: string | string[];
     worker?: string;
   };
 };
@@ -44,10 +44,13 @@ export const redwoodPlugin = async (
   const mode =
     options.mode ??
     (process.env.NODE_ENV === "development" ? "development" : "production");
-  const clientEntryPathname = resolve(
-    projectRootDir,
-    options?.entry?.client ?? "src/client.tsx",
-  );
+
+  const clientEntryPathnames = (
+    Array.isArray(options.entry?.client)
+      ? options.entry.client
+      : [options.entry?.client ?? "src/client.tsx"]
+  ).map((entry) => resolve(projectRootDir, entry));
+
   const workerEntryPathname = resolve(
     projectRootDir,
     options?.entry?.worker ?? "src/worker.tsx",
@@ -84,7 +87,7 @@ export const redwoodPlugin = async (
       mode,
       silent: options.silent ?? false,
       projectRootDir,
-      clientEntryPathname,
+      clientEntryPathnames,
       workerEntryPathname,
     }),
     ssrBridgePlugin({
@@ -113,7 +116,7 @@ export const redwoodPlugin = async (
       serverFiles,
     }),
     vitePreamblePlugin(),
-    injectVitePreamble({ clientEntryPathname, mode }),
+    injectVitePreamble({ clientEntryPathnames, mode }),
     useClientLookupPlugin({
       projectRootDir,
       clientFiles,


### PR DESCRIPTION
Adds support for multiple client entry points. Note that they need to be provided manually in the vite config:

```ts
import { defineConfig } from "vite";
import { redwood } from "rwsdk/vite";
import { cloudflare } from "@cloudflare/vite-plugin";

export default defineConfig({
  plugins: [
    cloudflare({
      viteEnvironment: { name: "worker" },
    }),
    redwood({
      entry: {
        client: ["src/client1.tsx", "src/client2.tsx"],
      },
    }),
  ],
});
```