### PR TITLE
fix: Change react deps to optional

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,18 +140,9 @@ importers:
       puppeteer-core:
         specifier: ^22.8.1
         version: 22.15.0
-      react:
-        specifier: 19.2.0-canary-39cad7af-20250411
-        version: 19.2.0-canary-39cad7af-20250411
-      react-dom:
-        specifier: 19.2.0-canary-39cad7af-20250411
-        version: 19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411)
       react-is:
         specifier: ^19.0.0
         version: 19.0.0
-      react-server-dom-webpack:
-        specifier: 19.2.0-canary-39cad7af-20250411
-        version: 19.2.0-canary-39cad7af-20250411(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)(webpack@5.97.1)
       rsc-html-stream:
         specifier: ^0.0.6
         version: 0.0.6
@@ -176,6 +167,16 @@ importers:
       wrangler:
         specifier: ^4.20.5
         version: 4.20.5(@cloudflare/workers-types@4.20250407.0)
+    optionalDependencies:
+      react:
+        specifier: 19.2.0-canary-39cad7af-20250411
+        version: 19.2.0-canary-39cad7af-20250411
+      react-dom:
+        specifier: 19.2.0-canary-39cad7af-20250411
+        version: 19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411)
+      react-server-dom-webpack:
+        specifier: 19.2.0-canary-39cad7af-20250411
+        version: 19.2.0-canary-39cad7af-20250411(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)(webpack@5.97.1)
     devDependencies:
       '@types/debug':
         specifier: ^4.1.12

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -155,9 +155,9 @@
   },
   "peerDependencies": {
     "vite": "^6.2.6",
-    "react": ">=19.2.0-0 || >=19.2.0",
-    "react-dom": ">=19.2.0-0 || >=19.2.0",
-    "react-server-dom-webpack": ">=19.2.0-0 || >=19.2.0"
+    "react": ">=19.2.0-0 <20",
+    "react-dom": ">=19.2.0-0 <20",
+    "react-server-dom-webpack": ">=19.2.0-0 <20"
   },
   "optionalDependencies": {
     "react": "19.2.0-canary-39cad7af-20250411",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -144,10 +144,7 @@
     "picocolors": "^1.1.1",
     "proper-lockfile": "^4.1.2",
     "puppeteer-core": "^22.8.1",
-    "react": "19.2.0-canary-39cad7af-20250411",
-    "react-dom": "19.2.0-canary-39cad7af-20250411",
     "react-is": "^19.0.0",
-    "react-server-dom-webpack": "19.2.0-canary-39cad7af-20250411",
     "rsc-html-stream": "^0.0.6",
     "tmp-promise": "^3.0.3",
     "ts-morph": "^25.0.1",
@@ -161,6 +158,11 @@
     "react": ">=19.2.0-0 || >=19.2.0",
     "react-dom": ">=19.2.0-0 || >=19.2.0",
     "react-server-dom-webpack": ">=19.2.0-0 || >=19.2.0"
+  },
+  "optionalDependencies": {
+    "react": "19.2.0-canary-39cad7af-20250411",
+    "react-dom": "19.2.0-canary-39cad7af-20250411",
+    "react-server-dom-webpack": "19.2.0-canary-39cad7af-20250411"
   },
   "peerDependenciesMeta": {
     "react": {


### PR DESCRIPTION
## Context

In [#653](https://github.com/redwoodjs/sdk/compare/link-to-pr-653), we changed rwsdk’s package.json to:
```json
"dependencies": {
  "react": "19.2.0-canary-39cad7af-20250411",
  "react-dom": "19.2.0-canary-39cad7af-20250411",
  "react-server-dom-webpack": "19.2.0-canary-39cad7af-20250411"
},
"peerDependencies": {
  "react": ">=19.2.0-0 || >=19.2.0",
  "react-dom": ">=19.2.0-0 || >=19.2.0",
  "react-server-dom-webpack": ">=19.2.0-0 || >=19.2.0"
},
"peerDependenciesMeta": {
  "react": { "optional": true },
  "react-dom": { "optional": true },
  "react-server-dom-webpack": { "optional": true }
}
```

We did this for backwards compat: users could keep what they had, but also take control of React deps by adding them themselves, instead of being locked to the versions pinned in rwsdk.

## Problem

With pnpm, this setup does not actually install React when the app does not declare it. Marking the peer as optional means pnpm does not treat it as required, and the fallback in dependencies was not installed either. Net effect: apps without React declared stop working. Our smoke tests failed at release time.

This did not show up in CI or manual tests when an existing node_modules already had React from a previous rwsdk install, which masked the issue.

## Solution

Use optional peers + optionalDependencies as the fallback:
```json
"peerDependencies": {
  "react": ">=19.2.0-0 <20",
  "react-dom": ">=19.2.0-0 <20",
  "react-server-dom-webpack": ">=19.2.0-0 <20"
},
"peerDependenciesMeta": {
  "react": { "optional": true },
  "react-dom": { "optional": true },
  "react-server-dom-webpack": { "optional": true }
},
"optionalDependencies": {
  "react": "19.2.0-canary-39cad7af-20250411",
  "react-dom": "19.2.0-canary-39cad7af-20250411",
  "react-server-dom-webpack": "19.2.0-canary-39cad7af-20250411"
}
```

* When the app does not declare React, pnpm, npm, and yarn will install the pinned fallback from optionalDependencies under rwsdk, restoring true backwards compat.
* When the app does declare React, the app's version is used.

## Verification

We tested these permutations in an isolated example:
* pnpm, peer required (no peerDependenciesMeta.optional) + no app React => pnpm auto‑installed a top‑level React at the latest version in the peer range.
* pnpm, peer optional + fallback in dependencies => React was not installed when the app lacked it. Broken.
* pnpm, peer optional + fallback in optionalDependencies => React was installed from optionalDependencies under the package when the app lacked it. When the app declared React, the app’s version won. This held with and without an existing node_modules.
* npm and yarn, peer optional + fallback in optionalDependencies => Fallback installed under the package when the app lacked React. Yarn shows an unmet peer warning; When the app declared React, the app’s version won.

This change keeps installs working for apps that do not declare React, and still allows apps to control React explicitly by adding it themselves.