### PR TITLE
fix: SSR on explicit reloads after HMR

### DIFF
--- a/sdk/src/vite/directivesPlugin.mts
+++ b/sdk/src/vite/directivesPlugin.mts
@@ -90,7 +90,7 @@ export const directivesPlugin = ({
           id,
         );
 
-        invalidateModule(devServer, environment, `virtual:use-${kind}-lookup`);
+        //invalidateModule(devServer, environment, `virtual:use-${kind}-lookup`);
       }
     }
   };

--- a/sdk/src/vite/findSsrSpecifiers.mts
+++ b/sdk/src/vite/findSsrSpecifiers.mts
@@ -1,0 +1,62 @@
+import { parse as sgParse, Lang as SgLang, Lang } from "@ast-grep/napi";
+import path from "path";
+
+/**
+ * Finds __vite_ssr_import__ and __vite_ssr_dynamic_import__ specifiers in the code.
+ * @param id The file identifier for language detection.
+ * @param code The code to search for SSR imports.
+ * @param log Optional logger function for debug output.
+ * @returns Object with arrays of static and dynamic import specifiers.
+ */
+export function findSsrImportSpecifiers(
+  id: string,
+  code: string,
+  log?: (...args: any[]) => void,
+): { imports: string[]; dynamicImports: string[] } {
+  const ext = path.extname(id).toLowerCase();
+  const lang = ext === ".tsx" || ext === ".jsx" ? Lang.Tsx : SgLang.TypeScript;
+  const logger = log ?? (() => {});
+  const imports: string[] = [];
+  const dynamicImports: string[] = [];
+
+  try {
+    const root = sgParse(lang, code);
+    const patterns = [
+      {
+        pattern: `__vite_ssr_import__("$SPECIFIER")`,
+        list: imports,
+      },
+      {
+        pattern: `__vite_ssr_import__('$SPECIFIER')`,
+        list: imports,
+      },
+      {
+        pattern: `__vite_ssr_dynamic_import__("$SPECIFIER")`,
+        list: dynamicImports,
+      },
+      {
+        pattern: `__vite_ssr_dynamic_import__('$SPECIFIER')`,
+        list: dynamicImports,
+      },
+    ];
+
+    for (const { pattern, list } of patterns) {
+      const matches = root.root().findAll(pattern);
+      for (const match of matches) {
+        const specifier = match.getMatch("SPECIFIER")?.text();
+        if (specifier) {
+          list.push(specifier);
+          logger(
+            `Found SSR import specifier: %s in pattern: %s`,
+            specifier,
+            pattern,
+          );
+        }
+      }
+    }
+  } catch (err) {
+    logger("Error parsing code for SSR imports: %O", err);
+  }
+
+  return { imports, dynamicImports };
+}

--- a/sdk/src/vite/miniflareHMRPlugin.mts
+++ b/sdk/src/vite/miniflareHMRPlugin.mts
@@ -188,6 +188,22 @@ export const miniflareHMRPlugin = (givenOptions: {
           );
         }
 
+        const virtualSSRModule = ctx.server.environments[
+          environment
+        ].moduleGraph.idToModuleMap.get(
+          VIRTUAL_SSR_PREFIX +
+            normalizeModulePath(givenOptions.rootDir, ctx.file),
+        );
+
+        if (virtualSSRModule) {
+          ctx.server.environments.client.moduleGraph.invalidateModule(
+            virtualSSRModule,
+            new Set(),
+            ctx.timestamp,
+            true,
+          );
+        }
+
         ctx.server.environments.client.hot.send({
           type: "custom",
           event: "rsc:update",
@@ -196,7 +212,6 @@ export const miniflareHMRPlugin = (givenOptions: {
           },
         });
 
-        //return [bridgeModule, virtualSSRModule];
         return [];
       }
     },

--- a/sdk/src/vite/ssrBridgePlugin.mts
+++ b/sdk/src/vite/ssrBridgePlugin.mts
@@ -1,7 +1,6 @@
 import type { Plugin, ViteDevServer } from "vite";
 import debug from "debug";
 import { SSR_BRIDGE_PATH } from "../lib/constants.mjs";
-import { invalidateModule } from "./invalidateModule.mjs";
 
 const log = debug("rwsdk:vite:ssr-bridge-plugin");
 const verboseLog = debug("verbose:rwsdk:vite:ssr-bridge-plugin");
