### PR TITLE
feat: Allow specifying wrangler config via env var

### DIFF
--- a/sdk/src/scripts/worker-run.mts
+++ b/sdk/src/scripts/worker-run.mts
@@ -19,15 +19,24 @@ export const runWorkerScript = async (relativeScriptPath: string) => {
     console.error("Error: Script path is required");
     console.log("\nUsage:");
     console.log("  npm run worker:run <script-path>");
-    console.log("\nExample:");
-    console.log("  npm run worker:run src/scripts/seed.ts\n");
+    console.log("\nOptions:");
+    console.log(
+      "  RWSDK_WRANGLER_CONFIG      Environment variable for config path",
+    );
+    console.log("\nExamples:");
+    console.log("  npm run worker:run src/scripts/seed.ts");
+    console.log(
+      "  RWSDK_WRANGLER_CONFIG=custom.toml npm run worker:run src/scripts/seed.ts\n",
+    );
     process.exit(1);
   }
 
   const scriptPath = resolve(process.cwd(), relativeScriptPath);
   debug("Running worker script: %s", scriptPath);
 
-  const workerConfigPath = await findWranglerConfig(process.cwd());
+  const workerConfigPath = process.env.RWSDK_WRANGLER_CONFIG
+    ? resolve(process.cwd(), process.env.RWSDK_WRANGLER_CONFIG)
+    : await findWranglerConfig(process.cwd());
   debug("Using wrangler config: %s", workerConfigPath);
 
   const workerConfig = unstable_readConfig({

--- a/sdk/src/vite/redwoodPlugin.mts
+++ b/sdk/src/vite/redwoodPlugin.mts
@@ -61,7 +61,10 @@ export const redwoodPlugin = async (
   const projectRootDir = process.cwd();
 
   const workerConfigPath =
-    options.configPath ?? (await findWranglerConfig(projectRootDir));
+    options.configPath ??
+    (process.env.RWSDK_WRANGLER_CONFIG
+      ? resolve(projectRootDir, process.env.RWSDK_WRANGLER_CONFIG)
+      : await findWranglerConfig(projectRootDir));
 
   const workerEntryPathname = await determineWorkerEntryPathname(
     projectRootDir,


### PR DESCRIPTION
## Problem
Currently, one is able to specify a custom config path for their wrangler config in our vite plugin, but not with `worker-run` scripts. We need to be able to specifying the wrangler config in both cases.

## Solution
Change both the vite pugin and `worker-run` to make use of a `RWSDK_WRANGLER_CONFIG` env var to specify the wrangler config path.

Went fr env var instead of a cli arg, so that it can be propagated more easily to the different parts that need to know the worker config path.

```bash
RWSDK_WRANGLER_CONFIG=... pnpm dev:init
RWSDK_WRANGLER_CONFIG=... pnpm dev
```

Solves #636