### PR TITLE
dev: Better verbose logging

### DIFF
--- a/.cursor/rules/dev.mdc
+++ b/.cursor/rules/dev.mdc
@@ -1,5 +1,5 @@
 ---
-description: When importing from `.mts` source files, use the `.mjs` extension in the import path. TypeScript will handle the resolution.
+description: When importing from `.mts` source files, use the `.mjs` extension in the import path. TypeScript will handle the resolution. Not though that the actual file extensions will be `.mts` though - it is only for TypeScript's benefit that the specifiers are `.mjs` in imports, even though the file extensions of the actual files are in fact `.mts`.
 globs: ['**/*.mts']
 alwaysApply: true
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ This project uses Prettier for code formatting. To format the code, run:
 pnpm format
 ```
 
-## To debug changes to the sdk locally for a project
+## Debugging changes to the sdk locally for a project
 
 The `rwsync` command provides a bridge between a local checkout of the `rwsdk` and a project that uses it, enabling a fast and efficient development workflow.
 
@@ -54,52 +54,25 @@ First, set the `RWSDK_REPO` environment variable in your shell's configuration f
 export RWSDK_REPO=/path/to/your/local/sdk
 ```
 
-### One-time Sync
+## Debugging the Vite Plugin
 
-To perform a one-time synchronization of your local SDK changes to your project, run the following command from your project's root directory:
+The RedwoodSDK Vite plugin is composed of several smaller, internal plugins. To debug them, you can use the [debug](https://www.npmjs.com/package/debug) package by setting the `DEBUG` environment variable.
 
+Each internal plugin has a unique namespace, like `rwsdk:vite:hmr-plugin`. To enable logging for a specific plugin, set the `DEBUG` variable to its namespace.
+
+For example, to see debug output from just the HMR plugin:
 ```sh
-rwsync
+DEBUG='rwsdk:vite:hmr-plugin'
 ```
 
-This will build the SDK, copy the relevant files into your project's `node_modules`, and then you can start your development server.
-
+You can also use a wildcard to enable logging for all internal Vite plugins:
 ```sh
-rwsync && npm run dev
+DEBUG='rwsdk:vite:*'
 ```
 
-### Watch Mode
+For more detailed "verbose" output, set the `VERBOSE` environment variable to `1`.
 
-For continuous development, you can use the watch mode. This will automatically sync changes from the SDK to your project whenever you save a file. You can also provide a command that will be automatically restarted after each sync.
-
+Here is a full example command that enables verbose logging for the HMR plugin, starts `rwsync` in watch mode to sync your local SDK changes with a test project, and redirects all output to a log file for analysis:
 ```sh
-# This will watch for changes, and cancel + re-run `pnpm dev` after each sync
-rwsync --watch "npm run dev"
+VERBOSE=1 DEBUG='rwsdk:vite:hmr-plugin' npx rwsync --watch "npm run dev" 2>&1 | tee /tmp/out.log
 ```
-
----
-
-## Under the hood
-
-### `rwsync`
-
-The `rwsync` script is used for testing out changes to a local checkout of the sdk repo to a RedwoodSDK project.
-
-#### Slow Sync (Full Install)
-
-A "slow sync" is performed whenever there is a change to the SDK's `package.json` file. This is the most robust method and ensures that any changes to dependencies (`dependencies`, `peerDependencies`, etc.) are correctly installed in your project.
-
-It works by:
-1. Running `pnpm build` in the SDK directory.
-2. Using `npm pack` to create a `.tgz` tarball of the SDK package.
-3. Installing this tarball in the target project using its native package manager (`npm`, `pnpm`, or `yarn`).
-4. Restoring the project's `package.json` and lockfile to their original state to avoid committing temporary changes.
-
-#### Fast Sync (File Copying)
-
-If only the code in the SDK has changed (but not its `package.json`), `rwsync` performs a "fast sync". This is much quicker and avoids the overhead of a full package installation.
-
-It works by:
-1. Running `pnpm build` in the SDK directory.
-2. Reading the `files` array from the SDK's `package.json`.
-3. Copying each file and directory listed in the `files` array directly into the project's `node_modules/rwsdk` directory.

--- a/sdk/src/vite/directivesPlugin.mts
+++ b/sdk/src/vite/directivesPlugin.mts
@@ -8,7 +8,6 @@ import { normalizeModulePath } from "./normalizeModulePath.mjs";
 import type { ViteDevServer } from "vite";
 
 const log = debug("rwsdk:vite:rsc-directives-plugin");
-const verboseLog = debug("verbose:rwsdk:vite:rsc-directives-plugin");
 
 const getLoader = (filePath: string) => {
   const ext = path.extname(filePath).slice(1);
@@ -120,11 +119,12 @@ export const directivesPlugin = ({
       });
     },
     async transform(code, id) {
-      verboseLog(
-        "Transform called for id=%s, environment=%s",
-        id,
-        this.environment.name,
-      );
+      process.env.VERBOSE &&
+        log(
+          "Transform called for id=%s, environment=%s",
+          id,
+          this.environment.name,
+        );
 
       const normalizedId = normalizeModulePath(projectRootDir, id);
 
@@ -158,7 +158,7 @@ export const directivesPlugin = ({
         };
       }
 
-      verboseLog("No transformation applied for id=%s", id);
+      process.env.VERBOSE && log("No transformation applied for id=%s", id);
     },
     configEnvironment(env, config) {
       log("Configuring environment: env=%s", env);
@@ -173,11 +173,12 @@ export const directivesPlugin = ({
           build.onLoad(
             { filter: /\.(js|ts|jsx|tsx|mts|mjs|cjs)$/ },
             async (args) => {
-              verboseLog(
-                "Esbuild onLoad called for environment=%s, path=%s",
-                env,
-                args.path,
-              );
+              process.env.VERBOSE &&
+                log(
+                  "Esbuild onLoad called for environment=%s, path=%s",
+                  env,
+                  args.path,
+                );
 
               const normalizedPath = normalizeModulePath(
                 projectRootDir,
@@ -244,11 +245,12 @@ export const directivesPlugin = ({
               try {
                 code = await fs.readFile(args.path, "utf-8");
               } catch {
-                verboseLog(
-                  "Failed to read file: %s, environment=%s",
-                  args.path,
-                  env,
-                );
+                process.env.VERBOSE &&
+                  log(
+                    "Failed to read file: %s, environment=%s",
+                    args.path,
+                    env,
+                  );
                 return undefined;
               }
 
@@ -269,12 +271,13 @@ export const directivesPlugin = ({
                   env,
                   args.path,
                 );
-                verboseLog(
-                  "Esbuild client component transformation for environment=%s, path=%s, code: %j",
-                  env,
-                  args.path,
-                  clientResult.code,
-                );
+                process.env.VERBOSE &&
+                  log(
+                    "Esbuild client component transformation for environment=%s, path=%s, code: %j",
+                    env,
+                    args.path,
+                    clientResult.code,
+                  );
                 return {
                   contents: clientResult.code,
                   loader: getLoader(args.path),
@@ -301,11 +304,12 @@ export const directivesPlugin = ({
                 };
               }
 
-              verboseLog(
-                "Esbuild no transformation applied for environment=%s, path=%s",
-                env,
-                args.path,
-              );
+              process.env.VERBOSE &&
+                log(
+                  "Esbuild no transformation applied for environment=%s, path=%s",
+                  env,
+                  args.path,
+                );
             },
           );
         },

--- a/sdk/src/vite/findSpecifiers.mts
+++ b/sdk/src/vite/findSpecifiers.mts
@@ -69,7 +69,7 @@ export function findImportSpecifiers(
 ): Array<{ s: number; e: number; raw: string }> {
   const ext = path.extname(id).toLowerCase();
   const lang = ext === ".tsx" || ext === ".jsx" ? Lang.Tsx : SgLang.TypeScript;
-  const logger = log ?? (() => {});
+  const logger = process.env.VERBOSE ? (log ?? (() => {})) : () => {};
   const results: Array<{ s: number; e: number; raw: string }> = [];
   try {
     // sgParse and lang must be provided by the consumer
@@ -140,7 +140,7 @@ export function findExports(
 ): ExportInfo[] {
   const ext = path.extname(id).toLowerCase();
   const lang = ext === ".tsx" || ext === ".jsx" ? Lang.Tsx : SgLang.TypeScript;
-  const logger = log ?? (() => {});
+  const logger = process.env.VERBOSE ? (log ?? (() => {})) : () => {};
   const results: ExportInfo[] = [];
   const seen = new Set<string>(); // Track seen exports to avoid duplicates
 

--- a/sdk/src/vite/findSsrSpecifiers.mts
+++ b/sdk/src/vite/findSsrSpecifiers.mts
@@ -15,7 +15,7 @@ export function findSsrImportSpecifiers(
 ): { imports: string[]; dynamicImports: string[] } {
   const ext = path.extname(id).toLowerCase();
   const lang = ext === ".tsx" || ext === ".jsx" ? Lang.Tsx : SgLang.TypeScript;
-  const logger = log ?? (() => {});
+  const logger = process.env.VERBOSE ? (log ?? (() => {})) : () => {};
   const imports: string[] = [];
   const dynamicImports: string[] = [];
 

--- a/sdk/src/vite/miniflareHMRPlugin.mts
+++ b/sdk/src/vite/miniflareHMRPlugin.mts
@@ -11,7 +11,7 @@ import { isJsFile } from "./isJsFile.mjs";
 import { invalidateModule } from "./invalidateModule.mjs";
 import { getShortName } from "../lib/getShortName.mjs";
 
-const verboseLog = debug("verbose:rwsdk:vite:hmr-plugin");
+const log = debug("rwsdk:vite:hmr-plugin");
 
 const hasDirective = async (filepath: string, directive: string) => {
   if (!isJsFile(filepath)) {
@@ -62,12 +62,16 @@ export const miniflareHMRPlugin = (givenOptions: {
         workerEntryPathname: entry,
       } = givenOptions;
 
-      verboseLog(
-        "Hot update: (env=%s) %s\nModule graph:\n\n%s",
-        this.environment.name,
-        ctx.file,
-        dumpFullModuleGraph(ctx.server, this.environment.name),
-      );
+      if (process.env.VERBOSE) {
+        this.environment.logger.info(
+          `Hot update: (env=${
+            this.environment.name
+          }) ${ctx.file}\nModule graph:\n\n${dumpFullModuleGraph(
+            ctx.server,
+            this.environment.name,
+          )}`,
+        );
+      }
 
       if (!["client", environment].includes(this.environment.name)) {
         return [];

--- a/sdk/src/vite/reactConditionsResolverPlugin.mts
+++ b/sdk/src/vite/reactConditionsResolverPlugin.mts
@@ -6,7 +6,6 @@ import enhancedResolve from "enhanced-resolve";
 import { ensureAliasArray } from "./ensureAliasArray.mjs";
 
 const log = debug("rwsdk:vite:react-conditions-resolver-plugin");
-const verboseLog = debug("verbose:rwsdk:vite:react-conditions-resolver-plugin");
 
 export const ENV_REACT_IMPORTS = {
   worker: [
@@ -58,26 +57,30 @@ export const ENV_IMPORT_MAPPINGS = Object.fromEntries(
 );
 
 function resolveEnvImportMappings(env: keyof typeof ENV_RESOLVERS) {
-  verboseLog("Resolving environment import mappings for env=%s", env);
+  process.env.VERBOSE &&
+    log("Resolving environment import mappings for env=%s", env);
 
   const mappings = new Map<string, string>();
   const reactImports = ENV_REACT_IMPORTS[env];
 
   for (const importRequest of reactImports) {
-    verboseLog("Resolving import request=%s for env=%s", importRequest, env);
+    process.env.VERBOSE &&
+      log("Resolving import request=%s for env=%s", importRequest, env);
 
     let resolved: string | false = false;
 
     try {
       resolved = ENV_RESOLVERS[env](ROOT_DIR, importRequest);
-      verboseLog(
-        "Successfully resolved %s to %s for env=%s",
-        importRequest,
-        resolved,
-        env,
-      );
+      process.env.VERBOSE &&
+        log(
+          "Successfully resolved %s to %s for env=%s",
+          importRequest,
+          resolved,
+          env,
+        );
     } catch {
-      verboseLog("Failed to resolve %s for env=%s", importRequest, env);
+      process.env.VERBOSE &&
+        log("Failed to resolve %s for env=%s", importRequest, env);
     }
 
     if (resolved) {
@@ -105,22 +108,24 @@ function createEsbuildResolverPlugin(envName: string) {
     name: `rwsdk:react-conditions-resolver-esbuild-${envName}`,
     setup(build: any) {
       build.onResolve({ filter: /.*/ }, (args: any) => {
-        verboseLog(
-          "ESBuild resolving %s for env=%s, args=%O",
-          args.path,
-          envName,
-          args,
-        );
+        process.env.VERBOSE &&
+          log(
+            "ESBuild resolving %s for env=%s, args=%O",
+            args.path,
+            envName,
+            args,
+          );
 
         const resolved = mappings.get(args.path);
 
         if (resolved && args.importer !== "") {
-          verboseLog(
-            "ESBuild resolving %s -> %s for env=%s",
-            args.path,
-            resolved,
-            envName,
-          );
+          process.env.VERBOSE &&
+            log(
+              "ESBuild resolving %s -> %s for env=%s",
+              args.path,
+              resolved,
+              envName,
+            );
           if (args.path === "react-server-dom-webpack/client.edge") {
             return;
           }
@@ -128,11 +133,12 @@ function createEsbuildResolverPlugin(envName: string) {
             path: resolved,
           };
         } else {
-          verboseLog(
-            "ESBuild no resolution found for %s for env=%s",
-            args.path,
-            envName,
-          );
+          process.env.VERBOSE &&
+            log(
+              "ESBuild no resolution found for %s for env=%s",
+              args.path,
+              envName,
+            );
         }
       });
     },
@@ -228,17 +234,19 @@ export const reactConditionsResolverPlugin = (): Plugin[] => {
           return;
         }
 
-        verboseLog(
-          "Resolving id=%s, environment=%s, importer=%s",
-          id,
-          envName,
-          importer,
-        );
+        process.env.VERBOSE &&
+          log(
+            "Resolving id=%s, environment=%s, importer=%s",
+            id,
+            envName,
+            importer,
+          );
 
         const mappings = ENV_IMPORT_MAPPINGS[envName];
 
         if (!mappings) {
-          verboseLog("No mappings found for environment: %s", envName);
+          process.env.VERBOSE &&
+            log("No mappings found for environment: %s", envName);
           return;
         }
 
@@ -249,7 +257,8 @@ export const reactConditionsResolverPlugin = (): Plugin[] => {
           return resolved;
         }
 
-        verboseLog("No resolution found for id=%s in env=%s", id, envName);
+        process.env.VERBOSE &&
+          log("No resolution found for id=%s in env=%s", id, envName);
       },
     },
   ];

--- a/sdk/src/vite/ssrBridgePlugin.mts
+++ b/sdk/src/vite/ssrBridgePlugin.mts
@@ -4,7 +4,6 @@ import { SSR_BRIDGE_PATH } from "../lib/constants.mjs";
 import { findSsrImportSpecifiers } from "./findSsrSpecifiers.mjs";
 
 const log = debug("rwsdk:vite:ssr-bridge-plugin");
-const verboseLog = debug("verbose:rwsdk:vite:ssr-bridge-plugin");
 
 export const VIRTUAL_SSR_PREFIX = "virtual:rwsdk:ssr:";
 
@@ -58,11 +57,12 @@ export const ssrBridgePlugin = ({
               "Setting up esbuild plugin to mark rwsdk/__ssr paths as external for worker",
             );
             build.onResolve({ filter: /.*$/ }, (args) => {
-              verboseLog(
-                "Esbuild onResolve called for path=%s, args=%O",
-                args.path,
-                args,
-              );
+              process.env.VERBOSE &&
+                log(
+                  "Esbuild onResolve called for path=%s, args=%O",
+                  args.path,
+                  args,
+                );
 
               if (args.path === "rwsdk/__ssr_bridge") {
                 log("Marking as external: %s", args.path);
@@ -79,12 +79,13 @@ export const ssrBridgePlugin = ({
       }
     },
     async resolveId(id) {
-      verboseLog(
-        "Resolving id=%s, environment=%s, isDev=%s",
-        id,
-        this.environment?.name,
-        isDev,
-      );
+      process.env.VERBOSE &&
+        log(
+          "Resolving id=%s, environment=%s, isDev=%s",
+          id,
+          this.environment?.name,
+          isDev,
+        );
 
       if (isDev) {
         // context(justinvdm, 27 May 2025): In dev, we need to dynamically load
@@ -124,15 +125,16 @@ export const ssrBridgePlugin = ({
         }
       }
 
-      verboseLog("No resolution for id=%s", id);
+      process.env.VERBOSE && log("No resolution for id=%s", id);
     },
     async load(id) {
-      verboseLog(
-        "Loading id=%s, isDev=%s, environment=%s",
-        id,
-        isDev,
-        this.environment.name,
-      );
+      process.env.VERBOSE &&
+        log(
+          "Loading id=%s, isDev=%s, environment=%s",
+          id,
+          isDev,
+          this.environment.name,
+        );
 
       if (
         id.startsWith(VIRTUAL_SSR_PREFIX) &&
@@ -146,7 +148,8 @@ export const ssrBridgePlugin = ({
           log("Dev mode: fetching SSR module for realPath=%s", realId);
           const result = await devServer?.environments.ssr.fetchModule(realId);
 
-          verboseLog("Fetch module result: id=%s, result=%O", realId, result);
+          process.env.VERBOSE &&
+            log("Fetch module result: id=%s, result=%O", realId, result);
 
           const code = "code" in result ? result.code : undefined;
           log("Fetched SSR module code length: %d", code?.length || 0);
@@ -154,7 +157,7 @@ export const ssrBridgePlugin = ({
           const { imports, dynamicImports } = findSsrImportSpecifiers(
             realId,
             code || "",
-            verboseLog,
+            log,
           );
 
           const allSpecifiers = [...new Set([...imports, ...dynamicImports])];
@@ -181,17 +184,18 @@ ${switchCases}
 
           log("Transformed SSR module code length: %d", transformedCode.length);
 
-          verboseLog(
-            "Transformed SSR module code for realId=%s: %s",
-            realId,
-            transformedCode,
-          );
+          process.env.VERBOSE &&
+            log(
+              "Transformed SSR module code for realId=%s: %s",
+              realId,
+              transformedCode,
+            );
 
           return transformedCode;
         }
       }
 
-      verboseLog("No load handling for id=%s", id);
+      process.env.VERBOSE && log("No load handling for id=%s", id);
     },
   };
 

--- a/sdk/src/vite/transformServerFunctions.mts
+++ b/sdk/src/vite/transformServerFunctions.mts
@@ -6,7 +6,6 @@ import { parse as sgParse, Lang as SgLang, Lang } from "@ast-grep/napi";
 import path from "path";
 
 const log = debug("rwsdk:vite:transform-server-functions");
-const verboseLog = debug("verbose:rwsdk:vite:transform-server-functions");
 
 interface TransformResult {
   code: string;
@@ -33,12 +32,12 @@ export const findExportInfo = (
   code: string,
   normalizedId?: string,
 ): ExportInfoCompat => {
-  verboseLog("Finding exported functions in source file");
+  process.env.VERBOSE && log("Finding exported functions in source file");
 
   const localFunctions = new Set<string>();
   const reExports: ExportInfoCompat["reExports"] = [];
 
-  const exportInfos = findExports(normalizedId || "file.ts", code, verboseLog);
+  const exportInfos = findExports(normalizedId || "file.ts", code, log);
 
   for (const exportInfo of exportInfos) {
     if (exportInfo.isReExport && exportInfo.moduleSpecifier) {
@@ -58,15 +57,17 @@ export const findExportInfo = (
         originalName: originalName,
         moduleSpecifier: exportInfo.moduleSpecifier,
       });
-      verboseLog(
-        "Found re-exported function: %s (original: %s) from %s",
-        exportInfo.name,
-        originalName,
-        exportInfo.moduleSpecifier,
-      );
+      process.env.VERBOSE &&
+        log(
+          "Found re-exported function: %s (original: %s) from %s",
+          exportInfo.name,
+          originalName,
+          exportInfo.moduleSpecifier,
+        );
     } else {
       localFunctions.add(exportInfo.name);
-      verboseLog("Found exported function: %s", exportInfo.name);
+      process.env.VERBOSE &&
+        log("Found exported function: %s", exportInfo.name);
     }
   }
 
@@ -102,7 +103,7 @@ function findDefaultFunctionName(
       return nameCapture?.text() || null;
     }
   } catch (err) {
-    verboseLog("Error finding default function name: %O", err);
+    process.env.VERBOSE && log("Error finding default function name: %O", err);
   }
   return null;
 }
@@ -128,7 +129,7 @@ function hasDefaultExport(code: string, normalizedId: string): boolean {
       }
     }
   } catch (err) {
-    verboseLog("Error checking for default export: %O", err);
+    process.env.VERBOSE && log("Error checking for default export: %O", err);
   }
   return false;
 }
@@ -140,19 +141,21 @@ export const transformServerFunctions = (
   serverFiles?: Set<string>,
   addServerModule?: (environment: string, id: string) => void,
 ): TransformResult | undefined => {
-  verboseLog(
-    "Transform server functions called for normalizedId=%s, environment=%s",
-    normalizedId,
-    environment,
-  );
+  process.env.VERBOSE &&
+    log(
+      "Transform server functions called for normalizedId=%s, environment=%s",
+      normalizedId,
+      environment,
+    );
 
   if (!hasDirective(code, "use server")) {
     log("Skipping: no 'use server' directive in id=%s", normalizedId);
-    verboseLog(
-      ":VERBOSE: Returning code unchanged for id=%s:\n%s",
-      normalizedId,
-      code,
-    );
+    process.env.VERBOSE &&
+      log(
+        ":VERBOSE: Returning code unchanged for id=%s:\n%s",
+        normalizedId,
+        code,
+      );
     return;
   }
 
@@ -239,10 +242,11 @@ export const transformServerFunctions = (
       const start = match.index;
       const end = match.index + match[0].length;
       s.remove(start, end);
-      verboseLog(
-        "Removed 'use server' directive from normalizedId=%s",
-        normalizedId,
-      );
+      process.env.VERBOSE &&
+        log(
+          "Removed 'use server' directive from normalizedId=%s",
+          normalizedId,
+        );
       break; // Only remove the first one
     }
 
@@ -358,7 +362,8 @@ export const transformServerFunctions = (
           }
         }
       } catch (err) {
-        verboseLog("Error processing default function: %O", err);
+        process.env.VERBOSE &&
+          log("Error processing default function: %O", err);
       }
     }
 
@@ -431,11 +436,12 @@ export const transformServerFunctions = (
     };
   }
 
-  verboseLog(
-    "No transformation applied for environment=%s, normalizedId=%s",
-    environment,
-    normalizedId,
-  );
+  process.env.VERBOSE &&
+    log(
+      "No transformation applied for environment=%s, normalizedId=%s",
+      environment,
+      normalizedId,
+    );
 };
 
 export type { TransformResult };


### PR DESCRIPTION
Our current convention of enabling verbose logs (added by me) is convoluted - we need to opt into specific verbose logs by copying the relevant `verbose:` prefix-ed namespace.

This PR lets us do this

```sh
VERBOSE=1 DEBUG='rwsdk:vite:hmr-plugin' npx rwsync --watch "npm run dev" 2>&1 | tee /tmp/out.log
```

It also adds some docs on using `DEBUG=...` in `CONTRIBUTION.md`