### PR TITLE
fix: Fixes and improvements for HMR and module graph

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,8 +205,8 @@ importers:
   starters/minimal:
     dependencies:
       rwsdk:
-        specifier: 0.1.15
-        version: 0.1.15(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0)
+        specifier: 0.1.15-test.20250714213423
+        version: 0.1.15-test.20250714213423(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0)
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 1.7.4
@@ -248,8 +248,8 @@ importers:
         specifier: ^13.1.1
         version: 13.1.1
       rwsdk:
-        specifier: 0.1.15
-        version: 0.1.15(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0)
+        specifier: 0.1.15-test.20250714213423
+        version: 0.1.15-test.20250714213423(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0)
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 1.7.4
@@ -3602,8 +3602,8 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
-  rwsdk@0.1.15:
-    resolution: {integrity: sha512-U36D06WkTh/K1NBOxVraPBxsPycjrXDpM+KuCFgvwye4zRKpLgXRdlEv87anSKE+25RRXj8tZ0OUj/3gkgqmag==}
+  rwsdk@0.1.15-test.20250714213423:
+    resolution: {integrity: sha512-AQVt/Pev0TfENYGfTxxo3wYXI5pi9MMQnc4JjxOjpgjCwZiE6rx4J8pJ3tnKMwO1uhht9UJgIdiKMdAv1gouUQ==}
     hasBin: true
     peerDependencies:
       vite: ^6.2.6
