### PR TITLE
Get rwsdk/db working with addon-testimonials

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,18 @@ Running this workflow does the following:
 *   Deletes the corresponding GitHub Release. If the deleted release was marked as "latest," the workflow automatically finds the most recent stable release and promotes it to "latest".
 *   Deletes the corresponding git tag from the remote repository.
 
+### Creating a Test Release from a Branch
+Sometimes you have changes made in your branch and would like to test them out or share them with others before making a new release. To create a test release from a branch to test changes:
+
+1.  In the GitHub UI, navigate to the [Release workflow](.github/workflows/release.yml).
+2.  From the "Use workflow from" dropdown, select the branch with the changes you want to test.
+3.  Choose `test` as the `version_type`.
+4.  Run the workflow.
+
+The easiest way to get the version string (e.g., `0.1.19-test.20250717130914`) is from the npm email notification. Alternatively, the workflow output will contain a line: `✨ Done! Released version 0.1.19-test.20250717130914`.
+
+Test releases receive special handling. They are published to npm under the `test` tag, but the release commit itself is not pushed to any branch. Instead, the script creates a release commit, tags it, and pushes *only the tag* to the remote. The local branch is then reset to its previous state. This makes the release commit available on the remote, referenced only by its tag, without including it in the main branch history.
+
 #### Why Deprecate Instead of Unpublish?
 
 This project uses `npm deprecate` instead of `npm unpublish` because unpublishing is highly restrictive and can be unreliable in an automated CI environment. The npm registry has strict policies to prevent breaking the package ecosystem:
@@ -132,9 +144,3 @@ The release workflow and underlying script (`sdk/sdk/scripts/release.sh`) follow
 7.  **Rollback**: If any step fails, the script reverts the version commit and cleans up all temporary files, leaving the repository in a clean state.
 
 #### Test Releases
-
-Test releases receive special handling. They are published to npm under the `test` tag, but the release commit itself is not pushed to any branch. Instead, the script creates a release commit, tags it, and pushes *only the tag* to the remote. The local branch is then reset to its previous state. This makes the release commit available on the remote, referenced only by its tag, without including it in the main branch history.
-
-### GitHub Token
-
-The release workflow requires a GitHub personal access token (PAT) with `repo` scope to be configured as a repository secret named `GH_TOKEN_FOR_RELEASES`. This is necessary for the workflow to push version bump commits and tags.

