### PR TITLE
fix: Recover from errors when doing HMR

### DIFF
--- a/sdk/src/vite/miniflareHMRPlugin.mts
+++ b/sdk/src/vite/miniflareHMRPlugin.mts
@@ -123,8 +123,6 @@ export const miniflareHMRPlugin = (givenOptions: {
           type: "full-reload",
           path: "*",
         });
-        // We don't reset `hasErrored` here.
-        // We wait for a successful request to confirm the server is healthy.
         return [];
       }
       const {


### PR DESCRIPTION
Up till now, when errors happening during the dev workflow (e.g. if file was saved with syntax errors), you would see the error overlay screen until you manually reloaded the page.

We now detect we are in an error state, and trigger a full page reload on file changes if this is the case, which brings the app back to a working state if the error has now been fixed.

Fixes #410 
Fixes #412