### PR TITLE
docs: Update incorrect filename in 4-auth.mdx

### DIFF
--- a/docs/src/content/docs/tutorial/full-stack-app/4-auth.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/4-auth.mdx
@@ -233,9 +233,9 @@ prefix("/user", userRoutes),
 
 We're co-locating the file that defines our auth routes with our auth pages.
 
-Let's take a look at `userRoutes`. This is coming from `src/app/pages/user/routes.tsx`.
+Let's take a look at `userRoutes`. This is coming from `src/app/pages/user/routes.ts`.
 
-```tsx title="src/app/pages/user/routes.tsx"
+```tsx title="src/app/pages/user/routes.ts"
 import { route } from "rwsdk/router";
 import { Login } from "./Login";
 import { sessions } from "@/session/store";


### PR DESCRIPTION
The file name in the tutorial is `routes.tsx`, but in the tutorial code I downloaded, it's `routes.ts`. The documentation should probably reflect the tutorial code.