### PR TITLE
fix: Revert back to Env type in defineScript API

### DIFF
--- a/sdk/src/runtime/script.ts
+++ b/sdk/src/runtime/script.ts
@@ -2,11 +2,11 @@ import { defineApp } from "./worker";
 import { env } from "cloudflare:workers";
 
 export const defineScript = (
-  fn: ({ env }: { env: Cloudflare.Env }) => Promise<unknown>,
+  fn: ({ env }: { env: Env }) => Promise<unknown>,
 ) => {
   const app = defineApp([
     async () => {
-      await fn({ env });
+      await fn({ env: env as Env });
       return new Response("Done!");
     },
   ]);

--- a/starters/standard/src/scripts/seed.ts
+++ b/starters/standard/src/scripts/seed.ts
@@ -1,8 +1,7 @@
 import { defineScript } from "rwsdk/worker";
 import { db, setupDb } from "@/db";
-import { env } from "cloudflare:workers";
 
-export default defineScript(async () => {
+export default defineScript(async ({ env }) => {
   await setupDb(env);
 
   await db.$executeRawUnsafe(`\


### PR DESCRIPTION
#606 changed `defineScript` to use `Cloudflare.Env`. Users relying on `@cloudflare/worker-types` and not the codegen-ed `worker-configuration.d.ts` were no longer able to augment types the same way as they previously did:

```tsx
declare module "cloudflare:workers" {
  namespace Cloudflare {
    interface Env {
      DB: any;
    }
  }
}

export default defineScript(async ({ env }) => {
  const db = drizzle(env.DB);
});
```

This change reverts that part of the type changes to the `defineScript` API to bring this compatibility back.

## Links
* Discussion: https://discord.com/channels/679514959968993311/1307974274145062912/1398877727217553468