### PR TITLE
fix: Provide import.meta.env.VITE_IS_DEV_SERVER when not preview

### DIFF
--- a/sdk/src/vite/devServerConstant.mts
+++ b/sdk/src/vite/devServerConstant.mts
@@ -12,7 +12,7 @@ export const devServerConstantPlugin = (): Plugin => {
   return {
     name: "rwsdk:dev-server-constant",
     config(_, { command, isPreview }) {
-      if (command === "serve" && isPreview) {
+      if (command === "serve" && !isPreview) {
         // context(justinvdm, 21 Jul 2025): Vite forwards this as `import.meta.env.DEV_IS_DEV_SERVER`
         process.env.VITE_IS_DEV_SERVER = "1";
       }


### PR DESCRIPTION
#609 introduced `import.meta.env.VITE_IS_DEV_SERVER`, which should only be present when dev server is running (not in deploys or for preview server).

There was a bug in the logic causing `import.meta.env.VITE_IS_DEV_SERVER` to only get added for the preview server instead of the dev server.

This in turn broke HMR with the following:

```
No module found for '__rsc_hot_update' in module lookup for "use server" directive
```