### PR TITLE
fix: Adding "use client" after dev server running

### DIFF
--- a/.cursor/rules/dev.mdc
+++ b/.cursor/rules/dev.mdc
@@ -1,0 +1,5 @@
+---
+description: When importing from `.mts` source files, use the `.mjs` extension in the import path. TypeScript will handle the resolution.
+globs: ['**/*.mts']
+alwaysApply: true
+---

--- a/sdk/src/vite/isJsFile.mts
+++ b/sdk/src/vite/isJsFile.mts
@@ -1,0 +1,3 @@
+export function isJsFile(filepath: string) {
+  return /\.(m|c)?(j|t)s(x)?$/.test(filepath);
+}

--- a/sdk/src/vite/miniflareHMRPlugin.mts
+++ b/sdk/src/vite/miniflareHMRPlugin.mts
@@ -159,7 +159,7 @@ export const miniflareHMRPlugin = (givenOptions: {
               );
 
             for (const clientModule of clientModules ?? []) {
-              invalidateModule(ctx.server, environment, clientModule);
+              invalidateModule(ctx.server, "client", clientModule);
             }
           }
         }

--- a/sdk/src/vite/miniflareHMRPlugin.mts
+++ b/sdk/src/vite/miniflareHMRPlugin.mts
@@ -164,9 +164,10 @@ export const miniflareHMRPlugin = (givenOptions: {
           }
         }
 
-        // context(justinvdm, 10 Jul 2025): If this isn't a file with a client directive,
-        // we shouldn't invalidate anything else to avoid full page reload
-        return hasClientDirective ? undefined : [];
+        // context(justinvdm, 10 Jul 2025): If this isn't a file with a client
+        // directive or a css file, we shouldn't invalidate anything else to
+        // avoid full page reload
+        return hasClientDirective || ctx.file.endsWith(".css") ? undefined : [];
       }
 
       // The worker needs an update, and the hot check is for the worker environment

--- a/sdk/src/vite/miniflareHMRPlugin.mts
+++ b/sdk/src/vite/miniflareHMRPlugin.mts
@@ -101,14 +101,12 @@ export const miniflareHMRPlugin = (givenOptions: {
             ctx.server,
             environment,
             "virtual:use-client-lookup.js",
-            { invalidateImportersRecursively: true },
           );
         });
         invalidateModule(
           ctx.server,
           environment,
           VIRTUAL_SSR_PREFIX + "/@id/virtual:use-client-lookup.js",
-          { invalidateImportersRecursively: true },
         );
       }
 
@@ -118,14 +116,12 @@ export const miniflareHMRPlugin = (givenOptions: {
             ctx.server,
             environment,
             "virtual:use-server-lookup.js",
-            { invalidateImportersRecursively: true },
           );
         });
         invalidateModule(
           ctx.server,
           environment,
           VIRTUAL_SSR_PREFIX + "/@id/virtual:use-server-lookup.js",
-          { invalidateImportersRecursively: true },
         );
       }
 
@@ -168,7 +164,9 @@ export const miniflareHMRPlugin = (givenOptions: {
           }
         }
 
-        return;
+        // context(justinvdm, 10 Jul 2025): If this isn't a file with a client directive,
+        // we shouldn't invalidate anything else to avoid full page reload
+        return hasClientDirective ? undefined : [];
       }
 
       // The worker needs an update, and the hot check is for the worker environment

--- a/sdk/src/vite/redwoodPlugin.mts
+++ b/sdk/src/vite/redwoodPlugin.mts
@@ -123,6 +123,8 @@ export const redwoodPlugin = async (
         })
       : [],
     miniflareHMRPlugin({
+      clientFiles,
+      serverFiles,
       rootDir: projectRootDir,
       viteEnvironment: { name: "worker" },
       workerEntryPathname,


### PR DESCRIPTION
## Problem
Currently, if a module starts off as without "use client", then gets "use client" added to it once the dev server is running, you'll get an error:
```
(ssr) No module found for '<id>' in module lookup for "use client" directive
```

The reason for this, is that we need to invalidate the client lookup (we use this module for finding the relevant client components when doing client or server side rendering), once a file gets a "use client" directive.

## Solution
Check whether files go from having to not having "use client" or "use server" directives, update the set of files we track accordingly, then invalidate the client (or server) lookup module so that it can be updated.

## Demo of fix
https://www.loom.com/share/ba1a0f1c1e5949eba81b5c86a38aebdd