--- a/docs/src/content/docs/core/database-do.mdx
+++ b/docs/src/content/docs/core/database-do.mdx
@@ -329,14 +329,14 @@ export async function getAllTestimonials() {
       jsonObjectFrom(
         eb
           .selectFrom("testimonial_statuses")
-          .selectAll()
+          .select(["id", "name"])
           .whereRef("testimonial_statuses.id", "=", "testimonials.statusId")
       ).as("status"),
       // Embed the related source object (many-to-one)
       jsonObjectFrom(
         eb
           .selectFrom("testimonial_sources")
-          .selectAll()
+          .select(["id", "name"])
           .whereRef("testimonial_sources.id", "=", "testimonials.sourceId")
       ).as("source"),
       // Embed an array of related tags (many-to-many)

--- a/docs/src/content/docs/core/database-do.mdx
+++ b/docs/src/content/docs/core/database-do.mdx
@@ -276,6 +276,113 @@ export async function getUserCredentials(
 
 ---
 
+## Patterns
+
+### Nesting Relational Data (ORM-like Behavior)
+
+While `rwsdk/db` uses a query builder instead of a full ORM, you can still structure your query results to include nested relational data. This is useful for avoiding N+1 query problems and for shaping data directly in the database layer. Kysely provides helper functions like `jsonObjectFrom` and `jsonArrayFrom` that make this easy.
+
+Here's an example that fetches testimonials and nests the related `status`, `source`, and `tags` information within each testimonial object.
+
+**1. The Schema**
+
+First, let's assume a schema with testimonials, statuses, sources, and a many-to-many relationship with tags.
+
+```ts title="src/db/migrations.ts"
+// Abridged for clarity
+await db.schema
+  .createTable("testimonials")
+  // ... other columns
+  .addColumn("sourceId", "integer", (col) =>
+    col.notNull().references("testimonial_sources.id")
+  )
+  .addColumn("statusId", "integer", (col) =>
+    col.notNull().references("testimonial_statuses.id")
+  )
+  .execute();
+
+await db.schema
+  .createTable("testimonial_taggings")
+  .addColumn("testimonialId", "text", (col) =>
+    col.notNull().references("testimonials.id")
+  )
+  .addColumn("tagId", "integer", (col) =>
+    col.notNull().references("testimonial_tags.id")
+  )
+  .execute();
+```
+
+**2. The Query**
+
+With the schema in place, you can write a query to fetch testimonials and embed the related data.
+
+```ts title="src/db/queries.ts"
+import { db } from "@/db";
+import { jsonObjectFrom, jsonArrayFrom } from "kysely/helpers/sqlite";
+
+export async function getAllTestimonials() {
+  return await db
+    .selectFrom("testimonials")
+    .selectAll("testimonials")
+    .select((eb) => [
+      // Embed the related status object (many-to-one)
+      jsonObjectFrom(
+        eb
+          .selectFrom("testimonial_statuses")
+          .selectAll()
+          .whereRef("testimonial_statuses.id", "=", "testimonials.statusId")
+      ).as("status"),
+      // Embed the related source object (many-to-one)
+      jsonObjectFrom(
+        eb
+          .selectFrom("testimonial_sources")
+          .selectAll()
+          .whereRef("testimonial_sources.id", "=", "testimonials.sourceId")
+      ).as("source"),
+      // Embed an array of related tags (many-to-many)
+      jsonArrayFrom(
+        eb
+          .selectFrom("testimonial_taggings")
+          .innerJoin(
+            "testimonial_tags",
+            "testimonial_tags.id",
+            "testimonial_taggings.tagId"
+          )
+          .select(["testimonial_tags.id", "testimonial_tags.name"])
+          .whereRef(
+            "testimonial_taggings.testimonialId",
+            "=",
+            "testimonials.id"
+          )
+      ).as("tags"),
+    ])
+    .execute();
+}
+```
+
+**3. The Result**
+
+The `getAllTestimonials` function will return an array of testimonial objects, each structured with nested data:
+
+```json
+[
+  {
+    "id": "abc-123",
+    "content": "This is a great product!",
+    "status": { "id": 1, "name": "Published" },
+    "source": { "id": 2, "name": "Website Form" },
+    "tags": [
+      { "id": 10, "name": "Positive Feedback" },
+      { "id": 12, "name": "Feature Request" }
+    ]
+  }
+]
+```
+
+This pattern allows you to fetch complex, nested data structures in a single, efficient query.
+
+---
+
 ## API Reference
 
 ### `createDb()`

--- a/docs/src/content/docs/core/database-do.mdx
+++ b/docs/src/content/docs/core/database-do.mdx
@@ -63,6 +63,21 @@ Migrations run when `createDb()` is called. If that happens at the module level 
 
 **Production**: When you deploy with `npm run release`, the deployment process includes an initial request to your application, which triggers migration updates.
 
+### Migration Failures and Rollback
+
+If a migration’s `up()` function fails, `rwsdk/db` automatically calls the corresponding `down()` function to undo any partial changes. This rollback is per-migration—previously successful ones are not affected.
+
+Because SQLite doesn’t support transactional DDL (Data Definition Language) statements, a failed migration can leave the database in a partially modified state. It is therefore important to write `down()` functions that are idempotent and can run safely even if `up()` only partially succeeded.
+
+```ts
+// Example of a defensive down() function
+async down(db) {
+  // Defensively drop tables that might not exist if `up()` failed
+  await db.schema.dropTable("posts").ifExists().execute();
+  await db.schema.dropTable("users").ifExists().execute();
+}
+```
+
 ---
 
 ## Setup
@@ -337,3 +352,11 @@ A: This is currently a preview feature, which means the API may evolve based on 
 **Q: How do I handle database backups?**
 
 A: Durable Objects automatically persist data, but like D1, there aren't built-in backup features. For critical applications, implement additional backup strategies. You can export data periodically or replicate to external systems as needed.
+
+**Q: Why does rwsdk/db auto-rollback failed migrations instead of leaving recovery to the developer?**
+
+A: We recognize that in many scenarios, particularly in production, a developer is best equipped to handle a failed migration with full context. Manual recovery can offer more granular control than a one-size-fits-all automated approach.
+
+However, `rwsdk/db` opts for automated rollbacks by default to ensure database integrity. The primary reason is that SQLite does not support transactions for schema changes (DDL). A failed `up()` migration could otherwise leave the database in an inconsistent, half-migrated state. By automatically running the `down()` function, we return the database to a known-good state. This is critical for the zero-setup, runtime-isolated environments `rwsdk/db` is designed for, where direct manual intervention may not be feasible.
+
+To work effectively with this automated system, it's best to plan migrations carefully. Each `down()` function should be written to cleanly undo only what its corresponding `up()` function does. This practice makes it much easier and safer to reason about the database state, fix the migration, and redeploy.

--- a/docs/src/content/docs/core/database-do.mdx
+++ b/docs/src/content/docs/core/database-do.mdx
@@ -65,7 +65,7 @@ Migrations run when `createDb()` is called. If that happens at the module level 
 
 ### Migration Failures and Rollback
 
-If a migration’s `up()` function fails, `rwsdk/db` automatically calls the corresponding `down()` function to undo any partial changes. This rollback is per-migration—previously successful ones are not affected.
+If a migration’s `up()` function fails, `rwsdk/db` automatically calls the corresponding `down()` function to undo any partial changes. This rollback is per-migration - previously successful ones are not affected.
 
 Because SQLite doesn’t support transactional DDL (Data Definition Language) statements, a failed migration can leave the database in a partially modified state. It is therefore important to write `down()` functions that are idempotent and can run safely even if `up()` only partially succeeded.
 

--- a/sdk/src/runtime/lib/db/SqliteDurableObject.ts
+++ b/sdk/src/runtime/lib/db/SqliteDurableObject.ts
@@ -30,36 +30,28 @@ export class SqliteDurableObject<T = any> extends DurableObject {
   }
 
   public async initialize(): Promise<void> {
-    console.log(
-      "################################ initialize called",
-      this.initialized,
-    );
     if (this.initialized) {
-      console.log("################################ already initialized");
       log("Database already initialized, skipping");
       return;
     }
 
     log("Initializing Durable Object database");
-    console.log(
-      "################################ initializing",
-      this.initialized,
-    );
     const migrator = createMigrator(
       this.kysely,
       this.migrations,
       this.migrationTableName,
     );
-    console.log("################################ migrating");
     const result = await migrator.migrateToLatest();
     if (result.error) {
+      console.log(
+        "rwsdk/db: Migrations failed, rolling back and throwing with the migration error: %O",
+        result.results,
+      );
+      await migrator.migrateDown();
       throw result.error;
     }
+    log("Migrations results", result.results);
     this.initialized = true;
-    console.log(
-      "################################ initialized",
-      this.initialized,
-    );
     log("Database initialization complete");
   }
 

--- a/sdk/src/runtime/lib/db/SqliteDurableObject.ts
+++ b/sdk/src/runtime/lib/db/SqliteDurableObject.ts
@@ -1,7 +1,12 @@
 import { DODialect } from "kysely-do";
 import { DurableObject } from "cloudflare:workers";
 
-import { Kysely, CompiledQuery, QueryResult } from "kysely";
+import {
+  Kysely,
+  CompiledQuery,
+  QueryResult,
+  ParseJSONResultsPlugin,
+} from "kysely";
 import { createMigrator } from "./index.js";
 import debug from "../debug.js";
 
@@ -26,6 +31,7 @@ export class SqliteDurableObject<T = any> extends DurableObject {
 
     this.kysely = new Kysely<T>({
       dialect: new DODialect({ ctx }),
+      plugins: [new ParseJSONResultsPlugin()],
     });
   }
 

--- a/sdk/src/runtime/lib/db/SqliteDurableObject.ts
+++ b/sdk/src/runtime/lib/db/SqliteDurableObject.ts
@@ -51,7 +51,10 @@ export class SqliteDurableObject<T = any> extends DurableObject {
       this.migrationTableName,
     );
     console.log("################################ migrating");
-    await migrator.migrateToLatest();
+    const result = await migrator.migrateToLatest();
+    if (result.error) {
+      throw result.error;
+    }
     this.initialized = true;
     console.log(
       "################################ initialized",

--- a/sdk/src/runtime/lib/db/SqliteDurableObject.ts
+++ b/sdk/src/runtime/lib/db/SqliteDurableObject.ts
@@ -30,19 +30,33 @@ export class SqliteDurableObject<T = any> extends DurableObject {
   }
 
   public async initialize(): Promise<void> {
+    console.log(
+      "################################ initialize called",
+      this.initialized,
+    );
     if (this.initialized) {
+      console.log("################################ already initialized");
       log("Database already initialized, skipping");
       return;
     }
 
     log("Initializing Durable Object database");
+    console.log(
+      "################################ initializing",
+      this.initialized,
+    );
     const migrator = createMigrator(
       this.kysely,
       this.migrations,
       this.migrationTableName,
     );
+    console.log("################################ migrating");
     await migrator.migrateToLatest();
     this.initialized = true;
+    console.log(
+      "################################ initialized",
+      this.initialized,
+    );
     log("Database initialization complete");
   }
 

--- a/sdk/src/runtime/script.ts
+++ b/sdk/src/runtime/script.ts
@@ -1,10 +1,15 @@
+import { defineApp } from "./worker";
+import { env } from "cloudflare:workers";
+
 export const defineScript = (
-  fn: ({ env }: { env: Env }) => Promise<unknown>,
+  fn: ({ env }: { env: Cloudflare.Env }) => Promise<unknown>,
 ) => {
-  return {
-    async fetch(request: Request, env: Env) {
+  const app = defineApp([
+    async () => {
       await fn({ env });
       return new Response("Done!");
     },
-  };
+  ]);
+
+  return app;
 };

--- a/sdk/src/scripts/debug-sync.mts
+++ b/sdk/src/scripts/debug-sync.mts
@@ -182,10 +182,8 @@ export const debugSync = async (opts: DebugSyncOptions) => {
   }
 
   // Initial sync for watch mode. We do it *after* acquiring the lock.
-  let initialSyncOk = false;
   try {
     await performSync(sdkDir, targetDir);
-    initialSyncOk = true;
   } catch (error) {
     console.error("❌ Initial sync failed:", error);
     console.log("   Still watching for changes...");
@@ -248,9 +246,9 @@ export const debugSync = async (opts: DebugSyncOptions) => {
   process.on("SIGINT", cleanup);
   process.on("SIGTERM", cleanup);
 
-  if (initialSyncOk) {
-    runWatchedCommand();
-  }
+  // Run the watched command even if the initial sync fails. This allows the
+  // user to see application errors and iterate more quickly.
+  runWatchedCommand();
 };
 
 if (import.meta.url === new URL(process.argv[1], import.meta.url).href) {


### PR DESCRIPTION
## Changes
I needed to make several fixes and improvements to get the testimonials addon working: https://github.com/ahaywood/addon-testimonial/pull/1

### Fix: `createDb()` now waits for `requestInfo` to be ready
We've designed [`createDb()`](https://f5069e4a.redwood-sdk-docs.pages.dev/core/database-do/#createdb) with the intention of being callable at the module level - this way one only needs to import `db`

Under the hood `createDb()` needs `requestInfo` to be around in order to hold onto some state for this db throughout the current request. However, `requestInfo` is not yet around at the point where `createDb()` is called.

This PR fixes this by having `createDb()` first wait for `requestInfo` to be around before trying to set state on it.

### Seed script now re-exports from worker entry point (`src/worker.tsx`)
Since `rwsdb/db` databases are durable objects, the seed script needs a way to tell miniflare about the relevant DO classes. It feels less than ideal to not to re-export the DO classes _again_ (once for seed script, once for worker entry point). So we have changed the seed script runner to get the durable object exports that the worker entry point uses (using ast-grep), and add these same re-exports to the seed script runner's wrapper script.

### Improvement: We now auto-rollback failed migrations
If a migration's `up()` function fails, `rwsdk/db` automatically calls the corresponding `down()` function to undo any partial changes. This rollback is per-migration - previously successful ones are not affected.

Here's the reasoning, in the form of the FAQ entry this PR also adds:

> **Q: Why does rwsdk/db auto-rollback failed migrations instead of leaving recovery to the developer?**
> 
> A: We recognize that in many scenarios, particularly in production, a developer is best equipped to handle a failed migration with full context. Manual recovery can offer more granular control than a one-size-fits-all automated approach.
> 
> However, `rwsdk/db` opts for automated rollbacks by default to ensure database integrity. The primary reason is that SQLite does not support transactions for schema changes (DDL). A failed `up()` migration could otherwise leave the database in an inconsistent, half-migrated state. By automatically running the `down()` function, we return the database to a known-good state. This is critical for the zero-setup, runtime-isolated environments `rwsdk/db` is designed for, where direct manual intervention may not be feasible.
> 
> To work effectively with this automated system, it's best to plan migrations carefully. Each `down()` function should be written to cleanly undo only what its corresponding `up()` function does. This practice makes it much easier and safer to reason about the database state, fix the migration, and redeploy

### Docs
Docs on the new auto-roll back behavior, an FAQ entry for it, a note about designing `down()` migrations to be idempotent, and a pattern for structuring relational queries.