### PR TITLE
fix: Response never returned for client components wrapped with layouts

### DIFF
--- a/sdk/src/runtime/lib/router.ts
+++ b/sdk/src/runtime/lib/router.ts
@@ -226,12 +226,14 @@ export function defineRoutes<T extends RequestInfo = RequestInfo>(
               layouts || [],
               requestInfo,
             );
-            if (!isClientReference(WrappedComponent)) {
+
+            if (!isClientReference(h)) {
               // context(justinvdm, 31 Jul 2025): We now know we're dealing with a page route,
               // so we create a deferred so that we can signal when we're done determining whether
               // we're returning a response or a react element
               requestInfo.rw.pageRouteResolved = Promise.withResolvers();
             }
+
             return await renderPage(requestInfo, WrappedComponent, onError);
           } else {
             const r = await (h(getRequestInfo()) as Promise<Response>);


### PR DESCRIPTION
## Context
The framework's routing API allows a route to return a React element, a `Response` object, or a promise that resolves to either. To handle this, a route is executed as a function inside a wrapper component. If the function returns a `Response`, it is handled via a rejection that is caught by the request handler to break out of the React rendering cycle.

In order for us to be sure we know whether `Response` was returned or not in all cases, in #630 we added a deferred that we block the response on, and only resolve/reject it once we know whether or not a response was returned from a component.

We only opt into this behaviour when we are dealing with _server_ components - since for client components, there is no possibility of returning a response instead in client components.

## Problem
When checking whether we were dealing with a client vs server component for the logic described above, we were accidentally checking the _wrapped_ component in the case of layouts. If the layout was a server component, we'd opt into the logic where we wait for the deferred, even though nothing would ever resolve it since the underlying component was a client component.

## Solution
Check the right thing :) check whether the underlying component was a client component rather than the wrapped component.