### PR TITLE
fix: No props in client components when { ssr: false }

### DIFF
--- a/sdk/src/runtime/imports/client.ts
+++ b/sdk/src/runtime/imports/client.ts
@@ -42,8 +42,8 @@ export const clientWebpackRequire = memoize(async (id: string) => {
 
   const Lazy = React.lazy(() => promisedDefault);
 
-  const Wrapped = () =>
-    React.createElement(ClientOnly, null, React.createElement(Lazy));
+  const Wrapped = (props: any) =>
+    React.createElement(ClientOnly, null, React.createElement(Lazy, props));
 
   return { [id]: Wrapped };
 });


### PR DESCRIPTION
When using `render(..., { ssr: false })`, we wrap client components in order for their initial render result on mount to be `null`, so that we can match the hydrated RSC payload.

When doing this wrapping, we were not passing along the props passed to the wrapper.

As a result, client components used in server components did not get the props passed to them from those server components.

Fixes #583