### PR TITLE
🐛 Fixed code highlighting

### DIFF
--- a/docs/src/content/docs/core/authentication.mdx
+++ b/docs/src/content/docs/core/authentication.mdx
@@ -149,7 +149,7 @@ When a request comes in, we:
 4. If there's an active session, we pull the user ID from it and load the user from the **database ([D1](https://developers.cloudflare.com/d1/) + [Prisma](https://www.prisma.io/))**.
 
 <Code
-  language="typescript"
+  lang="typescript"
   title="src/worker.tsx"
   code={importedCodeStandardWorker}
   collapse={"2-17, 19-19, 21-22, 31-31, 33-47"}
@@ -179,14 +179,14 @@ For more on passkeys, see [passkeys.dev](https://passkeys.dev/).
 6. If successful, the session is updated with the **user ID**.
 
 <Code
-  language="typescript"
+  lang="typescript"
   title="src/app/pages/user/Login.tsx"
   code={importedCodeStandardLogin}
   collapse={"1-18, 20-24, 41-90"}
 />
 
 <Code
-  language="typescript"
+  lang="typescript"
   title="src/app/pages/user/functions.ts"
   code={importedCodeStandardAuthFunctions}
   collapse={"1-109, 111-112, 114-116, 119-169"}
@@ -199,7 +199,7 @@ For more on passkeys, see [passkeys.dev](https://passkeys.dev/).
 Registration follows a very similar 3-step WebAuthn process as login:
 
 <Code
-  language="typescript"
+  lang="typescript"
   title="src/app/pages/user/Login.tsx"
   code={importedCodeStandardLogin}
   collapse={"1-18, 20-41, 64-90"}
@@ -219,14 +219,14 @@ Cloudflare has built-in bot protection, but it works by detecting and blocking m
 4. The backend verifies the token using `verifyTurnstileToken()` before completing registration.
 
 <Code
-  language="typescript"
+  lang="typescript"
   title="src/app/pages/user/Login.tsx"
   code={importedCodeStandardLogin}
   collapse={"1-15, 18-18, 20-22, 24-41, 43-48, 57-62, 64-72, 76-88"}
 />
 
 <Code
-  language="typescript"
+  lang="typescript"
   title="src/app/pages/user/functions.ts"
   code={importedCodeStandardAuthFunctions}
   collapse={"1-38, 40-43, 45-46, 55-93, 95-176"}


### PR DESCRIPTION
Changed `language` prop to `lang` based on [Expressive Code documentation](https://expressive-code.com/key-features/code-component/#available-props)

Before:

<img width="1452" height="1872" alt="CleanShot 2025-08-27 at 21 47 58@2x" src="https://github.com/user-attachments/assets/f9e1d9b2-c04a-477f-be2a-ecc48355ee91" />

After:

<img width="1446" height="1868" alt="CleanShot 2025-08-27 at 21 48 15@2x" src="https://github.com/user-attachments/assets/dc5414d4-032b-4330-b214-40b9cf54e42d" />
