### PR TITLE
fix: HMR for adding/removing "use client"

### DIFF
--- a/sdk/src/vite/miniflareHMRPlugin.mts
+++ b/sdk/src/vite/miniflareHMRPlugin.mts
@@ -180,18 +180,18 @@ export const miniflareHMRPlugin = (givenOptions: {
       let serverDirectiveChanged = false;
 
       if (!clientFiles.has(ctx.file) && hasClientDirective) {
-        clientFiles.add(ctx.file);
+        clientFiles.add(normalizeModulePath(ctx.file, givenOptions.rootDir));
         clientDirectiveChanged = true;
       } else if (clientFiles.has(ctx.file) && !hasClientDirective) {
-        clientFiles.delete(ctx.file);
+        clientFiles.delete(normalizeModulePath(ctx.file, givenOptions.rootDir));
         clientDirectiveChanged = true;
       }
 
       if (!serverFiles.has(ctx.file) && hasServerDirective) {
-        serverFiles.add(ctx.file);
+        serverFiles.add(normalizeModulePath(ctx.file, givenOptions.rootDir));
         serverDirectiveChanged = true;
       } else if (serverFiles.has(ctx.file) && !hasServerDirective) {
-        serverFiles.delete(ctx.file);
+        serverFiles.delete(normalizeModulePath(ctx.file, givenOptions.rootDir));
         serverDirectiveChanged = true;
       }
 
@@ -208,6 +208,11 @@ export const miniflareHMRPlugin = (givenOptions: {
           environment,
           VIRTUAL_SSR_PREFIX + "/@id/virtual:use-client-lookup.js",
         );
+        invalidateModule(
+          ctx.server,
+          environment,
+          VIRTUAL_SSR_PREFIX + "virtual:use-client-lookup.js",
+        );
       }
 
       if (serverDirectiveChanged) {
@@ -222,6 +227,11 @@ export const miniflareHMRPlugin = (givenOptions: {
           ctx.server,
           environment,
           VIRTUAL_SSR_PREFIX + "/@id/virtual:use-server-lookup.js",
+        );
+        invalidateModule(
+          ctx.server,
+          environment,
+          VIRTUAL_SSR_PREFIX + "virtual:use-server-lookup.js",
         );
       }
 


### PR DESCRIPTION
We maintain lookups of client and server modules to use for client and ssr to be able to find and import these modules dynamically when they need to be used.

We make sure to add/remove from these lookups as files change (e.g. `"use client"` getting added to a module that did not have it). Problem is, when we did this adding/removing, we were not normalizing the paths - the lookups use vite style paths (`/src/app/Button.tsx`), but we were setting them as absolute paths (`/path/to/project/src/app/Button.tsx`)