### PR TITLE
Fix interruptors: render middleware elements; unify router flow

### DIFF
--- a/sdk/src/runtime/lib/router.ts
+++ b/sdk/src/runtime/lib/router.ts
@@ -182,67 +182,150 @@ export function defineRoutes<T extends RequestInfo = RequestInfo>(
         path = path + "/";
       }
 
-      // Find matching route
-      let match: RouteMatch<T> | null = null;
+      // Flow below; helpers are declared after the main flow for readability
 
-      for (const route of flattenedRoutes) {
-        if (typeof route === "function") {
-          const r = await route(getRequestInfo());
+      // 1) Global middlewares
+      // ----------------------
+      const globalResult = await handleGlobalMiddlewares();
 
-          if (r instanceof Response) {
-            return r;
-          }
-
-          continue;
-        }
-
-        const params = matchPath<T>(route.path, path);
-        if (params) {
-          match = { params, handler: route.handler, layouts: route.layouts };
-          break;
-        }
+      if (globalResult) {
+        return globalResult;
       }
+
+      // 2) Match route
+      // ----------------------
+      const match: RouteMatch<T> | null = matchRoute();
 
       if (!match) {
         // todo(peterp, 2025-01-28): Allow the user to define their own "not found" route.
         return new Response("Not Found", { status: 404 });
       }
 
-      let { params, handler, layouts } = match;
+      return await runWithRequestInfoOverrides(
+        { params: match.params } as Partial<T>,
+        async () => {
+          const { routeMiddlewares, componentHandler } = parseHandlers(
+            match.handler,
+          );
 
-      return runWithRequestInfoOverrides({ params } as Partial<T>, async () => {
+          // 3) Route-specific middlewares
+          // -----------------------------
+          const mwHandled = await handleRouteMiddlewares(routeMiddlewares);
+
+          if (mwHandled) {
+            return mwHandled;
+          }
+
+          // 4) Final component (always last item)
+          // -------------------------------------
+          return await handleRouteComponent(
+            componentHandler,
+            match.layouts || [],
+          );
+        },
+      );
+
+      // --- Helpers ---
+      function parseHandlers(handler: RouteHandler<T>) {
         const handlers = Array.isArray(handler) ? handler : [handler];
+        const routeMiddlewares = handlers.slice(
+          0,
+          Math.max(handlers.length - 1, 0),
+        );
+        const componentHandler = handlers[handlers.length - 1];
+        return {
+          routeMiddlewares: routeMiddlewares as RouteMiddleware<T>[],
+          componentHandler,
+        };
+      }
 
-        for (const h of handlers) {
-          if (isRouteComponent(h)) {
-            const requestInfo = getRequestInfo();
-            const WrappedComponent = wrapWithLayouts(
-              wrapHandlerToThrowResponses(h as RouteComponent<T>) as React.FC,
-              layouts || [],
-              requestInfo,
-            );
+      function renderElement(element: React.ReactElement) {
+        const requestInfo = getRequestInfo();
+        const Element: React.FC = () => element;
+        return renderPage(requestInfo, Element, onError);
+      }
 
-            if (!isClientReference(h)) {
-              // context(justinvdm, 31 Jul 2025): We now know we're dealing with a page route,
-              // so we create a deferred so that we can signal when we're done determining whether
-              // we're returning a response or a react element
-              requestInfo.rw.pageRouteResolved = Promise.withResolvers();
-            }
+      async function handleMiddlewareResult(
+        result: Response | React.JSX.Element | void,
+      ): Promise<Response | undefined> {
+        if (result instanceof Response) {
+          return result;
+        }
+        if (result && React.isValidElement(result)) {
+          return await renderElement(result);
+        }
+        return undefined;
+      }
 
-            return await renderPage(requestInfo, WrappedComponent, onError);
-          } else {
-            const r = await (h(getRequestInfo()) as Promise<Response>);
-            if (r instanceof Response) {
-              return r;
-            }
+      async function handleGlobalMiddlewares(): Promise<Response | undefined> {
+        for (const route of flattenedRoutes) {
+          if (typeof route !== "function") break; // stop at first route definition
+          const result = await route(getRequestInfo());
+          const handled = await handleMiddlewareResult(result);
+          if (handled) return handled;
+        }
+        return undefined;
+      }
+
+      function matchRoute(): RouteMatch<T> | null {
+        for (const route of flattenedRoutes) {
+          if (typeof route === "function") continue;
+          const params = matchPath<T>(route.path, path);
+          if (params) {
+            return { params, handler: route.handler, layouts: route.layouts };
           }
         }
+        return null;
+      }
 
-        // Add fallback return
+      async function handleRouteMiddlewares(
+        mws: RouteMiddleware<T>[],
+      ): Promise<Response | undefined> {
+        for (const mw of mws) {
+          const result = await (mw(getRequestInfo()) as Promise<
+            Response | React.JSX.Element | void
+          >);
+          const handled = await handleMiddlewareResult(result);
+          if (handled) return handled;
+        }
+        return undefined;
+      }
+
+      async function handleRouteComponent(
+        component: RouteFunction<T> | RouteComponent<T>,
+        layouts: React.FC<LayoutProps<T>>[],
+      ): Promise<Response> {
+        if (isRouteComponent(component)) {
+          const requestInfo = getRequestInfo();
+          const WrappedComponent = wrapWithLayouts(
+            wrapHandlerToThrowResponses(
+              component as RouteComponent<T>,
+            ) as React.FC,
+            layouts,
+            requestInfo,
+          );
+
+          if (!isClientReference(component)) {
+            // context(justinvdm, 31 Jul 2025): We now know we're dealing with a page route,
+            // so we create a deferred so that we can signal when we're done determining whether
+            // we're returning a response or a react element
+            requestInfo.rw.pageRouteResolved = Promise.withResolvers();
+          }
+
+          return await renderPage(requestInfo, WrappedComponent, onError);
+        }
+
+        // If the last handler is not a component, handle as middleware result (no layouts)
+        const tailResult = await (component(getRequestInfo()) as Promise<
+          Response | React.JSX.Element | void
+        >);
+        const handledTail = await handleMiddlewareResult(tailResult);
+        if (handledTail) return handledTail;
+
         return new Response("Response not returned from route handler", {
           status: 500,
         });
-      });
+      }
     },
   };
 }

