### PR TITLE
fix: `createDb()` in `queue()` handlers

### DIFF
--- a/sdk/src/runtime/lib/db/DOWorkerDialect.ts
+++ b/sdk/src/runtime/lib/db/DOWorkerDialect.ts
@@ -10,10 +10,17 @@ import {
 
 const log = debug("sdk:db:do-worker-dialect");
 
-export class DOWorkerDialect {
-  config: { stub: any };
+type DOWorkerDialectConfig = {
+  kyselyExecuteQuery: (compiledQuery: {
+    sql: string;
+    parameters: readonly unknown[];
+  }) => Promise<QueryResult<any>>;
+};
 
-  constructor(config: { stub: any }) {
+export class DOWorkerDialect {
+  config: DOWorkerDialectConfig;
+
+  constructor(config: DOWorkerDialectConfig) {
     this.config = config;
   }
 
@@ -35,16 +42,16 @@ export class DOWorkerDialect {
 }
 
 class DOWorkerDriver implements Driver {
-  config: { stub: any };
+  config: DOWorkerDialectConfig;
 
-  constructor(config: { stub: any }) {
+  constructor(config: DOWorkerDialectConfig) {
     this.config = config;
   }
 
   async init() {}
 
   async acquireConnection(): Promise<DatabaseConnection> {
-    return new DOWorkerConnection(this.config.stub.kyselyExecuteQuery);
+    return new DOWorkerConnection(this.config.kyselyExecuteQuery);
   }
 
   async beginTransaction(conn: any) {

--- a/sdk/src/runtime/lib/db/createDb.ts
+++ b/sdk/src/runtime/lib/db/createDb.ts
@@ -1,54 +1,19 @@
 import { Kysely } from "kysely";
-import { requestInfo, waitForRequestInfo } from "../../requestInfo/worker.js";
 import { DOWorkerDialect } from "./DOWorkerDialect.js";
 import { type SqliteDurableObject } from "./index.js";
-import { env } from "cloudflare:workers";
-
-const createDurableObjectDb = <T>(
-  durableObjectBinding: DurableObjectNamespace<SqliteDurableObject>,
-  name = "main",
-): Kysely<T> => {
-  const durableObjectId = durableObjectBinding.idFromName(name);
-  const stub = durableObjectBinding.get(durableObjectId);
-  stub.initialize();
-
-  return new Kysely<T>({
-    dialect: new DOWorkerDialect({ stub }) as any,
-  });
-};
 
 export function createDb<T>(
-  durableObjectBinding: any,
+  durableObjectBinding: DurableObjectNamespace<SqliteDurableObject>,
   name = "main",
 ): Kysely<T> {
-  // context(justinvdm, 11 Aug 2025): We fall back to this map if we're not in a
-  // request context. For example, if `createDb` is called in a handler other
-  // than `fetch`, such as `queue`. It'll only ever store a single instance of
-  // the db.
-  const singletonDbInstanceMap = new Map();
-
-  const getOrCreateDb = () => {
-    const instanceMap = requestInfo.rw?.databases ?? singletonDbInstanceMap;
-    let db = instanceMap.get(name);
-
-    if (!db) {
-      db = createDurableObjectDb<T>(durableObjectBinding, name);
-      instanceMap.set(name, db);
-    }
-
-    return db;
-  };
-
-  return new Proxy({} as Kysely<T>, {
-    get(target, prop, receiver) {
-      const db = getOrCreateDb();
-      const value = db[prop as keyof Kysely<T>];
-
-      if (typeof value === "function") {
-        return value.bind(db);
-      }
-
-      return value;
-    },
+  return new Kysely<T>({
+    dialect: new DOWorkerDialect({
+      kyselyExecuteQuery: (...args) => {
+        const durableObjectId = durableObjectBinding.idFromName(name);
+        const stub = durableObjectBinding.get(durableObjectId);
+        stub.initialize();
+        return stub.kyselyExecuteQuery(...args);
+      },
+    }),
   });
 }

--- a/sdk/src/runtime/lib/db/createDb.ts
+++ b/sdk/src/runtime/lib/db/createDb.ts
@@ -21,8 +21,10 @@ export function createDb<T>(
   durableObjectBinding: any,
   name = "main",
 ): Kysely<T> {
-  // context(justinvdm, 11 Aug 2025): We fall back to this map if we're not in a request context.
-  // It'll only ever store a single instance of the db.
+  // context(justinvdm, 11 Aug 2025): We fall back to this map if we're not in a
+  // request context. For example, if `createDb` is called in a handler other
+  // than `fetch`, such as `queue`. It'll only ever store a single instance of
+  // the db.
   const singletonDbInstanceMap = new Map();
 
   const getOrCreateDb = () => {

--- a/sdk/src/runtime/lib/db/index.ts
+++ b/sdk/src/runtime/lib/db/index.ts
@@ -2,3 +2,4 @@ export * from "./migrations.js";
 export * from "./SqliteDurableObject.js";
 export * from "./createDb.js";
 export type * from "./typeInference/database.js";
+export { sql } from "kysely";


### PR DESCRIPTION
## Context
In Cloudflare Workers, each incoming event (e.g. an HTTP request or a Queue batch) runs inside its own isolated execution context. Any I/O object created in one event - including a Durable Object stub - can only be used in that same event. Attempting to use it in another event results in an error.

Previously, our database helper deferred creating the stub until the first time the database was accessed in a request. This was implemented using a Proxy around the database object.

## Problem
While this approach delayed stub creation compared to doing it at module load time, it still created the stub earlier than necessary. The stub would be created when the database object was first touched in the request lifecycle, not when a query was actually executed.

In HTTP request handlers this generally worked, but when calling the database from a Queue handler, the stub could still be tied to an earlier event. This would trigger the “Cannot perform I/O on behalf of a different request” error when used in the new event.

## Solution
The stub is now obtained at the point a query is executed, rather than when the database object is first accessed.

At query time:
1. A fresh stub is obtained for the current event.
2. Any setup steps are run.
3. The query is executed immediately.

Because the stub is now obtained within the same event that will use it, it is not reused across events and does not cause the cross-event I/O error. Obtaining a stub involves only in-memory lookups in the Worker environment, so doing it at query time should not have a meaningful performance cost. The heavier work of executing the query happens in the same place as before.