### PR TITLE
fix: Use client lookup resolving in re-entry case

### DIFF
--- a/sdk/src/vite/createDirectiveLookupPlugin.mts
+++ b/sdk/src/vite/createDirectiveLookupPlugin.mts
@@ -317,7 +317,8 @@ export const createDirectiveLookupPlugin = async ({
 
       if (
         source === config.virtualModuleName ||
-        source === `/@id/${config.virtualModuleName}`
+        source === `/@id/${config.virtualModuleName}` ||
+        source === `/@id/${config.virtualModuleName}.js`
       ) {
         log("Resolving %s module", config.virtualModuleName);
         // context(justinvdm, 16 Jun 2025): Include .js extension


### PR DESCRIPTION
## Background context
Since #521, we add a `.js` suffix to our virtual client+server lookups (e.g. `virtual:use-client-lookup.js`) when resolving the requested module id (e.g. `virtual:use-client-lookup`). We do this to allow plugins that process files js files by looking at their file extension to also match on these modules.

## Problem
In the case of the SSR bridge, already resolved modules (e.g. `virtual:use-client-lookup.js`) are re-resolved:
1. module is resolved for SSR environment: e.g. `virtual:use-client-lookup` -> `virtual:use-client-lookup.js`
2. later, worker environment does a dynamic import for this resolved SSR module: e.g. `/@id/virtual:use-client-lookup.js` -> `virtual:rwsdk:ssr:/@id/virtual:use-client-lookup.js`
3. we now reach the directive lookup plugin (e.g. the one we use to process `"use client"` directives) again for the SSR environment, but now with the resolved id: `/@id/virtual:use-client-lookup.js`
4. in this case, we should match on this, and simply return the id as `virtual:use-client-lookup.js`, but we do not

## Solution
Do step 4 correctly by correctly matching on `/@id/virtual:use-client-lookup.js` - i.e, with `.js` suffix added on