--- a/sdk/src/runtime/lib/router.ts
+++ b/sdk/src/runtime/lib/router.ts
@@ -259,7 +259,9 @@ export function defineRoutes<T extends RequestInfo = RequestInfo>(
 
       async function handleGlobalMiddlewares(): Promise<Response | undefined> {
         for (const route of flattenedRoutes) {
-          if (typeof route !== "function") break; // stop at first route definition
+          if (typeof route !== "function") {
+            break; // stop at first route definition
+          }
           const result = await route(getRequestInfo());
           const handled = await handleMiddlewareResult(result);
           if (handled) return handled;

--- a/sdk/src/runtime/lib/router.ts
+++ b/sdk/src/runtime/lib/router.ts
@@ -25,22 +25,17 @@ export type RwContext = {
 
 export type RouteMiddleware<T extends RequestInfo = RequestInfo> = (
   requestInfo: T,
-) =>
-  | Response
-  | Promise<Response>
-  | void
-  | Promise<void>
-  | Promise<Response | void>;
+) => MaybePromise<React.JSX.Element | Response | void>;
 
 type RouteFunction<T extends RequestInfo = RequestInfo> = (
   requestInfo: T,
-) => Response | Promise<Response>;
+) => MaybePromise<Response>;
 
 type MaybePromise<T> = T | Promise<T>;
 
 type RouteComponent<T extends RequestInfo = RequestInfo> = (
   requestInfo: T,
-) => MaybePromise<React.JSX.Element | Response>;
+) => MaybePromise<React.JSX.Element | Response | void>;
 
 type RouteHandler<T extends RequestInfo = RequestInfo> =
   | RouteFunction<T>

--- a/sdk/src/runtime/lib/router.ts
+++ b/sdk/src/runtime/lib/router.ts
@@ -260,7 +260,7 @@ export function defineRoutes<T extends RequestInfo = RequestInfo>(
       async function handleGlobalMiddlewares(): Promise<Response | undefined> {
         for (const route of flattenedRoutes) {
           if (typeof route !== "function") {
-            break; // stop at first route definition
+            continue;
           }
           const result = await route(getRequestInfo());
           const handled = await handleMiddlewareResult(result);


### PR DESCRIPTION
## Context
The router runs a sequence of handlers for each request:
1) global middlewares
2) route matching
3) route-specific middlewares
4) final page component

Middlewares can return a Response, an element, or undefined. The final page component returns an element and may also return a Response.

## Problem
- Global middlewares did not use the same element handling and render path as the page component. If a global middleware returned an element, it was not rendered as a page interruptor.
- Route-specific middlewares used duplicated logic intermixed with component handling, which made the flow unclear and caused the page component handling to run per iteration rather than once at the end.
- Layout wrapping was not clearly separated to only apply to the final page component.

This made interruptor-style middlewares unreliable and the code hard to follow.

## Solution
- Run both global and route-specific middlewares through the same result pipeline:
  - Response: return it.
  - Element: render it via the standard page render path.
  - Undefined: continue.
- Keep layout wrapping strictly for the final page component only.
- Make the request flow explicit and linear:
  1) run global middlewares
  2) match route
  3) run route-specific middlewares
  4) run the final component
- Factor out helper logic for parsing handlers and for handling middleware results so the same rules are applied in steps 1 and 3, and the component behavior is isolated in step 4.

Also fixed the corresponding types to make sure they match the return types we've designed for in each case.

## Example
This app demonstrates both a global interruptor and a route-level interruptor.

```tsx
import { defineApp, requestInfo } from "rwsdk/worker";
import { render, route } from "rwsdk/router";

import { Document } from "@/app/Document";
import { Home } from "@/app/pages/Home";
import { setCommonHeaders } from "@/app/headers";

export type AppContext = {};

export default defineApp([
  setCommonHeaders(),
  ({ ctx }) => {
    // setup ctx here
    ctx;
  },
  async () => {
    await new Promise((resolve) => setTimeout(resolve, 100));
    const url = new URL(requestInfo.request.url);
    if (url.searchParams.get("render_global_interruptor")) {
      console.log("###### rendering global interruptor");
      return <div>Global interruptor</div>;
    }
  },
  render(Document, [
    route("/", [
      async () => {
        await new Promise((resolve) => setTimeout(resolve, 100));
        const url = new URL(requestInfo.request.url);
        if (url.searchParams.get("render_page_interruptor")) {
          console.log("###### rendering page interruptor");
          return <div>Page interruptor</div>;
        }
      },
      () => {
        return <div>Page</div>;
      },
    ]),
  ]),
]);
```

## Demo of it working
(Please excuse the DnB :p didn't realise muted looms still record output sound!)

https://www.loom.com/share/9768b14e27774f6ba261424c72abd92c