### PR TITLE
dev: Small improvement to debugging rwsdk for projects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 ## To debug changes to the sdk locally
 
 ```sh
-npx rwsync /path/to/sdk/repo && pnpm dev
+SDK_REPO=/path/to/sdk/repo npx rwsync && pnpm dev
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+## To debug changes to the sdk locally
+
+```sh
+rwsync /path/to/sdk/repo && pnpm dev
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,48 @@
-## To debug changes to the sdk locally
+# Contributing
+
+This document provides instructions for contributing to the SDK.
+
+## Getting Started
+
+1.  Make sure you have [Node.js](https://nodejs.org) (>=22) installed.
+2.  This project uses [pnpm](https://pnpm.io) as a package manager, which is managed using [Corepack](https://nodejs.org/api/corepack.html). Enable Corepack by running:
+    ```sh
+    corepack enable
+    ```
+3.  Install dependencies from the root of the `sdk` directory:
 
 ```sh
-SDK_REPO=/path/to/sdk/repo npx rwsync && npm run dev
+pnpm install
+```
+
+## Building
+
+To build the `rwsdk` package, run the following command from the root of the `sdk` directory:
+
+```sh
+pnpm --filter rwsdk build
+```
+
+## Testing
+
+To run the test suite for the `rwsdk` package, run this command from the root of the `sdk` directory:
+
+```sh
+pnpm --filter rwsdk test
+```
+
+## Formatting
+
+This project uses Prettier for code formatting. To format the code, run:
+
+```sh
+pnpm format
+```
+
+## To debug changes to the sdk locally for a project
+
+Run this following in the project's root directory:
+
+```sh
+RWSDK_REPO=/path/to/sdk/repo npx rwsync && npm run dev
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 ## To debug changes to the sdk locally
 
 ```sh
-rwsync /path/to/sdk/repo && pnpm dev
+npx rwsync /path/to/sdk/repo && pnpm dev
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 ## To debug changes to the sdk locally
 
 ```sh
-SDK_REPO=/path/to/sdk/repo npx rwsync && pnpm dev
+SDK_REPO=/path/to/sdk/repo npx rwsync && npm run dev
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,10 @@ To run the test suite for the `rwsdk` package, run this command from the root of
 pnpm --filter rwsdk test
 ```
 
+## Smoke Testing
+
+For details on how to run smoke tests, please see the [smoke testing documentation](./SMOKE-TESTING.md).
+
 ## Formatting
 
 This project uses Prettier for code formatting. To format the code, run:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,8 +196,8 @@ importers:
   starters/minimal:
     dependencies:
       rwsdk:
-        specifier: 0.1.7-test.20250702144615
-        version: 0.1.7-test.20250702144615(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0)
+        specifier: 0.1.7-test.20250702144845
+        version: 0.1.7-test.20250702144845(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0)
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 1.7.4
@@ -239,8 +239,8 @@ importers:
         specifier: ^13.1.1
         version: 13.1.1
       rwsdk:
-        specifier: 0.1.7-test.20250702144615
-        version: 0.1.7-test.20250702144615(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0)
+        specifier: 0.1.7-test.20250702144845
+        version: 0.1.7-test.20250702144845(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0)
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 1.7.4
@@ -3580,8 +3580,8 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
-  rwsdk@0.1.7-test.20250702144615:
-    resolution: {integrity: sha512-ojd1x3unEXVEd9T7MHUlpALHEoxLS9ORzNmAPdWiVcYOzavB7VC6pVGavBPCSJeGbjXjD0UbEXClEDkaNQZT4Q==}
+  rwsdk@0.1.7-test.20250702144845:
+    resolution: {integrity: sha512-BeqFiKEU4U0+XeEqrI/6SLPSkYOhm2NNzAXmpQyK9TiFwkUt5OHJ+i6tfBFSZYOFj/wudU9UYdpbmFjfBu6agA==}
     hasBin: true
     peerDependencies:
       vite: ^6.2.6
@@ -8312,7 +8312,7 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  rwsdk@0.1.7-test.20250702144615(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0):
+  rwsdk@0.1.7-test.20250702144845(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0):
     dependencies:
       '@ast-grep/napi': 0.38.5
       '@cloudflare/vite-plugin': 1.7.4(rollup@4.40.0)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(workerd@1.20250617.0)(wrangler@4.20.5(@cloudflare/workers-types@4.20250407.0))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,8 +196,8 @@ importers:
   starters/minimal:
     dependencies:
       rwsdk:
-        specifier: 0.1.7-test.20250702144845
-        version: 0.1.7-test.20250702144845(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0)
+        specifier: 0.1.7-test.20250702145135
+        version: 0.1.7-test.20250702145135(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0)
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 1.7.4
@@ -239,8 +239,8 @@ importers:
         specifier: ^13.1.1
         version: 13.1.1
       rwsdk:
-        specifier: 0.1.7-test.20250702144845
-        version: 0.1.7-test.20250702144845(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0)
+        specifier: 0.1.7-test.20250702145135
+        version: 0.1.7-test.20250702145135(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0)
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 1.7.4
@@ -3580,8 +3580,8 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
-  rwsdk@0.1.7-test.20250702144845:
-    resolution: {integrity: sha512-BeqFiKEU4U0+XeEqrI/6SLPSkYOhm2NNzAXmpQyK9TiFwkUt5OHJ+i6tfBFSZYOFj/wudU9UYdpbmFjfBu6agA==}
+  rwsdk@0.1.7-test.20250702145135:
+    resolution: {integrity: sha512-v/umJs8SEBXqKBDGQgro3EMxYXCOGgukNUlqQGV9kKwYF2R/H/q1QnQATcVMPyvOeHFtqqLXT1fTu1xVSys65g==}
     hasBin: true
     peerDependencies:
       vite: ^6.2.6
@@ -8312,7 +8312,7 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  rwsdk@0.1.7-test.20250702144845(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0):
+  rwsdk@0.1.7-test.20250702145135(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0):
     dependencies:
       '@ast-grep/napi': 0.38.5
       '@cloudflare/vite-plugin': 1.7.4(rollup@4.40.0)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(workerd@1.20250617.0)(wrangler@4.20.5(@cloudflare/workers-types@4.20250407.0))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,8 +196,8 @@ importers:
   starters/minimal:
     dependencies:
       rwsdk:
-        specifier: 0.1.7
-        version: 0.1.7(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0)
+        specifier: 0.1.7-test.20250702144028
+        version: 0.1.7-test.20250702144028(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0)
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 1.7.4
@@ -239,8 +239,8 @@ importers:
         specifier: ^13.1.1
         version: 13.1.1
       rwsdk:
-        specifier: 0.1.7
-        version: 0.1.7(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0)
+        specifier: 0.1.7-test.20250702144028
+        version: 0.1.7-test.20250702144028(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0)
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 1.7.4
@@ -3580,8 +3580,8 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
-  rwsdk@0.1.7:
-    resolution: {integrity: sha512-SO1zzQwOPsH4rD/OsXqv56+VMx0gxA40LuauVgoeDc2+bT8eUCTkajhzUkthe5sFAnsTlYZ1/5dALS75qjClzA==}
+  rwsdk@0.1.7-test.20250702144028:
+    resolution: {integrity: sha512-yd1a3pNM/LLBPtsmrlpnk4eRpbU648T+mIUZFmBTe73itmk7ZTynWyVP+xgr/UtudcMXkDxrGOINHS46n6bZvw==}
     hasBin: true
     peerDependencies:
       vite: ^6.2.6
@@ -8312,7 +8312,7 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  rwsdk@0.1.7(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0):
+  rwsdk@0.1.7-test.20250702144028(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0):
     dependencies:
       '@ast-grep/napi': 0.38.5
       '@cloudflare/vite-plugin': 1.7.4(rollup@4.40.0)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(workerd@1.20250617.0)(wrangler@4.20.5(@cloudflare/workers-types@4.20250407.0))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,8 +196,8 @@ importers:
   starters/minimal:
     dependencies:
       rwsdk:
-        specifier: 0.1.7-test.20250702144028
-        version: 0.1.7-test.20250702144028(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0)
+        specifier: 0.1.7-test.20250702144615
+        version: 0.1.7-test.20250702144615(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0)
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 1.7.4
@@ -239,8 +239,8 @@ importers:
         specifier: ^13.1.1
         version: 13.1.1
       rwsdk:
-        specifier: 0.1.7-test.20250702144028
-        version: 0.1.7-test.20250702144028(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0)
+        specifier: 0.1.7-test.20250702144615
+        version: 0.1.7-test.20250702144615(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0)
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 1.7.4
@@ -3580,8 +3580,8 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
-  rwsdk@0.1.7-test.20250702144028:
-    resolution: {integrity: sha512-yd1a3pNM/LLBPtsmrlpnk4eRpbU648T+mIUZFmBTe73itmk7ZTynWyVP+xgr/UtudcMXkDxrGOINHS46n6bZvw==}
+  rwsdk@0.1.7-test.20250702144615:
+    resolution: {integrity: sha512-ojd1x3unEXVEd9T7MHUlpALHEoxLS9ORzNmAPdWiVcYOzavB7VC6pVGavBPCSJeGbjXjD0UbEXClEDkaNQZT4Q==}
     hasBin: true
     peerDependencies:
       vite: ^6.2.6
@@ -8312,7 +8312,7 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  rwsdk@0.1.7-test.20250702144028(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0):
+  rwsdk@0.1.7-test.20250702144615(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0):
     dependencies:
       '@ast-grep/napi': 0.38.5
       '@cloudflare/vite-plugin': 1.7.4(rollup@4.40.0)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(workerd@1.20250617.0)(wrangler@4.20.5(@cloudflare/workers-types@4.20250407.0))

--- a/sdk/bin/rwsync
+++ b/sdk/bin/rwsync
@@ -1,0 +1,2 @@
+#!/bin/sh
+DIR=$PWD && (cd "${@:-SDK_REPO}/sdk" && pnpm debug-sync $DIR)

--- a/sdk/bin/rwsync
+++ b/sdk/bin/rwsync
@@ -1,2 +1,2 @@
 #!/bin/sh
-DIR=$PWD && (cd "${@:-SDK_REPO}/sdk" && pnpm debug:sync $DIR)
+DIR=$PWD && (cd "${@:-$SDK_REPO}/sdk" && pnpm debug:sync $DIR)

--- a/sdk/bin/rwsync
+++ b/sdk/bin/rwsync
@@ -1,2 +1,2 @@
 #!/bin/sh
-DIR=$PWD && (cd "${@:-$SDK_REPO}/sdk" && pnpm debug:sync $DIR)
+DIR=$PWD && (cd "${@:-$RWSDK_REPO}/sdk" && pnpm debug:sync $DIR)

--- a/sdk/bin/rwsync
+++ b/sdk/bin/rwsync
@@ -1,2 +1,2 @@
 #!/bin/sh
-DIR=$PWD && (cd "${@:-SDK_REPO}/sdk" && pnpm debug-sync $DIR)
+DIR=$PWD && (cd "${@:-SDK_REPO}/sdk" && pnpm debug:sync $DIR)

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -9,7 +9,8 @@
   },
   "files": [
     "./README.md",
-    "./dist"
+    "./dist",
+    "./bin"
   ],
   "scripts": {
     "build": "tsc --build --clean && tsc",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -4,7 +4,8 @@
   "description": "Build fast, server-driven webapps on Cloudflare with SSR, RSC, and realtime",
   "type": "module",
   "bin": {
-    "rw-scripts": "./bin/rw-scripts.mjs"
+    "rw-scripts": "./bin/rw-scripts.mjs",
+    "rwsync": "./bin/rwsync"
   },
   "files": [
     "./README.md",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rwsdk",
-  "version": "0.1.7-test.20250702144348",
+  "version": "0.1.7-test.20250702144615",
   "description": "Build fast, server-driven webapps on Cloudflare with SSR, RSC, and realtime",
   "type": "module",
   "bin": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rwsdk",
-  "version": "0.1.7-test.20250702144028",
+  "version": "0.1.7-test.20250702144348",
   "description": "Build fast, server-driven webapps on Cloudflare with SSR, RSC, and realtime",
   "type": "module",
   "bin": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rwsdk",
-  "version": "0.1.7",
+  "version": "0.1.7-test.20250702144028",
   "description": "Build fast, server-driven webapps on Cloudflare with SSR, RSC, and realtime",
   "type": "module",
   "bin": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rwsdk",
-  "version": "0.1.7-test.20250702144845",
+  "version": "0.1.7-test.20250702145135",
   "description": "Build fast, server-driven webapps on Cloudflare with SSR, RSC, and realtime",
   "type": "module",
   "bin": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rwsdk",
-  "version": "0.1.7-test.20250702144615",
+  "version": "0.1.7-test.20250702144845",
   "description": "Build fast, server-driven webapps on Cloudflare with SSR, RSC, and realtime",
   "type": "module",
   "bin": {

--- a/sdk/src/scripts/debug-sync.mts
+++ b/sdk/src/scripts/debug-sync.mts
@@ -130,8 +130,8 @@ if (import.meta.url === new URL(process.argv[1], import.meta.url).href) {
     const targetDir = positionalArgs[0] ?? process.cwd();
     debugSync({
       targetDir,
-      sdkDir: process.env.SDK_REPO
-        ? path.resolve(__dirname, process.env.SDK_REPO, "sdk")
+      sdkDir: process.env.RWSDK_REPO
+        ? path.resolve(__dirname, process.env.RWSDK_REPO, "sdk")
         : path.resolve(__dirname, "..", ".."),
       dev: flags.has("--dev"),
       watch: flags.has("--watch"),

--- a/sdk/src/scripts/debug-sync.mts
+++ b/sdk/src/scripts/debug-sync.mts
@@ -106,6 +106,7 @@ export const debugSync = async (opts: DebugSyncOptions) => {
     $({
       stdio: "inherit",
       shell: true,
+      cwd: sdkDir,
     })`npx chokidar-cli './src/**' './package.json' -c "${syncCommand}"`;
   } else if (build) {
     console.log("🏗️ Running build in target directory...");

--- a/sdk/src/scripts/debug-sync.mts
+++ b/sdk/src/scripts/debug-sync.mts
@@ -1,6 +1,8 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { $ } from "../lib/$.mjs";
+import fs from "node:fs/promises";
+import { existsSync } from "node:fs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -12,6 +14,64 @@ export interface DebugSyncOptions {
   build?: boolean;
 }
 
+const getPackageManagerInfo = (targetDir: string) => {
+  if (existsSync(path.join(targetDir, "yarn.lock"))) {
+    return { name: "yarn", lockFile: "yarn.lock", command: "add" };
+  }
+  if (existsSync(path.join(targetDir, "pnpm-lock.yaml"))) {
+    return { name: "pnpm", lockFile: "pnpm-lock.yaml", command: "add" };
+  }
+  return { name: "npm", lockFile: "package-lock.json", command: "install" };
+};
+
+const performSync = async (sdkDir: string, targetDir: string) => {
+  console.log("🏗️  rebuilding sdk...");
+  await $({ cwd: sdkDir, stdio: "inherit", shell: true })`pnpm build`;
+
+  console.log("📦 packing sdk...");
+  const packResult = await $({ cwd: sdkDir, shell: true })`npm pack`;
+  const tarballName = packResult.stdout?.trim() ?? "";
+  const tarballPath = path.resolve(sdkDir, tarballName);
+
+  console.log(` installing ${tarballName} in ${targetDir}...`);
+
+  const pm = getPackageManagerInfo(targetDir);
+  const packageJsonPath = path.join(targetDir, "package.json");
+  const lockfilePath = path.join(targetDir, pm.lockFile);
+
+  const originalPackageJson = await fs
+    .readFile(packageJsonPath, "utf-8")
+    .catch(() => null);
+  const originalLockfile = await fs
+    .readFile(lockfilePath, "utf-8")
+    .catch(() => null);
+
+  try {
+    let installCommand = `${pm.name} ${pm.command} ${tarballPath}`;
+    if (pm.name === "yarn") {
+      installCommand = `yarn add file:${tarballPath}`;
+    }
+    await $({
+      cwd: targetDir,
+      stdio: "inherit",
+      shell: true,
+    })`${installCommand}`;
+  } finally {
+    if (originalPackageJson) {
+      console.log("Restoring package.json...");
+      await fs.writeFile(packageJsonPath, originalPackageJson);
+    }
+    if (originalLockfile) {
+      console.log(`Restoring ${pm.lockFile}...`);
+      await fs.writeFile(lockfilePath, originalLockfile);
+    }
+    await fs.unlink(tarballPath).catch(() => {
+      // ignore if deletion fails
+    });
+  }
+  console.log("✅ done syncing");
+};
+
 export const debugSync = async (opts: DebugSyncOptions) => {
   const { targetDir, sdkDir = process.cwd(), dev, watch, build } = opts;
 
@@ -20,10 +80,11 @@ export const debugSync = async (opts: DebugSyncOptions) => {
     process.exit(1);
   }
 
-  const syncCommand = `echo 🏗️ rebuilding... && pnpm build && rm -rf ${targetDir}/node_modules/rwsdk/dist ${targetDir}/node_modules/rwsdk/package.json && echo 📁 syncing sdk from ${sdkDir} to ${targetDir}/node_modules/rwsdk/... && cp -r ${sdkDir}/package.json ${sdkDir}/dist ${targetDir}/node_modules/rwsdk/ && echo ✅ done syncing`;
+  const thisScriptPath = fileURLToPath(import.meta.url);
+  const syncCommand = `tsx ${thisScriptPath} --_sync ${sdkDir} ${targetDir}`;
 
   // Run initial sync
-  await $({ stdio: "inherit", shell: true })`${syncCommand}`;
+  await performSync(sdkDir, targetDir);
 
   if (!process.env.NO_CLEAN_VITE) {
     console.log("🧹 Cleaning Vite cache...");
@@ -58,15 +119,22 @@ export const debugSync = async (opts: DebugSyncOptions) => {
 
 if (import.meta.url === new URL(process.argv[1], import.meta.url).href) {
   const args = process.argv.slice(2);
-  const targetDir = args[0] ?? process.cwd();
-  const flags = new Set(args.slice(1));
-  debugSync({
-    targetDir,
-    sdkDir: process.env.SDK_REPO
-      ? path.resolve(__dirname, process.env.SDK_REPO, "sdk")
-      : path.resolve(__dirname, "..", ".."),
-    dev: flags.has("--dev"),
-    watch: flags.has("--watch"),
-    build: flags.has("--build"),
-  });
+  const flags = new Set(args.filter((arg) => arg.startsWith("--")));
+  const positionalArgs = args.filter((arg) => !arg.startsWith("--"));
+
+  if (flags.has("--_sync")) {
+    const [sdkDir, targetDir] = positionalArgs;
+    await performSync(sdkDir, targetDir);
+  } else {
+    const targetDir = positionalArgs[0] ?? process.cwd();
+    debugSync({
+      targetDir,
+      sdkDir: process.env.SDK_REPO
+        ? path.resolve(__dirname, process.env.SDK_REPO, "sdk")
+        : path.resolve(__dirname, "..", ".."),
+      dev: flags.has("--dev"),
+      watch: flags.has("--watch"),
+      build: flags.has("--build"),
+    });
+  }
 }

--- a/starters/minimal/package.json
+++ b/starters/minimal/package.json
@@ -22,7 +22,7 @@
     "types": "tsc"
   },
   "dependencies": {
-    "rwsdk": "0.1.7-test.20250702144615"
+    "rwsdk": "0.1.7-test.20250702144845"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.7.4",

--- a/starters/minimal/package.json
+++ b/starters/minimal/package.json
@@ -22,7 +22,7 @@
     "types": "tsc"
   },
   "dependencies": {
-    "rwsdk": "0.1.7"
+    "rwsdk": "0.1.7-test.20250702144028"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.7.4",

--- a/starters/minimal/package.json
+++ b/starters/minimal/package.json
@@ -22,7 +22,7 @@
     "types": "tsc"
   },
   "dependencies": {
-    "rwsdk": "0.1.7-test.20250702144845"
+    "rwsdk": "0.1.7-test.20250702145135"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.7.4",

--- a/starters/minimal/package.json
+++ b/starters/minimal/package.json
@@ -22,7 +22,7 @@
     "types": "tsc"
   },
   "dependencies": {
-    "rwsdk": "0.1.7-test.20250702144028"
+    "rwsdk": "0.1.7-test.20250702144615"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.7.4",

--- a/starters/standard/package.json
+++ b/starters/standard/package.json
@@ -31,7 +31,7 @@
     "@prisma/client": "~6.8.2",
     "@simplewebauthn/browser": "^13.1.0",
     "@simplewebauthn/server": "^13.1.1",
-    "rwsdk": "0.1.7-test.20250702144615"
+    "rwsdk": "0.1.7-test.20250702144845"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.7.4",

--- a/starters/standard/package.json
+++ b/starters/standard/package.json
@@ -31,7 +31,7 @@
     "@prisma/client": "~6.8.2",
     "@simplewebauthn/browser": "^13.1.0",
     "@simplewebauthn/server": "^13.1.1",
-    "rwsdk": "0.1.7"
+    "rwsdk": "0.1.7-test.20250702144028"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.7.4",

--- a/starters/standard/package.json
+++ b/starters/standard/package.json
@@ -31,7 +31,7 @@
     "@prisma/client": "~6.8.2",
     "@simplewebauthn/browser": "^13.1.0",
     "@simplewebauthn/server": "^13.1.1",
-    "rwsdk": "0.1.7-test.20250702144845"
+    "rwsdk": "0.1.7-test.20250702145135"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.7.4",

--- a/starters/standard/package.json
+++ b/starters/standard/package.json
@@ -31,7 +31,7 @@
     "@prisma/client": "~6.8.2",
     "@simplewebauthn/browser": "^13.1.0",
     "@simplewebauthn/server": "^13.1.1",
-    "rwsdk": "0.1.7-test.20250702144028"
+    "rwsdk": "0.1.7-test.20250702144615"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.7.4",


### PR DESCRIPTION
Makes it possible for one to do this to test out changes to a local checkout of the sdk:

```sh
# maybe put this in something your shell will `source` (e.g. ~/.bashrc)
export RWSDK_REPO=/path/to/sdk/repo

npx rwsync && npm run dev
```