### PR TITLE
fix: follow server redirects in client navigation

### DIFF
--- a/sdk/src/runtime/clientNavigation.ts
+++ b/sdk/src/runtime/clientNavigation.ts
@@ -38,7 +38,7 @@ export function validateClickEvent(event: MouseEvent, target: HTMLElement) {
 
 export function initClientNavigation(
   opts: {
-    onNavigate: () => void;
+    onNavigate: () => Promise<void>;
   } = {
     onNavigate: async function onNavigate() {
       // @ts-expect-error

--- a/sdk/src/runtime/clientNavigation.ts
+++ b/sdk/src/runtime/clientNavigation.ts
@@ -46,6 +46,11 @@ export function initClientNavigation(
     },
   },
 ) {
+  if (document.body.getAttribute("data-rw-init-client-nav") === "true") {
+    return;
+  }
+
+  document.body.setAttribute("data-rw-init-client-nav", "true");
   // Intercept all anchor tag clicks
   document.addEventListener(
     "click",


### PR DESCRIPTION
Closes #601

- Client navigation is now expected to be initialized with `initClient({ spaMode: true })`
- This flag is used to alter the behavior of fetch transport to follow redirects in the response recursively
- For backwards compatibility, adds a check to avoid initializing client navigation more than once
- Update the type of `onNavigate` to be a promise

I dug into this without seeing #603 😅. But if I understand correctly, my approach is different and as a result, client side rendering remains possible across same origin redirects.

I also figured that given cross-origin server redirects are acceptable with server navigation, it would make sense to gracefully fall back to server redirects when we encounter them. This is now done by catching the CORS error and falling back to browser navigation.

Unfortunately there's no way to see the location of a cross origin redirect in a fetch response, so the check is for a generic `TypeError: Failed to fetch`. However the fallback behavior is simply to reload the window at the originally requested url on the site's origin, so I don't see this being an issue.

This is working nicely from my perspective as a dev user. But if this doesn't make sense as a contribution I'm happy to make changes.

https://github.com/user-attachments/assets/df004862-8a76-4b99-8f78-d96a7efe873a