@@ -8351,7 +8351,7 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  rwsdk@0.1.15(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0):
+  rwsdk@0.1.15-test.20250714213423(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0):
     dependencies:
       '@ast-grep/napi': 0.38.5
       '@cloudflare/vite-plugin': 1.7.4(rollup@4.40.0)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(workerd@1.20250617.0)(wrangler@4.20.5(@cloudflare/workers-types@4.20250407.0))

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rwsdk",
-  "version": "0.1.15",
+  "version": "0.1.15-test.20250714213423",
   "description": "Build fast, server-driven webapps on Cloudflare with SSR, RSC, and realtime",
   "type": "module",
   "bin": {

--- a/sdk/src/runtime/imports/client.ts
+++ b/sdk/src/runtime/imports/client.ts
@@ -6,7 +6,7 @@ export const loadModule = memoize(async (id: string) => {
     return await import(/* @vite-ignore */ id);
   } else {
     const { useClientLookup } = await import(
-      "virtual:use-client-lookup" as string
+      "virtual:use-client-lookup.js" as string
     );
 
     const moduleFn = useClientLookup[id];

--- a/sdk/src/runtime/imports/ssr.ts
+++ b/sdk/src/runtime/imports/ssr.ts
@@ -2,7 +2,7 @@ import memoize from "lodash/memoize";
 
 export const ssrLoadModule = memoize(async (id: string) => {
   const { useClientLookup } = await import(
-    "virtual:use-client-lookup" as string
+    "virtual:use-client-lookup.js" as string
   );
 
   const moduleFn = useClientLookup[id];

--- a/sdk/src/runtime/imports/worker.ts
+++ b/sdk/src/runtime/imports/worker.ts
@@ -4,7 +4,7 @@ import { ssrWebpackRequire as baseSsrWebpackRequire } from "rwsdk/__ssr_bridge";
 
 export const loadServerModule = memoize(async (id: string) => {
   const { useServerLookup } = await import(
-    "virtual:use-server-lookup" as string
+    "virtual:use-server-lookup.js" as string
   );
 
   const moduleFn = useServerLookup[id];

--- a/sdk/src/runtime/register/ssr.ts
+++ b/sdk/src/runtime/register/ssr.ts
@@ -3,7 +3,7 @@ import { createServerReference as baseCreateServerReference } from "react-server
 
 export const loadServerModule = memoize(async (id: string) => {
   const { useServerLookup } = await import(
-    "virtual:use-server-lookup" as string
+    "virtual:use-server-lookup.js" as string
   );
 
   const moduleFn = useServerLookup[id];

--- a/sdk/src/vite/createDirectiveLookupPlugin.mts
+++ b/sdk/src/vite/createDirectiveLookupPlugin.mts
@@ -271,7 +271,7 @@ export const createDirectiveLookupPlugin = async ({
           build.onResolve(
             {
               filter: new RegExp(
-                `^(${escapedVirtualModuleName}|${escapedPrefixedModuleName})$`,
+                `^(${escapedVirtualModuleName}|${escapedPrefixedModuleName})\.js$`,
               ),
             },
             () => {
@@ -281,7 +281,7 @@ export const createDirectiveLookupPlugin = async ({
                   config.virtualModuleName,
                 );
               return {
-                path: config.virtualModuleName,
+                path: `${config.virtualModuleName}.js`,
                 external: true,
               };
             },
@@ -318,15 +318,11 @@ export const createDirectiveLookupPlugin = async ({
     resolveId(source) {
       process.env.VERBOSE && log("Resolving id=%s", source);
 
-      if (
-        source === config.virtualModuleName ||
-        source === `/@id/${config.virtualModuleName}` ||
-        source === `/@id/${config.virtualModuleName}.js`
-      ) {
+      if (source === `${config.virtualModuleName}.js`) {
         log("Resolving %s module", config.virtualModuleName);
         // context(justinvdm, 16 Jun 2025): Include .js extension
         // so it goes through vite processing chain
-        return `${config.virtualModuleName}.js`;
+        return source;
       }
 
       process.env.VERBOSE && log("No resolution for id=%s", source);

--- a/sdk/src/vite/findSsrSpecifiers.mts
+++ b/sdk/src/vite/findSsrSpecifiers.mts
@@ -23,19 +23,19 @@ export function findSsrImportSpecifiers(
     const root = sgParse(lang, code);
     const patterns = [
       {
-        pattern: `__vite_ssr_import__("$SPECIFIER")`,
+        pattern: `__vite_ssr_import__("$SPECIFIER", $$$REST)`,
         list: imports,
       },
       {
-        pattern: `__vite_ssr_import__('$SPECIFIER')`,
+        pattern: `__vite_ssr_import__('$SPECIFIER', $$$REST)`,
         list: imports,
       },
       {
-        pattern: `__vite_ssr_dynamic_import__("$SPECIFIER")`,
+        pattern: `__vite_ssr_dynamic_import__("$SPECIFIER", $$$REST)`,
         list: dynamicImports,
       },
       {
-        pattern: `__vite_ssr_dynamic_import__('$SPECIFIER')`,
+        pattern: `__vite_ssr_dynamic_import__('$SPECIFIER', $$$REST)`,
         list: dynamicImports,
       },
     ];

--- a/sdk/src/vite/findSsrSpecifiers.mts
+++ b/sdk/src/vite/findSsrSpecifiers.mts
@@ -23,6 +23,22 @@ export function findSsrImportSpecifiers(
     const root = sgParse(lang, code);
     const patterns = [
       {
+        pattern: `__vite_ssr_import__("$SPECIFIER")`,
+        list: imports,
+      },
+      {
+        pattern: `__vite_ssr_import__('$SPECIFIER')`,
+        list: imports,
+      },
+      {
+        pattern: `__vite_ssr_dynamic_import__("$SPECIFIER")`,
+        list: dynamicImports,
+      },
+      {
+        pattern: `__vite_ssr_dynamic_import__('$SPECIFIER')`,
+        list: dynamicImports,
+      },
+      {
         pattern: `__vite_ssr_import__("$SPECIFIER", $$$REST)`,
         list: imports,
       },

--- a/sdk/src/vite/miniflareHMRPlugin.mts
+++ b/sdk/src/vite/miniflareHMRPlugin.mts
@@ -63,7 +63,7 @@ export const miniflareHMRPlugin = (givenOptions: {
       } = givenOptions;
 
       if (process.env.VERBOSE) {
-        this.environment.logger.info(
+        log(
           `Hot update: (env=${
             this.environment.name
           }) ${ctx.file}\nModule graph:\n\n${dumpFullModuleGraph(
@@ -137,33 +137,30 @@ export const miniflareHMRPlugin = (givenOptions: {
         ) ?? [],
       );
 
+      console.log("######", ctx.file, this.environment.name);
       const isWorkerUpdate =
         ctx.file === entry ||
         modules.some((module) => hasEntryAsAncestor(module, entry));
-
-      // The worker doesnt need an update
-      // => Short circuit HMR
-      if (!isWorkerUpdate) {
-        return [];
-      }
 
       // The worker needs an update, but this is the client environment
       // => Notify for HMR update of any css files imported by in worker, that are also in the client module graph
       // Why: There may have been changes to css classes referenced, which might css modules to change
       if (this.environment.name === "client") {
-        for (const [_, module] of ctx.server.environments[environment]
-          .moduleGraph.idToModuleMap) {
-          // todo(justinvdm, 13 Dec 2024): We check+update _all_ css files in worker module graph,
-          // but it could just be a subset of css files that are actually affected, depending
-          // on the importers and imports of the changed file. We should be smarter about this.
-          if (module.file && module.file.endsWith(".css")) {
-            const clientModules =
-              ctx.server.environments.client.moduleGraph.getModulesByFile(
-                module.file,
-              );
+        if (isWorkerUpdate) {
+          for (const [_, module] of ctx.server.environments[environment]
+            .moduleGraph.idToModuleMap) {
+            // todo(justinvdm, 13 Dec 2024): We check+update _all_ css files in worker module graph,
+            // but it could just be a subset of css files that are actually affected, depending
+            // on the importers and imports of the changed file. We should be smarter about this.
+            if (module.file && module.file.endsWith(".css")) {
+              const clientModules =
+                ctx.server.environments.client.moduleGraph.getModulesByFile(
+                  module.file,
+                );
 
-            for (const clientModule of clientModules ?? []) {
-              invalidateModule(ctx.server, "client", clientModule);
+              for (const clientModule of clientModules ?? []) {
+                invalidateModule(ctx.server, "client", clientModule);
+              }
             }
           }
         }

--- a/starters/minimal/package.json
+++ b/starters/minimal/package.json
@@ -22,7 +22,7 @@
     "types": "tsc"
   },
   "dependencies": {
-    "rwsdk": "0.1.15"
+    "rwsdk": "0.1.15-test.20250714213423"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.7.4",

--- a/starters/standard/package.json
+++ b/starters/standard/package.json
@@ -31,7 +31,7 @@
     "@prisma/client": "~6.8.2",
     "@simplewebauthn/browser": "^13.1.0",
     "@simplewebauthn/server": "^13.1.1",
-    "rwsdk": "0.1.15"
+    "rwsdk": "0.1.15-test.20250714213423"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.7.4",


### PR DESCRIPTION
## Fix module graph for SSR modules
### Context
To support SSR having its own module resolution behaviour (e.g. not using `react-server` import condition or RSC react runtimes) while still existing in the same runtime env as the rest of the worker (where `react-sever` import condition and RSC react runtimes should apply), we have separate `worker` and `ssr` environments, then have an "ssr bridge" concept: in the `worker` environment, for all modules to be evaluated in SSR context, we fetch code from the `ssr` environment for that module.

We parse the code we fetch from the SSR environment to find all imports vite does (`__vite_ssr_import__`, `__vite_ssr_dynamic_import__`), and add `import`s for these fetches so that vite will build the module graph correctly.

### The fix
There was a bug in the way we parse the vite SSR imports - we weren't matching on cases where there were extra arguments being passed to these functions. As a result, vite wasn't able to construct the module graph correctly. Ultimately, this meant that when some modules were invalidated, their importers should have been invalidated too, but werent (since the link between them in the graph wasn't there).

## Invalidate explicitly for SSR
On changes to files in SSR graph, we now invalidate the relevant module and as well as its importers (recursively), then invalidate the same way for the corresponding virtual modules in the worker module graph, as well as its importers (also recursively).

## Better client module invalidation
We now:
* look at all client updates - rather than only ones that were also worker updates as we did previously; then
* invalid all the modules vite tells us where relevant when a file changes - previously we'd pass control on to vite's own HMR invalidation logic for use client modules and css files, and otherwise short circuit, but this turns out to be necessary

## Improvement: Avoid redundant logic for client/server lookups
We maintain "lookup" modules for modules with `use client` and `use server` directives, in order to find and import them on demand when RSC needs them. We were handling different variations on how these modules might be resolved (with/without `/@id/`, with/without `.js). We now instead avoid the possibility of there being multiple ways for these to be resolved, so that there's only one request id every specified for each - `virtual:use-client-lookup.js` and `virtual:use-server-lookup.js`) => we were able to remove complexity by only needing to resolve these modules 1 way instead of multiple different ways.