### PR TITLE
fix: Use wss only when upgrading https

### DIFF
--- a/sdk/src/runtime/lib/realtime/client.ts
+++ b/sdk/src/runtime/lib/realtime/client.ts
@@ -19,13 +19,14 @@ export const realtimeTransport =
     const clientId = crypto.randomUUID();
 
     const clientUrl = new URL(window.location.href);
+    const isHttps = clientUrl.protocol === "https:";
     clientUrl.protocol = "";
     clientUrl.host = "";
 
     const setupWebSocket = () => {
       if (ws) return;
 
-      const protocol = IS_DEV ? "ws" : "wss";
+      const protocol = isHttps ? "wss" : "ws";
 
       ws = new WebSocket(
         `${protocol}://${window.location.host}/__realtime?` +


### PR DESCRIPTION
## Problem
Our current realtime implementation only uses `ws://` with the vite dev server, and otherwise uses `wss://`. This breaks usage with `pnpm preview`

## Solution
Use `wss://` when upgrading `https://`, otherwise use `ws://`