### PR TITLE
fix: Avoid misleading wrapper error message

### DIFF
--- a/sdk/src/runtime/render/renderRscThenableToHtmlStream.tsx
+++ b/sdk/src/runtime/render/renderRscThenableToHtmlStream.tsx
@@ -48,11 +48,17 @@ export const renderRscThenableToHtmlStream = async ({
     nonce: requestInfo.rw.nonce,
     onError(error, { componentStack }) {
       try {
+        if (!error) {
+          error = new Error(
+            `A falsy value was thrown during rendering: ${String(error)}.`,
+          );
+        }
+
         const message = error
           ? ((error as any).stack ?? (error as any).message ?? error)
           : error;
 
-        const wrappedMessage = `Error rendering RSC to HTML stream: ${message}\n\nComponent stack:\n${componentStack}`;
+        const wrappedMessage = `${message}\n\nComponent stack:${componentStack}`;
 
         if (error instanceof Error) {
           const wrappedError = new Error(wrappedMessage);


### PR DESCRIPTION
I added wrapper error info in #556 so that we include component stack. Part of that wrapper included a `Error Rendering RSC to HTML stream.` prefix to the underlying error message.

That prefixing ended up misleading people into thinking the actual error was `Error Rendering RSC to HTML stream` (#564). This PR removes that prefix to avoid this, but keeps the component stack info.