### PR TITLE
docs: Removing banner configuration

### DIFF
--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -5,17 +5,6 @@ import { docsSchema } from "@astrojs/starlight/schema";
 export const collections = {
   docs: defineCollection({
     loader: docsLoader(),
-    schema: docsSchema({
-      extend: z.object({
-        banner: z
-          .object({
-            content: z.string(),
-          })
-          .default({
-            content:
-              "4th April 2025: This is a preview, whilst production-ready, it means some <a href='https://github.com/redwoodjs/sdk/issues/244' target='_blank'>APIs might change</a>",
-          }),
-      }),
-    }),
+    schema: docsSchema(),
   }),
 };


### PR DESCRIPTION
Removed the top banner stating we are in preview mode since April 2025