### PR TITLE
Allow response status and headers to be modified.

### DIFF
--- a/sdk/src/runtime/requestInfo/types.ts
+++ b/sdk/src/runtime/requestInfo/types.ts
@@ -2,11 +2,17 @@ import { RwContext } from "../lib/router";
 
 export interface DefaultAppContext {}
 
+// NOTE: (peterp, 2025-08-01):
+// I think we should rename this to something other than request-info.
+// Since it's both the request and the response.
+// HttpMessages?
 export interface RequestInfo<Params = any, AppContext = DefaultAppContext> {
   request: Request;
   params: Params;
   ctx: AppContext;
+  /** @deprecated: Use `response.headers` instead */
   headers: Headers;
   rw: RwContext;
   cf: ExecutionContext;
+  response: ResponseInit;
 }

--- a/sdk/src/runtime/requestInfo/worker.ts
+++ b/sdk/src/runtime/requestInfo/worker.ts
@@ -9,7 +9,7 @@ const requestInfoStore = new AsyncLocalStorage<Record<string, any>>();
 
 const requestInfoBase = {};
 
-const REQUEST_INFO_KEYS = ["request", "params", "ctx", "headers", "rw", "cf"];
+const REQUEST_INFO_KEYS = ["request", "params", "ctx", "headers", "rw", "cf", "response"];
 
 REQUEST_INFO_KEYS.forEach((key) => {
   Object.defineProperty(requestInfoBase, key, {

--- a/sdk/src/runtime/worker.tsx
+++ b/sdk/src/runtime/worker.tsx
@@ -72,6 +72,11 @@ export const defineApp = <
           pageRouteResolved: undefined,
         };
 
+        const userResponseInit: ResponseInit = {
+          status: 200,
+          headers: new Headers(),
+        };
+
         const outerRequestInfo: RequestInfo<any, T["ctx"]> = {
           request,
           headers: userHeaders,
@@ -79,6 +84,7 @@ export const defineApp = <
           params: {},
           ctx: {},
           rw,
+          response: userResponseInit,
         };
 
         const createPageElement = (
@@ -135,10 +141,13 @@ export const defineApp = <
           });
 
           if (isRSCRequest) {
+            const responseHeaders = new Headers(userResponseInit.headers);
+            responseHeaders.set("content-type", "text/x-component; charset=utf-8");
+            
             return new Response(rscPayloadStream, {
-              headers: {
-                "content-type": "text/x-component; charset=utf-8",
-              },
+              status: userResponseInit.status,
+              statusText: userResponseInit.statusText,
+              headers: responseHeaders,
             });
           }
 
@@ -166,10 +175,13 @@ export const defineApp = <
             html = html.pipeThrough(injectRSCPayloadStream);
           }
 
+          const responseHeaders = new Headers(userResponseInit.headers);
+          responseHeaders.set("content-type", "text/html; charset=utf-8");
+          
           return new Response(html, {
-            headers: {
-              "content-type": "text/html; charset=utf-8",
-            },
+            status: userResponseInit.status,
+            statusText: userResponseInit.statusText,
+            headers: responseHeaders,
           });
         };
 
@@ -197,9 +209,20 @@ export const defineApp = <
         // we need to return a mutable response object.
         const mutableResponse = new Response(response.body, response);
 
+        // Merge user headers from the legacy headers object
         for (const [key, value] of userHeaders.entries()) {
           if (!response.headers.has(key)) {
             mutableResponse.headers.set(key, value);
+          }
+        }
+
+        // Merge headers from user response init (these take precedence)
+        if (userResponseInit.headers) {
+          const userResponseHeaders = new Headers(userResponseInit.headers);
+          for (const [key, value] of userResponseHeaders.entries()) {
+            if (!response.headers.has(key)) {
+              mutableResponse.headers.set(key, value);
+            }
           }
         }
 


### PR DESCRIPTION
I think that we need to consider adding this as an option. I don't know if this is the right way to go about it, but I wanted to start the conversation.

The `renderToString` and `renderToStream` methods are, I think, quite difficult to get right - and this is a quick win for us so that we can unblock @jldec.

I think I found better names for the request info object. I think we should call it HTTP messages. Which is what the Firefox manual refers to as request and response. I think we should also deprecate the headers and then just require that people set it on the actual response object. 