### PR TITLE
fix(docs): drop extra ‘and’

### DIFF
--- a/docs/src/content/docs/tutorial/full-stack-app/4-auth.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/4-auth.mdx
@@ -1460,7 +1460,7 @@ But, there's one more thing. Let's move the `result` message above the form and 
   ...
 ```
 
-We can also style this, using an `<Alert />` shadcn/ui component. We just need to import our component at the top and and wrap our `{result}`.
+We can also style this, using an `<Alert />` shadcn/ui component. We just need to import our component at the top and wrap our `{result}`.
 
 ```tsx title="src/app/pages/user/Login.tsx" showLineNumbers=false
 import { Alert, AlertTitle } from "@/app/components/ui/alert";

--- a/sdk/src/runtime/ssrBridge.ts
+++ b/sdk/src/runtime/ssrBridge.ts
@@ -1,6 +1,6 @@
 // context(justinvdm, 28 May 2025): This is the "bridge" between the RSC side
-// and and the SSR side, both run inside the same runtime environment. We have
-// this separation so that they can each be processed with their own respective
+// and the SSR side, both run inside the same runtime environment. We have this
+// separation so that they can each be processed with their own respective
 // import conditions and bundling logic
 //
 // **NOTE:** Any time we need to import from SSR side in RSC side, we need to


### PR DESCRIPTION
Nothing too crazy. I was going through the codebase and noticed the typo(s). Thanks for working on RedwoodSDK!

---

💖