### PR TITLE
fix: NODE_ENV=development deploys and previews

### DIFF
--- a/docs/src/content/docs/tutorial/full-stack-app/2-create-app.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/2-create-app.mdx
@@ -261,12 +261,11 @@ Before this will work in production, we need to update our security headers to a
 
 ```tsx title="src/app/headers.ts" collapse={1-26} {30}
 import { RouteMiddleware } from "rwsdk/router";
-import { IS_DEV } from "rwsdk/constants";
 
 export const setCommonHeaders =
 (): RouteMiddleware =>
 ({ headers, rw: { nonce } }) => {
-  if (!IS_DEV) {
+  if (!import.meta.env.VITE_IS_DEV_SERVER) {
     // Forces browsers to always use HTTPS for a specified time period (2 years)
     headers.set(
       "Strict-Transport-Security",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,8 +205,8 @@ importers:
   starters/minimal:
     dependencies:
       rwsdk:
-        specifier: file:/Users/justin/rw/sdk/sdk/rwsdk-0.1.20.tgz
-        version: file:sdk/rwsdk-0.1.20.tgz(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0)
+        specifier: 0.1.20
+        version: 0.1.20(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0)
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 1.7.4
@@ -3604,13 +3604,6 @@ packages:
 
   rwsdk@0.1.20:
     resolution: {integrity: sha512-PfYGWmXcWkMTkv1gcg5AMnM1SANQGvAMfx7jmZqtzlS65g8KP5mBFcAjC3bhSpgEbUaCFTrj6hHO2YEUp9o1PA==}
-    hasBin: true
-    peerDependencies:
-      vite: ^6.2.6
-
-  rwsdk@file:sdk/rwsdk-0.1.20.tgz:
-    resolution: {integrity: sha512-aPdnk9Dc6Wkr+BrCCJt+BN5OTqxvV0CGtu4AkJLAn6/wstQhqHOrRe6tvDjSfU5oUqKvBSdH5OEJ7pNcoqvFqg==, tarball: file:sdk/rwsdk-0.1.20.tgz}
-    version: 0.1.20
     hasBin: true
     peerDependencies:
       vite: ^6.2.6
@@ -8359,56 +8352,6 @@ snapshots:
       queue-microtask: 1.2.3
 
   rwsdk@0.1.20(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0):
-    dependencies:
-      '@ast-grep/napi': 0.38.5
-      '@cloudflare/vite-plugin': 1.7.4(rollup@4.40.0)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(workerd@1.20250617.0)(wrangler@4.20.5(@cloudflare/workers-types@4.20250407.0))
-      '@cloudflare/workers-types': 4.20250407.0
-      '@puppeteer/browsers': 2.10.1
-      '@types/fs-extra': 11.0.4
-      '@types/react': 19.1.2
-      '@types/react-dom': 19.1.2(@types/react@19.1.2)
-      '@types/react-is': 19.0.0
-      '@vitejs/plugin-react': 4.3.4(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))
-      chokidar: 3.6.0
-      debug: 4.4.0
-      enhanced-resolve: 5.18.1
-      eventsource-parser: 3.0.0
-      execa: 9.5.2
-      fs-extra: 11.3.0
-      glob: 11.0.1
-      ignore: 7.0.4
-      jsonc-parser: 3.3.1
-      kysely: 0.28.2
-      kysely-do: 0.0.1-rc.1(kysely@0.28.2)
-      lodash: 4.17.21
-      magic-string: 0.30.17
-      miniflare: 4.20250617.3
-      picocolors: 1.1.1
-      proper-lockfile: 4.1.2
-      puppeteer-core: 22.15.0
-      react: 19.2.0-canary-39cad7af-20250411
-      react-dom: 19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411)
-      react-is: 19.0.0
-      react-server-dom-webpack: 19.2.0-canary-39cad7af-20250411(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)(webpack@5.97.1)
-      rsc-html-stream: 0.0.6
-      tmp-promise: 3.0.3
-      ts-morph: 25.0.1
-      unique-names-generator: 4.7.1
-      vibe-rules: 0.2.31
-      vite: 6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0)
-      vite-tsconfig-paths: 5.1.4(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))
-      wrangler: 4.20.5(@cloudflare/workers-types@4.20250407.0)
-    transitivePeerDependencies:
-      - bare-buffer
-      - bufferutil
-      - rollup
-      - supports-color
-      - typescript
-      - utf-8-validate
-      - webpack
-      - workerd
-
-  rwsdk@file:sdk/rwsdk-0.1.20.tgz(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0):
     dependencies:
       '@ast-grep/napi': 0.38.5
       '@cloudflare/vite-plugin': 1.7.4(rollup@4.40.0)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(workerd@1.20250617.0)(wrangler@4.20.5(@cloudflare/workers-types@4.20250407.0))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,8 +205,8 @@ importers:
   starters/minimal:
     dependencies:
       rwsdk:
-        specifier: 0.1.20
-        version: 0.1.20(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0)
+        specifier: file:/Users/justin/rw/sdk/sdk/rwsdk-0.1.20.tgz
+        version: file:sdk/rwsdk-0.1.20.tgz(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0)
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 1.7.4
@@ -248,8 +248,8 @@ importers:
         specifier: ^13.1.1
         version: 13.1.1
       rwsdk:
-        specifier: file:/Users/justin/rw/sdk/sdk/rwsdk-0.1.20.tgz
-        version: file:sdk/rwsdk-0.1.20.tgz(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0)
+        specifier: 0.1.20
+        version: 0.1.20(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0)
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 1.7.4
@@ -3609,7 +3609,7 @@ packages:
       vite: ^6.2.6
 
   rwsdk@file:sdk/rwsdk-0.1.20.tgz:
-    resolution: {integrity: sha512-GHOlVQXix4fZZTSrr1/ldAT6GDDs8LUxBz5Yq8ihDOqwLbF8tP4n6ha8LtrTvUbxSSN4uhUi1q6cJk+subW9bw==, tarball: file:sdk/rwsdk-0.1.20.tgz}
+    resolution: {integrity: sha512-aPdnk9Dc6Wkr+BrCCJt+BN5OTqxvV0CGtu4AkJLAn6/wstQhqHOrRe6tvDjSfU5oUqKvBSdH5OEJ7pNcoqvFqg==, tarball: file:sdk/rwsdk-0.1.20.tgz}
     version: 0.1.20
     hasBin: true
     peerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,8 +248,8 @@ importers:
         specifier: ^13.1.1
         version: 13.1.1
       rwsdk:
-        specifier: 0.1.20
-        version: 0.1.20(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0)
+        specifier: file:/Users/justin/rw/sdk/sdk/rwsdk-0.1.20.tgz
+        version: file:sdk/rwsdk-0.1.20.tgz(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0)
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 1.7.4
@@ -3604,6 +3604,13 @@ packages:
 
   rwsdk@0.1.20:
     resolution: {integrity: sha512-PfYGWmXcWkMTkv1gcg5AMnM1SANQGvAMfx7jmZqtzlS65g8KP5mBFcAjC3bhSpgEbUaCFTrj6hHO2YEUp9o1PA==}
+    hasBin: true
+    peerDependencies:
+      vite: ^6.2.6
+
+  rwsdk@file:sdk/rwsdk-0.1.20.tgz:
+    resolution: {integrity: sha512-GHOlVQXix4fZZTSrr1/ldAT6GDDs8LUxBz5Yq8ihDOqwLbF8tP4n6ha8LtrTvUbxSSN4uhUi1q6cJk+subW9bw==, tarball: file:sdk/rwsdk-0.1.20.tgz}
+    version: 0.1.20
     hasBin: true
     peerDependencies:
       vite: ^6.2.6
@@ -8352,6 +8359,56 @@ snapshots:
       queue-microtask: 1.2.3
 
   rwsdk@0.1.20(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0):
+    dependencies:
+      '@ast-grep/napi': 0.38.5
+      '@cloudflare/vite-plugin': 1.7.4(rollup@4.40.0)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(workerd@1.20250617.0)(wrangler@4.20.5(@cloudflare/workers-types@4.20250407.0))
+      '@cloudflare/workers-types': 4.20250407.0
+      '@puppeteer/browsers': 2.10.1
+      '@types/fs-extra': 11.0.4
+      '@types/react': 19.1.2
+      '@types/react-dom': 19.1.2(@types/react@19.1.2)
+      '@types/react-is': 19.0.0
+      '@vitejs/plugin-react': 4.3.4(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))
+      chokidar: 3.6.0
+      debug: 4.4.0
+      enhanced-resolve: 5.18.1
+      eventsource-parser: 3.0.0
+      execa: 9.5.2
+      fs-extra: 11.3.0
+      glob: 11.0.1
+      ignore: 7.0.4
+      jsonc-parser: 3.3.1
+      kysely: 0.28.2
+      kysely-do: 0.0.1-rc.1(kysely@0.28.2)
+      lodash: 4.17.21
+      magic-string: 0.30.17
+      miniflare: 4.20250617.3
+      picocolors: 1.1.1
+      proper-lockfile: 4.1.2
+      puppeteer-core: 22.15.0
+      react: 19.2.0-canary-39cad7af-20250411
+      react-dom: 19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411)
+      react-is: 19.0.0
+      react-server-dom-webpack: 19.2.0-canary-39cad7af-20250411(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)(webpack@5.97.1)
+      rsc-html-stream: 0.0.6
+      tmp-promise: 3.0.3
+      ts-morph: 25.0.1
+      unique-names-generator: 4.7.1
+      vibe-rules: 0.2.31
+      vite: 6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0)
+      vite-tsconfig-paths: 5.1.4(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))
+      wrangler: 4.20.5(@cloudflare/workers-types@4.20250407.0)
+    transitivePeerDependencies:
+      - bare-buffer
+      - bufferutil
+      - rollup
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - webpack
+      - workerd
+
+  rwsdk@file:sdk/rwsdk-0.1.20.tgz(rollup@4.40.0)(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(webpack@5.97.1)(workerd@1.20250617.0):
     dependencies:
       '@ast-grep/napi': 0.38.5
       '@cloudflare/vite-plugin': 1.7.4(rollup@4.40.0)(vite@6.3.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0))(workerd@1.20250617.0)(wrangler@4.20.5(@cloudflare/workers-types@4.20250407.0))

--- a/sdk/src/runtime/client.tsx
+++ b/sdk/src/runtime/client.tsx
@@ -125,7 +125,7 @@ export const initClient = async ({
   });
 
   if (import.meta.hot) {
-    import.meta.hot.on("rsc:update", (e) => {
+    import.meta.hot.on("rsc:update", (e: { file: string }) => {
       console.log("[rwsdk] hot update", e.file);
       callServer("__rsc_hot_update", [e.file]);
     });

--- a/sdk/src/runtime/entries/auth.ts
+++ b/sdk/src/runtime/entries/auth.ts
@@ -1,1 +1,2 @@
+import "./types/worker";
 export * from "../lib/auth";

--- a/sdk/src/runtime/entries/client.ts
+++ b/sdk/src/runtime/entries/client.ts
@@ -1,3 +1,4 @@
+import "./types/client";
 export * from "../client";
 export * from "../register/client";
 export * from "../lib/streams/consumeEventStream";

--- a/sdk/src/runtime/entries/clientSSR.ts
+++ b/sdk/src/runtime/entries/clientSSR.ts
@@ -1,1 +1,2 @@
+import "./types/ssr";
 export * from "../lib/streams/consumeEventStream";

--- a/sdk/src/runtime/entries/router.ts
+++ b/sdk/src/runtime/entries/router.ts
@@ -1,2 +1,3 @@
+import "./types/shared";
 export * from "../lib/router";
 export * from "../lib/links";

--- a/sdk/src/runtime/entries/ssr.ts
+++ b/sdk/src/runtime/entries/ssr.ts
@@ -1,1 +1,2 @@
+import "./types/ssr";
 export * from "../register/ssr";

--- a/sdk/src/runtime/entries/types/client.ts
+++ b/sdk/src/runtime/entries/types/client.ts
@@ -1,0 +1,1 @@
+import "./shared";

--- a/sdk/src/runtime/entries/types/shared.ts
+++ b/sdk/src/runtime/entries/types/shared.ts
@@ -1,0 +1,8 @@
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+
+interface ImportMetaEnv {
+  readonly DEV: boolean;
+  readonly VITE_IS_DEV_SERVER: string;
+}

--- a/sdk/src/runtime/entries/types/ssr.ts
+++ b/sdk/src/runtime/entries/types/ssr.ts
@@ -1,0 +1,1 @@
+import "./shared";

--- a/sdk/src/runtime/entries/types/worker.ts
+++ b/sdk/src/runtime/entries/types/worker.ts
@@ -1,0 +1,1 @@
+import "./shared";

--- a/sdk/src/runtime/entries/worker.ts
+++ b/sdk/src/runtime/entries/worker.ts
@@ -1,3 +1,4 @@
+import "./types/worker";
 export * from "../register/worker";
 export * from "../worker";
 export * from "../error";

--- a/sdk/src/runtime/imports/client.ts
+++ b/sdk/src/runtime/imports/client.ts
@@ -2,6 +2,7 @@ import React from "react";
 import memoize from "lodash/memoize";
 
 export const loadModule = memoize(async (id: string) => {
+  console.log("#########", import.meta.env.DEV, process.env.PREVIEW);
   if (import.meta.env.DEV && !process.env.PREVIEW) {
     return await import(/* @vite-ignore */ id);
   } else {

--- a/sdk/src/runtime/imports/client.ts
+++ b/sdk/src/runtime/imports/client.ts
@@ -2,8 +2,7 @@ import React from "react";
 import memoize from "lodash/memoize";
 
 export const loadModule = memoize(async (id: string) => {
-  console.log("#########", import.meta.env.DEV, process.env.PREVIEW);
-  if (import.meta.env.DEV && !process.env.PREVIEW) {
+  if (import.meta.env.VITE_IS_DEV_SERVER) {
     return await import(/* @vite-ignore */ id);
   } else {
     const { useClientLookup } = await import(

--- a/sdk/src/runtime/lib/auth/session.ts
+++ b/sdk/src/runtime/lib/auth/session.ts
@@ -1,10 +1,11 @@
 import { ErrorResponse } from "../../error";
-import { IS_DEV } from "../../constants";
 import { env } from "cloudflare:workers";
 
 const AUTH_SECRET_KEY =
   (env as { AUTH_SECRET_KEY?: string }).AUTH_SECRET_KEY ??
-  (IS_DEV ? "development-secret-key-do-not-use-in-production" : undefined);
+  (import.meta.env.VITE_IS_DEV_SERVER
+    ? "development-secret-key-do-not-use-in-production"
+    : undefined);
 
 if (AUTH_SECRET_KEY === "") {
   console.warn(

--- a/sdk/src/runtime/lib/realtime/client.ts
+++ b/sdk/src/runtime/lib/realtime/client.ts
@@ -1,6 +1,5 @@
 import { initClient, type Transport, type ActionResponse } from "../../client";
 import { createFromReadableStream } from "react-server-dom-webpack/client.browser";
-import { IS_DEV } from "../../constants";
 import { MESSAGE_TYPE } from "./shared";
 const DEFAULT_KEY = "default";
 

--- a/sdk/src/runtime/lib/turnstile/useTurnstile.ts
+++ b/sdk/src/runtime/lib/turnstile/useTurnstile.ts
@@ -1,7 +1,6 @@
 "use client";
 
 import { useRef, useCallback } from "react";
-import { IS_DEV } from "../../constants";
 
 export function useTurnstile(siteKey: string) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -17,7 +16,9 @@ export function useTurnstile(siteKey: string) {
       widgetIdRef.current = (window as any).turnstile.render(
         containerRef.current,
         {
-          sitekey: IS_DEV ? "1x00000000000000000000AA" : siteKey,
+          sitekey: import.meta.env.VITE_IS_DEV_SERVER
+            ? "1x00000000000000000000AA"
+            : siteKey,
           callback: (token: string) => resolverRef.current.resolve(token),
         },
       );

--- a/sdk/src/runtime/register/worker.ts
+++ b/sdk/src/runtime/register/worker.ts
@@ -5,8 +5,6 @@ import {
 } from "react-server-dom-webpack/server.edge";
 import { getServerModuleExport } from "../imports/worker.js";
 
-import { IS_DEV } from "../constants";
-
 export function registerServerReference(
   action: Function,
   id: string,
@@ -56,7 +54,7 @@ export async function rscActionHandler(req: Request): Promise<unknown> {
   const args = (await decodeReply(data, null)) as unknown[];
   const actionId = url.searchParams.get("__rsc_action_id");
 
-  if (IS_DEV && actionId === "__rsc_hot_update") {
+  if (import.meta.env.VITE_IS_DEV_SERVER && actionId === "__rsc_hot_update") {
     return null;
   }
 

--- a/sdk/src/runtime/worker.tsx
+++ b/sdk/src/runtime/worker.tsx
@@ -14,7 +14,6 @@ import { RequestInfo, DefaultAppContext } from "./requestInfo/types";
 
 import { Route, type RwContext, defineRoutes } from "./lib/router";
 import { generateNonce } from "./lib/utils";
-import { IS_DEV } from "./constants";
 import { ssrWebpackRequire } from "./imports/worker";
 
 declare global {
@@ -118,7 +117,7 @@ export const defineApp = <
           onError: (error: unknown) => void,
         ) => {
           if (isClientReference(requestInfo.rw.Document)) {
-            if (IS_DEV) {
+            if (import.meta.env.DEV) {
               console.error("Document cannot be a client component");
             }
 

--- a/sdk/src/runtime/worker.tsx
+++ b/sdk/src/runtime/worker.tsx
@@ -41,7 +41,10 @@ export const defineApp = <
         const url = new URL(request.url);
         url.pathname = url.pathname.slice("/assets/".length);
         return env.ASSETS.fetch(new Request(url.toString(), request));
-      } else if (IS_DEV && request.url.includes("/__vite_preamble__")) {
+      } else if (
+        import.meta.env.VITE_IS_DEV_SERVER &&
+        request.url.includes("/__vite_preamble__")
+      ) {
         return new Response(
           'import RefreshRuntime from "/@react-refresh"; RefreshRuntime.injectIntoGlobalHook(window); window.$RefreshReg$ = () => {}; window.$RefreshSig$ = () => (type) => type; window.__vite_plugin_react_preamble_installed__ = true;',
           {

--- a/sdk/src/vite/devServerConstant.mts
+++ b/sdk/src/vite/devServerConstant.mts
@@ -1,0 +1,21 @@
+import { Plugin } from "vite";
+
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      VITE_IS_DEV_SERVER: string;
+    }
+  }
+}
+
+export const devServerConstantPlugin = (): Plugin => {
+  return {
+    name: "rwsdk:dev-server-constant",
+    config(_, { command, isPreview }) {
+      if (command === "serve" && isPreview) {
+        // context(justinvdm, 21 Jul 2025): Vite forwards this as `import.meta.env.DEV_IS_DEV_SERVER`
+        process.env.VITE_IS_DEV_SERVER = "1";
+      }
+    },
+  };
+};

--- a/sdk/src/vite/redwoodPlugin.mts
+++ b/sdk/src/vite/redwoodPlugin.mts
@@ -2,6 +2,8 @@ import { resolve } from "node:path";
 import { InlineConfig } from "vite";
 import { unstable_readConfig } from "wrangler";
 import { cloudflare } from "@cloudflare/vite-plugin";
+
+import { devServerConstantPlugin } from "./devServerConstant.mjs";
 import { hasOwnCloudflareVitePlugin } from "./hasOwnCloudflareVitePlugin.mjs";
 
 import reactPlugin from "@vitejs/plugin-react";
@@ -97,6 +99,7 @@ export const redwoodPlugin = async (
 
   return [
     devServerTimingPlugin(),
+    devServerConstantPlugin(),
     configPlugin({
       silent: options.silent ?? false,
       projectRootDir,

--- a/sdk/tsconfig.json
+++ b/sdk/tsconfig.json
@@ -43,6 +43,7 @@
 
     "types": [
       "./types/react.d.ts",
+      "./types/clientGlobal.d.ts",
       "./types/global.d.ts",
       "./types/vite.d.ts",
       "@cloudflare/workers-types"

--- a/sdk/types/clientGlobal.d.ts
+++ b/sdk/types/clientGlobal.d.ts
@@ -1,0 +1,14 @@
+/* eslint-disable no-var */
+/// <reference types="react/experimental" />
+
+import { CallServerCallback } from "react-server-dom-webpack/client.browser";
+
+declare global {
+  var __rsc_callServer: CallServerCallback;
+  var __rw: {
+    callServer: CallServerCallback;
+    upgradeToRealtime: (options?: { key?: string }) => Promise<void>;
+  };
+}
+
+export {};

--- a/sdk/types/global.d.ts
+++ b/sdk/types/global.d.ts
@@ -1,23 +1,9 @@
-/* eslint-disable no-var */
-/// <reference types="react/experimental" />
-
-import { CallServerCallback } from "react-server-dom-webpack/client.browser";
 import { ViteHotContext } from "vite/types/hot";
 
 declare global {
   var __webpack_require__: (id: string) => unknown;
-  var __rsc_callServer: CallServerCallback;
-  var __rw: {
-    callServer: CallServerCallback;
-    upgradeToRealtime: (options?: { key?: string }) => Promise<void>;
-  };
   interface ImportMeta {
-    readonly env: ImportMetaEnv;
     hot?: ViteHotContext;
-  }
-
-  interface ImportMetaEnv {
-    readonly DEV: boolean;
   }
 }
 

--- a/starters/minimal/src/app/headers.ts
+++ b/starters/minimal/src/app/headers.ts
@@ -1,10 +1,9 @@
 import { RouteMiddleware } from "rwsdk/router";
-import { IS_DEV } from "rwsdk/constants";
 
 export const setCommonHeaders =
   (): RouteMiddleware =>
   ({ headers, rw: { nonce } }) => {
-    if (!IS_DEV) {
+    if (!import.meta.env.VITE_IS_DEV_SERVER) {
       // Forces browsers to always use HTTPS for a specified time period (2 years)
       headers.set(
         "Strict-Transport-Security",

--- a/starters/standard/src/app/headers.ts
+++ b/starters/standard/src/app/headers.ts
@@ -1,10 +1,9 @@
 import { RouteMiddleware } from "rwsdk/router";
-import { IS_DEV } from "rwsdk/constants";
 
 export const setCommonHeaders =
   (): RouteMiddleware =>
   ({ headers, rw: { nonce } }) => {
-    if (!IS_DEV) {
+    if (!import.meta.env.VITE_IS_DEV_SERVER) {
       // Forces browsers to always use HTTPS for a specified time period (2 years)
       headers.set(
         "Strict-Transport-Security",

--- a/starters/standard/src/app/pages/user/functions.ts
+++ b/starters/standard/src/app/pages/user/functions.ts
@@ -13,11 +13,11 @@ import { requestInfo } from "rwsdk/worker";
 import { db } from "@/db";
 import { env } from "cloudflare:workers";
 
-const IS_DEV = process.env.NODE_ENV === "development";
-
 function getWebAuthnConfig(request: Request) {
   const rpID = env.WEBAUTHN_RP_ID ?? new URL(request.url).hostname;
-  const rpName = IS_DEV ? "Development App" : env.WEBAUTHN_APP_NAME;
+  const rpName = import.meta.env.VITE_IS_DEV_SERVER
+    ? "Development App"
+    : env.WEBAUTHN_APP_NAME;
   return {
     rpName,
     rpID,


### PR DESCRIPTION
## Context
So far, we've (I've) been been using `import.meta.DEV` to determine both:
* Is the the dev server running
* Is the application running in dev mode (`NODE_ENV=development`)

This is wrong of course, and breaks down in cases where one wants to use `NODE_ENV=development` in deployments or previews.

Why would one want to use `NODE_ENV=development` for deploys or previews? Use cases include easier debugging more dev info on staging deployments and vite previews.

## Solution
We now no longer conflate the dev server running with whether `NODE_ENV=development` was given. We now have:
* `import.meta.env.VITE_IS_DEV_SERVER` - only true when the dev server is running (not a deployment or preview). Is independent of the value of `NODE_ENV=development` or the mode that vite is running in
* `import.meta.env.DEV` - determined by the mode that vite is running in - we still have this via vite, and it still implies the app is running in development mode, which defaults to whether was `NODE_ENV=development`

We now use `VITE_IS_DEV_SERVER` in places where what we are actually trying to determine, is whether the app is running via the dev server. For example:
* when determining whether the load modules dynamically via the dev server or not
* when determining whether to inject the vite dev HMR preamble

Fixes #607 