### PR TITLE
docs: Update incorrect filename security.mdx

### DIFF
--- a/docs/src/content/docs/core/security.mdx
+++ b/docs/src/content/docs/core/security.mdx
@@ -19,7 +19,7 @@ The standard starter includes a set of security headers by default in [`app/head
 
 <Code
   language="typescript"
-  title="src/app/pages/auth/LoginPage.tsx"
+  title="src/app/headers.ts"
   code={importedCodeStandardHeaders}
   collapse={"1-3"}
 />


### PR DESCRIPTION
The file referenced in the core docs on [Security](https://docs.rwsdk.com/core/security/) doesn't match the included snippet. Fixed.