### PR TITLE
fix: handle Ctrl+C gracefully during deployment prompt

### DIFF
--- a/sdk/src/scripts/ensure-deploy-env.mts
+++ b/sdk/src/scripts/ensure-deploy-env.mts
@@ -35,6 +35,14 @@ const promptForDeployment = async (): Promise<boolean> => {
   });
 
   return new Promise((resolve) => {
+
+    // Handle Ctrl+C (SIGINT)
+    rl.on('SIGINT', () => {
+      rl.close();
+      console.log('\nDeployment cancelled.');
+      process.exit(1);
+    });
+
     rl.question("Do you want to proceed with deployment? (y/N): ", (answer) => {
       rl.close();
       resolve(answer.toLowerCase() === "y");


### PR DESCRIPTION
Add SIGINT handler to properly exit when user presses Ctrl+C
instead of continuing with deployment

## Problem
When prompted "Do you want to proceed with deployment? (y/N):", pressing Ctrl+C doesn't properly cancel the deployment. The script continues running instead of exiting.

## Solution
Added a SIGINT event handler to the readline interface that:
- Closes the readline interface
- Prints "Deployment cancelled." message
- Exits with code 1

This ensures Ctrl+C behaves as expected and cancels the deployment process.