### PR TITLE
fix: Correct virtual SSR module invalidation and import side-effect logic

### DIFF
--- a/sdk/src/vite/directivesPlugin.mts
+++ b/sdk/src/vite/directivesPlugin.mts
@@ -6,7 +6,6 @@ import { transformClientComponents } from "./transformClientComponents.mjs";
 import { transformServerFunctions } from "./transformServerFunctions.mjs";
 import { normalizeModulePath } from "./normalizeModulePath.mjs";
 import type { ViteDevServer } from "vite";
-import { invalidateModule } from "./invalidateModule.mjs";
 
 const log = debug("rwsdk:vite:rsc-directives-plugin");
 const verboseLog = debug("verbose:rwsdk:vite:rsc-directives-plugin");
@@ -89,8 +88,6 @@ export const directivesPlugin = ({
           lookupModule,
           id,
         );
-
-        //invalidateModule(devServer, environment, `virtual:use-${kind}-lookup`);
       }
     }
   };

--- a/sdk/src/vite/miniflareHMRPlugin.mts
+++ b/sdk/src/vite/miniflareHMRPlugin.mts
@@ -196,7 +196,7 @@ export const miniflareHMRPlugin = (givenOptions: {
         );
 
         if (virtualSSRModule) {
-          ctx.server.environments.client.moduleGraph.invalidateModule(
+          ctx.server.environments.worker.moduleGraph.invalidateModule(
             virtualSSRModule,
             new Set(),
             ctx.timestamp,


### PR DESCRIPTION
Follow-up to previous PR (#586) - there were some issues in it for establishing proper module graph linkage for virtual SSR modules.

Fixes:
* Corrected environment scope for invalidation: Virtual SSR modules must be invalidated in the worker environment, not client, to ensure proper propagation without triggering full reloads.
* Handled modules without code (e.g. CSS): CSS and other plugin-handled modules can return undefined from fetchModule(). We now avoid skipping these entirely and still extract specifiers to maintain accurate graph linkage.
* Replaced the switch-wrapped `ssrImport()` + return logic with direct inline injection of `import()` side effects. This change restores correct behaviour for some module types (notably CSS), though the exact cause of breakage in the previous version is not yet fully understood.