### PR TITLE
fix: More HMR fixes for robustness

### DIFF
--- a/sdk/src/vite/miniflareHMRPlugin.mts
+++ b/sdk/src/vite/miniflareHMRPlugin.mts
@@ -73,21 +73,6 @@ export const miniflareHMRPlugin = (givenOptions: {
         );
       }
 
-      if (this.environment.name === "ssr") {
-        log("SSR update, invalidating recursively", ctx.file);
-        invalidateModule(ctx.server, "ssr", ctx.file, {
-          invalidateImportersRecursively: true,
-        });
-        invalidateModule(
-          ctx.server,
-          environment,
-          VIRTUAL_SSR_PREFIX +
-            normalizeModulePath(givenOptions.rootDir, ctx.file),
-          { invalidateImportersRecursively: true },
-        );
-        return [];
-      }
-
       if (!["client", environment].includes(this.environment.name)) {
         return [];
       }
@@ -177,6 +162,7 @@ export const miniflareHMRPlugin = (givenOptions: {
               }
             }
           }
+          return undefined;
         }
 
         return ctx.modules;

--- a/sdk/src/vite/miniflareHMRPlugin.mts
+++ b/sdk/src/vite/miniflareHMRPlugin.mts
@@ -45,6 +45,40 @@ const hasEntryAsAncestor = (
   return false;
 };
 
+const isInUseClientGraph = ({
+  file,
+  clientFiles,
+  server,
+}: {
+  file: string;
+  clientFiles: Set<string>;
+  server: ViteDevServer;
+}) => {
+  const id = normalizeModulePath(server.config.root, file);
+  if (clientFiles.has(id)) {
+    return true;
+  }
+
+  const modules = server.environments.client.moduleGraph.getModulesByFile(file);
+
+  if (!modules) {
+    return false;
+  }
+
+  for (const m of modules) {
+    for (const importer of m.importers) {
+      if (
+        importer.file &&
+        isInUseClientGraph({ file: importer.file, clientFiles, server })
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+};
+
 export const miniflareHMRPlugin = (givenOptions: {
   clientFiles: Set<string>;
   serverFiles: Set<string>;
@@ -71,6 +105,32 @@ export const miniflareHMRPlugin = (givenOptions: {
             this.environment.name,
           )}`,
         );
+      }
+
+      if (!isJsFile(ctx.file) && !ctx.file.endsWith(".css")) {
+        return;
+      }
+
+      if (this.environment.name === "ssr") {
+        log("SSR update, invalidating recursively", ctx.file);
+        const isUseClientUpdate = isInUseClientGraph({
+          file: ctx.file,
+          clientFiles,
+          server: ctx.server,
+        });
+
+        if (!isUseClientUpdate) {
+          return [];
+        }
+
+        invalidateModule(ctx.server, "ssr", ctx.file);
+        invalidateModule(
+          ctx.server,
+          environment,
+          VIRTUAL_SSR_PREFIX +
+            normalizeModulePath(givenOptions.rootDir, ctx.file),
+        );
+        return [];
       }
 
       if (!["client", environment].includes(this.environment.name)) {
@@ -137,9 +197,7 @@ export const miniflareHMRPlugin = (givenOptions: {
         ) ?? [],
       );
 
-      const isWorkerUpdate =
-        ctx.file === entry ||
-        modules.some((module) => hasEntryAsAncestor(module, entry));
+      const isWorkerUpdate = Boolean(modules);
 
       // The worker needs an update, but this is the client environment
       // => Notify for HMR update of any css files imported by in worker, that are also in the client module graph
@@ -162,7 +220,16 @@ export const miniflareHMRPlugin = (givenOptions: {
               }
             }
           }
-          return undefined;
+        }
+
+        const isUseClientUpdate = isInUseClientGraph({
+          file: ctx.file,
+          clientFiles,
+          server: ctx.server,
+        });
+
+        if (!isUseClientUpdate && !ctx.file.endsWith(".css")) {
+          return [];
         }
 
         return ctx.modules;


### PR DESCRIPTION
## Avoid js transforms for css
### Context
To support SSR having its own module resolution behaviour (e.g. not using `react-server` import condition or RSC react runtimes) while still existing in the same runtime env as the rest of the worker (where `react-sever` import condition and RSC react runtimes should apply), we have separate `worker` and `ssr` environments, then have an "ssr bridge" concept: in the `worker` environment, for all modules to be evaluated in SSR context, we fetch code from the `ssr` environment for that module.

We parse the code we fetch from the SSR environment to find all imports vite does (`__vite_ssr_import__`, `__vite_ssr_dynamic_import__`), and add `import`s for these fetches so that vite will build the module graph correctly.

### The fix
We do this fetching and transforming too for css modules too - except in these cases the result of the fetch is an empty string, and should remain that way rather than getting any other code added to it, in order to avoid adding js to the css.

## Opt out of custom HMR logic for non js and css files
If the js files are not js (e.g. js, jsx, mjs, cjs, ts, mts, etc) and not css, we should ignore them and pass control on to other plugins. We were trying to process .sqlite files during HMR, for e.g, which was resulting in HMR of these modules causing miniflare to crash.

## Skip HMR for SSR env when files are not in "use client" import chains
HMR for SSR should only look at "use client" files, or files imported by "use client" files. It was processing for other files (e.g. .sqlite files - while we avoid non js/css files now regardless, it still shows the need for more thorough checking for the use client graph for HMR in SSR env).

## Skip HMR for client env when files are not in "use client" import chains
It is possible for the client environment to contain files that are neither marked with "use client" nor imported by files that are. For example, if there is a style.css imported in worker module graph. For this specific example, to be honest, I'm not entirely sure why for this example case, I noticed this when inspecting the module graph. Regardless, it shows the need for more thorough checking for whether the module is in fact part of "use client" import chains.

For this reason, we short circuit HMR for the client env if we the file is not in a "use client" import chain.

## Avoid recursive invalidating for SSR modules
Turns out we only need to invalidate the SSR modules themselves - not their importers as well - for HMR to work correctly for SSR.