@@ -91,7 +90,6 @@ export const ssrBridgePlugin = ({
         // SSR modules, so we return the virtual id so that the dynamic loading
         // can happen in load()
         if (id.startsWith(VIRTUAL_SSR_PREFIX)) {
-          invalidateModule(devServer, "worker", id);
           log("Returning virtual SSR id for dev: %s", id);
           return id;
         }
@@ -108,7 +106,6 @@ export const ssrBridgePlugin = ({
             virtualId,
           );
 
-          invalidateModule(devServer, "worker", virtualId);
           return virtualId;
         }
       } else {
@@ -159,7 +156,7 @@ export const ssrBridgePlugin = ({
 
           // context(justinvdm, 27 May 2025): Prefix all imports in SSR modules so that they're separate in module graph from non-SSR
           const transformedCode = `
-await (async function(__vite_ssr_import__, __vite_ssr_dynamic_import__) {${code}})((id) => __vite_ssr_import__('/@id/${VIRTUAL_SSR_PREFIX}'+id), (id) => __vite_ssr_dynamic_import__('/@id/${VIRTUAL_SSR_PREFIX}'+id));
+await (async function(__vite_ssr_import__, __vite_ssr_dynamic_import__) {${code}})((id) => import('/@id/${VIRTUAL_SSR_PREFIX}'+id), (id) => import('/@id/${VIRTUAL_SSR_PREFIX}'+id));
 `;
 
           log("Transformed SSR module code length: %d", transformedCode.length);

--- a/sdk/src/vite/transformClientComponents.mts
+++ b/sdk/src/vite/transformClientComponents.mts
@@ -2,7 +2,6 @@ import MagicString from "magic-string";
 import debug from "debug";
 import { hasDirective } from "./hasDirective.mjs";
 import { findExports, type ExportInfo } from "./findSpecifiers.mjs";
-import type { ViteDevServer } from "vite";
 
 interface TransformContext {
   environmentName: string;


### PR DESCRIPTION
## Context
We have a concept of virtual SSR modules as part of the worker environment's module graph. Each corresponds to a module in the SSR environment's module graph.

This allows us to do processing for two different environments - most importantly, `worker` environment can use `react-server` import condition and RSC react runtime, `ssr` environment can use classic react runtime and _no_ `react-server` import condition.

In order to accomplish this, we have a vite `load()` plugin hook, which loads the virtual SSR modules in the worker env by calling `fetchModule` for the corresponding module in the SSR env.

## Problem 1
We need to invalidate the virtual SSR module when the actual file changes, so that vite can reload it (as well as dependent modules in the graph) correctly with its changes accounted for.

## Problem 2: The underlying one
Invalidating it should be enough - if we actually had the correct module graph.

Turns out we didn't.

We had this - notice that each virtual module is a leaf node:

```
- /Users/justin/rw/blotter/rwsdk-hydration-example/src/worker.tsx
  ...
- virtual:rwsdk:ssr:/node_modules/.vite/deps_ssr/chunk-5SVCMTR3.js?v=6970a862 [virtual]
- virtual:rwsdk:ssr:/node_modules/.vite/deps_ssr/chunk-6Y5HNGJW.js?v=6970a862 [virtual]
- virtual:rwsdk:ssr:/node_modules/.vite/deps_ssr/chunk-TBJU3W5Y.js?v=6970a862 [virtual]
- virtual:rwsdk:ssr:/node_modules/.vite/deps_ssr/chunk-5UXEC3AS.js?v=6970a862 [virtual]
- virtual:rwsdk:ssr:/node_modules/.vite/deps_ssr/chunk-BDXQCHU4.js?v=6970a862 [virtual]
- virtual:rwsdk:ssr:/node_modules/.vite/deps_ssr/chunk-PTYHVFOF.js?v=6970a862 [virtual]
- virtual:rwsdk:ssr:/@id/virtual:use-client-lookup.js [virtual]
- virtual:rwsdk:ssr:/src/app/pages/components/client-component.tsx [virtual]
- virtual:rwsdk:ssr:/node_modules/.vite/deps_ssr/react_jsx-dev-runtime.js?v=7d86d101 [virtual]
- virtual:rwsdk:ssr:/src/app/pages/components/foo.ts [virtual]
```

What we want is this:

```
- /Users/justin/rw/blotter/rwsdk-hydration-example/src/worker.tsx
...
    - virtual:rwsdk:ssr:rwsdk/__ssr_bridge [virtual]
      - virtual:rwsdk:ssr:/node_modules/.vite/deps_ssr/chunk-PTYHVFOF.js?v=fb8dc2f5 [virtual]
      - virtual:rwsdk:ssr:/@id/virtual:use-client-lookup.js [virtual]
        - virtual:rwsdk:ssr:/src/app/pages/components/client-component.tsx [virtual]
          - virtual:rwsdk:ssr:/src/app/pages/components/foo.ts [virtual]
        - virtual:rwsdk:ssr:/src/app/pages/user/Login.tsx [virtual]
...
```

Why is it a problem that graph is incorrect? Vite correctly identifies the invalidate as a dead end (since there are no importers of the module), and does a full reload.

Why didn't we have the correct module graph?

The `fetchModule` code we do in the `load()` for the virtual SSR modules had imports that look like this, as a result of vite transforming them:

```ts
__vite_ssr_import__("...")
```

These are fine for runtime purposes, and at this point vite has already tracked the imports it needs for the relevant environment (`ssr`) before it did this transforming.

Thing is, we're now returning this code in a `load()` that is processing for a _different environment_ - `worker`. Vite needs to see `import`s instead so that it can track them correctly to build the module graph.

## Solution
* To build module graph correctly: use ast-grep to collect all `__vite_ssr_import__`s and `__vite_ssr_dynamic_import__`s
* Wrap the code such that whenever a `_vite_ssr_import` or `__vite_ssr_dynamic_import__` happens, we also `import()` it as a side effect - importantly, the literal itself. The resulting code looks something like
```ts
await (async function(__vite_ssr_import__, __vite_ssr_dynamic_import__) {/* code returned by fetchModule() goes here */ })(
  (id, ...args) => ssrImport(id, false, ...args),
  (id, ...args) => ssrImport(id, true, ...args)
);

function ssrImport(id, isDynamic, ...args) {
  switch (id) {
    case "/src/app/pages/components/client-component.ts": import("virtual:rwsdk:ssr:/src/app/pages/components/client-component.ts"),
    case "/src/app/pages/components/foo.ts": import("virtual:rwsdk:ssr:/src/app/pages/components/foo.ts"),
    // ...
  }

  const virtualId = '/@id/virtual:rwsdk:ssr:' + id;
  return isDynamic ? __vite_ssr_dynamic_import__(virtualId, ...args) : __vite_ssr_import__(virtualId, ...args);
}
```
* Then invalidate the virtual SSR module when the corresponding actual file changes

## Links
* [Support thread](https://discord.com/channels/679514959968993311/1392212607322034187)