### PR TITLE
fix: renderRealtimeClients() usage with client navigation

### DIFF
--- a/sdk/src/runtime/lib/realtime/durableObject.ts
+++ b/sdk/src/runtime/lib/realtime/durableObject.ts
@@ -74,7 +74,7 @@ export class RealtimeDurableObject extends DurableObject {
 
   async webSocketMessage(ws: WebSocket, data: ArrayBuffer) {
     const clientId = ws.deserializeAttachment() as string;
-    const clientInfo = await this.getClientInfo(clientId);
+    let clientInfo = await this.getClientInfo(clientId);
 
     const message = new Uint8Array(data);
     const messageType = message[0];
@@ -83,6 +83,13 @@ export class RealtimeDurableObject extends DurableObject {
       const decoder = new TextDecoder();
       const jsonData = decoder.decode(message.slice(1));
       const { id, args, requestId, clientUrl } = JSON.parse(jsonData);
+
+      clientInfo = {
+        ...clientInfo,
+        url: clientUrl,
+      };
+
+      await this.storeClientInfo(clientInfo);
 
       try {
         await this.handleAction(ws, id, args, clientInfo, requestId, clientUrl);


### PR DESCRIPTION
## Problem
For each realtime channel, we currently store the relevant url for each connected client, and use this when rendering clients on demand using `renderRealtimeClients()`. However, we weren't accounting for changes to the url done as a result of client navigation.

## Solution
We already use each url we get for a client when client actions and navigations happen to determine how the client should be updated. We just need to store this latest url as the new url for usage with `renderRealtimeClient()`.