### PR TITLE
fix(vite): Implement robust alias resolution for directive scan

### DIFF
--- a/.worklogs/justin/2025-09-03-directive-scan-timing-in-dev.md
+++ b/.worklogs/justin/2025-09-03-directive-scan-timing-in-dev.md
@@ -87,7 +87,7 @@ This is the definitive solution because it is the most efficient (the hook only 
 
 ## 7. Final Implementation: The "Dummy File" Strategy
 
-The "Just-in-Time" content generation via `onLoad` was the correct strategy, but it was further refined to be more compatible with Vite's file-based dependency scanner.
+The "Just-In-Time" content generation via `onLoad` was the correct strategy, but it was further refined to be more compatible with Vite's file-based dependency scanner.
 
 The final, definitive implementation uses a physical "dummy file" to provide a stable target for `esbuild`, and then hijacks the loading of that file to provide the dynamic content.
 
@@ -97,3 +97,17 @@ The final, definitive implementation uses a physical "dummy file" to provide a s
 4.  **Just-in-Time Scan and Content Injection:** The `onLoad` hook's logic remains the same. The first time it's triggered for one of the dummy files, it runs the directive scan (guarded by a promise). Once the scan completes, it generates the appropriate barrel content in memory and returns it directly to `esbuild`, effectively replacing the empty content of the dummy file.
 
 This is the most robust solution because it works with `esbuild`'s file-based nature while still providing our content dynamically, all triggered at the exact moment it's needed.
+
+### 8. The Definitive Fix: Plugin Ordering (`enforce: 'post'`)
+
+After extensive investigation into Vite's resolver and `esbuild`'s behavior, the final solution was discovered to be an issue of **plugin ordering**. Two distinct but related problems were solved:
+
+1.  **Architectural Flaw:** Our initial scanner used a simplistic, custom alias resolution logic. The switch to using Vite's `createIdResolver` was a critical architectural improvement. While this change alone did not fix the immediate bug, it made our scanner significantly more robust and compatible with the Vite ecosystem by aligning it with the same resolver that Vite's own dependency optimizer uses.
+
+2.  **Timing/Ordering Flaw:** The direct cause of the alias resolution failure was that our `configPlugin` was running *before* other plugins (e.g., `vite-tsconfig-paths`) had a chance to add their aliases to the configuration. When our scanner ran, it was working with an incomplete set of aliases. The initial focus on the `@/*` syntax was a **red herring**; the problem was that we were missing aliases from any plugin that ran after ours.
+
+The solution was to fix the ordering:
+
+-   **Add `enforce: 'post'` to `configPlugin.mts`:** This Vite-specific property forces our plugin to run *after* all other plugins. This guarantees that when our `configResolved` hook executes, the configuration contains the complete, final list of aliases from all sources.
+
+This ordering change was the definitive fix for the bug. It ensured that our architecturally sound scanner—now powered by `createIdResolver`—was finally being fed the correct data.

--- a/.worklogs/justin/2025-09-03-directive-scan-timing-in-dev.md
+++ b/.worklogs/justin/2025-09-03-directive-scan-timing-in-dev.md
@@ -1,0 +1,39 @@
+# Work Log: 2025-09-03 - Solving Directive Scan Resolution and Timing
+
+## 1. Problem Definition & Goal
+
+The initial problem was a failure in our custom `esbuild`-based directive scanner (`runDirectivesScan`). This scanner is responsible for discovering `"use client"` and `"use server"` directives by traversing the application's dependency graph.
+
+The scanner's module resolution logic was too simplistic and broke when it encountered a project that used star (`*`) path aliases. This revealed a fundamental flaw in our approach: we were attempting to re-implement complex module resolution logic that Vite already handles perfectly.
+
+The goal therefore shifted from patching our scanner to integrating Vite's own resolution capabilities, and then solving the subsequent timing challenges that this integration revealed.
+
+## 2. Investigation: From "How" to "When"
+
+### 2.1. Part 1: Finding the Right Tool
+
+The first step was to find a way to leverage Vite's resolver. We investigated Vite's source code and found:
+*   Vite's internal `esbuildDepPlugin` was not exported and could not be used directly.
+*   However, Vite *does* export a `createIdResolver` function, which provides access to its powerful, alias-aware resolution logic. This became the target for our integration.
+
+### 2.2. Part 2: Finding the Right Time
+
+Simply calling `createIdResolver` was not enough. This led to a deeper investigation into the Vite dev server's startup lifecycle, revealing a critical timing issue. For the resolver to work correctly, it needs the fully initialized `Environment` object, which contains the complete plugin container and resolved configuration.
+
+Our scan, therefore, had to run *after* the environments were initialized, but *before* Vite's dependency optimizer (`optimizeDeps`) started, so that the results of our scan (the barrel files) could be included in the pre-bundling process.
+
+We explored using Vite's standard plugin hooks:
+*   **`configResolved`:** This hook runs too early. The `Environment` objects exist only as configuration and lack the fully initialized plugin containers needed by the resolver.
+*   **`configureServer`:** This hook also runs too early. While Vite awaits promises from this hook, it runs *before* Vite's internal `_initEnvironments()` method is called. This meant our scan would finish before the environments were truly ready.
+
+## 3. The Solution: Intercepting Environment Initialization
+
+Since no public hook exists in the small window between environment initialization and dependency scanning, the most precise solution was to intercept the internal process that bridges them.
+
+The chosen strategy is to wrap Vite's internal `_initEnvironments` method on the `ViteDevServer` instance.
+
+1.  **Use `configureServer` to get access:** The `configureServer` hook provides access to the `server` instance.
+2.  **Wrap the Internal Method:** We store a reference to the original `server._initEnvironments` method and replace it with our own `async` function.
+3.  **Enforce the Correct Order:** Our wrapper function first `await`s the original method, ensuring Vite's environments are fully initialized. Immediately after, it runs our `runDirectivesScan`.
+
+This approach, while relying on an internal API, is a targeted and robust solution. It allows us to inject our logic at the exact moment required, ensuring our scanner uses Vite's own resolver with a fully prepared environment, and that its output is ready for the dependency optimizers. This solves both the original resolution bug and the subsequent timing issue.

--- a/.worklogs/justin/2025-_09_03-directive-scan-timing-in-dev.md
+++ b/.worklogs/justin/2025-_09_03-directive-scan-timing-in-dev.md
@@ -1,0 +1,17 @@
+This refined approach is surgically precise. It uses the earliest possible hook to guarantee our logic is injected at the correct point, solving the timing issue in a robust and reliable way, all within a single, maintainable plugin.
+
+## 5. Final Strategy: A "Just-In-Time" Scan
+
+The patching strategy, while theoretically sound, proved to be unreliable in practice. The core issue remained that interfering with Vite's internal startup lifecycle is inherently fragile.
+
+The final, successful, and dramatically simpler solution is to abandon patching entirely and run the scan "Just-In-Time."
+
+The insight is that we don't need to preemptively run the scan and then pause other processes. Instead, we can wait until the `client` or `ssr` optimizer *first asks for one of our barrel files*. At that precise moment, we know the scan results are needed, and we can be reasonably certain that the dev server and its environments have been instantiated.
+
+The implementation is as follows:
+1.  **Store the Server Instance:** We use the standard `configureServer` hook for one simple purpose: to get and store a reference to the `ViteDevServer` instance.
+2.  **Trigger Scan on First Resolution:** We retain the custom `esbuild` plugin that is injected into the `client` and `ssr` optimizers. Its `onResolve` hook still intercepts requests for our barrel files.
+3.  **Run Scan Inside `onResolve`:** The first time this hook is triggered, it uses the stored server reference to access `server.environments.worker` and *then* runs the `runDirectivesScan`. A guard ensures the scan is only run once, with subsequent requests awaiting the result of the first scan.
+4.  **Generate Barrels and Proceed:** Once the scan promise resolves, the `onResolve` hook generates the barrel content (using the now-populated file sets) and allows the optimization to proceed.
+
+This approach is superior because it eliminates all fragile monkey-patching, relies on stable public APIs, and performs the expensive scan only at the precise moment it is first required. It is simpler, more robust, and more aligned with Vite's event-driven nature.

--- a/docs/architecture/devServerDependencyOptimization.md
+++ b/docs/architecture/devServerDependencyOptimization.md
@@ -39,3 +39,21 @@ This approach is superior because it works *with* the bundler's expectations.
 -   **It Delegates Responsibility:** We are no longer responsible for mapping a source file to its final, optimized chunk path. By using a standard package import, we delegate the resolution to Vite's core module resolver, which correctly and automatically handles the mapping to the final pre-bundled chunk.
 
 By framing our dependencies in a way Vite is designed to understand, we resolve the request waterfall and achieve the original performance goal in a clean, stable, and maintainable way.
+
+### 3. Solving the Inter-Environment Race Condition
+
+A critical challenge in this process is the timing of the standalone scan relative to the `client` and `ssr` optimizers that consume its output.
+
+**The Problem: Parallel Optimization**
+
+Vite's dev server is designed for efficiency and initializes all environments (`worker`, `client`, `ssr`) in parallel. This means their `optimizeDeps` processes also kick off concurrently. This creates a natural race condition: our standalone scan, which is triggered by the `worker` environment's initialization, is still running when the `client` and `ssr` optimizers start. Consequently, the `client` and `ssr` optimizers attempt to process our barrel files *before* the scan has finished populating them with content, leading to a failed optimization.
+
+**The Solution: A Two-Part Synchronization Strategy**
+
+We solve this race condition using a single plugin (`directiveModulesDevPlugin`) that employs a two-part strategy based on patching Vite's startup process:
+
+1.  **Orchestration (in the `config` hook):** We use the very early `config` hook to patch the `createEnvironment` and `init` methods of the `worker` environment. This allows us to run our standalone scan at the exact moment the `worker` is initialized. Upon completion, the scan resolves a shared promise, which acts as a signal.
+
+2.  **Synchronization (via an `esbuild` plugin):** In the same `config` hook, we inject a custom `esbuild` plugin into the `optimizeDeps` configuration for the `client` and `ssr` environments. This plugin has an `onResolve` hook that intercepts requests for our barrel files. The hook's only job is to `await` the shared promise from the worker scan. This effectively pauses the `client` and `ssr` optimizers at the critical moment, forcing them to wait until the `worker` scan is complete before they proceed.
+
+This strategy, while complex, creates a reliable causal chain. It allows Vite to retain its parallel startup for general efficiency but creates a targeted, synchronous dependency for our specific barrel files, ensuring the entire process completes in the correct order.

--- a/docs/architecture/devServerDependencyOptimization.md
+++ b/docs/architecture/devServerDependencyOptimization.md
@@ -14,11 +14,11 @@ This forced `optimizeDeps` into an inefficient mode. Seeing hundreds of individu
 
 The final, robust solution works *with* Vite's architecture rather than fighting it. It gives us full control over the discovery process and then communicates the results to Vite using standard, public APIs. The strategy has two main parts.
 
-### 1. A Controlled, Standalone `esbuild` Scan
+### 1. A Standalone `esbuild` Scan (Pre-Optimization)
 
-Before Vite's dev server starts, we run our own, separate `esbuild` scan.
--   **Exhaustive Discovery:** This scan starts from the application's entry points and traverses the entire dependency graph. Because we control this process, we can ensure it is exhaustive. A custom `esbuild` plugin reads the content of every resolved module and checks for `"use client"` or `"use server"` directives, populating a complete and accurate list of all directive-marked files.
--   **Configuration-Aware:** Crucially, this standalone scan is configured to use the application's final, resolved Vite configuration (including `resolve.alias`). This ensures its module resolution perfectly mimics the application's runtime behavior, making the scan both accurate and reliable.
+Before Vite's `optimizeDeps` process begins, we run our own, separate `esbuild` scan.
+-   **Exhaustive Discovery:** This scan starts from the application's entry points and traverses the entire dependency graph. It uses a custom `esbuild` plugin—internal to our scanning process—that reads the content of every resolved module and checks for `"use client"` or `"use server"` directives, populating a complete and accurate list of all directive-marked files.
+-   **Configuration-Aware:** The scanner's key feature is its use of Vite's own internal module resolver (`createIdResolver`). By passing it the application's final, resolved Vite configuration, we ensure its module resolution perfectly mimics the application's runtime behavior, making the scan both accurate and reliable.
 
 With this scan complete, we have a definitive list of all client components *before* Vite's optimizer begins its work.
 

--- a/docs/architecture/productionBuildProcess.md
+++ b/docs/architecture/productionBuildProcess.md
@@ -18,10 +18,10 @@ To resolve this, we implement a five-step process that begins with a broad disco
 
 ### Step 1: Initial Directive Scan
 
-Before any Vite environments are built, we run a fast, preliminary `esbuild` scan on the application's `worker` entry point.
+Before any Vite environments are built, we run our own, separate `esbuild` scan on the application's `worker` entry point.
 
--   **Purpose:** The goal of this scan is to traverse the entire potential dependency graph and create a master list of every file that contains a `"use client"` or `"use server"` directive.
--   **Vite Compatibility:** This scan is configured to use a custom plugin that mirrors Vite's own resolving capabilities, allowing it to correctly handle project-specific configurations like `resolve.alias`.
+-   **Purpose:** To traverse the entire potential dependency graph and create a master list of every file that contains a `"use client"` or `"use server"` directive. This scan uses a custom `esbuild` plugin, internal to our scanning process, to inspect file contents.
+-   **Vite Compatibility:** The scanner is built on `esbuild` but crucially uses Vite's own internal module resolver (`createIdResolver`). This ensures that its dependency traversal perfectly mimics the application's actual runtime behavior, correctly handling complex project configurations like `resolve.alias`.
 
 This initial step provides a complete, albeit unfiltered, list of all potential directive modules.
 

--- a/sdk/src/vite/buildApp.mts
+++ b/sdk/src/vite/buildApp.mts
@@ -27,15 +27,15 @@ export async function buildApp({
   serverFiles: Set<string>;
   projectRootDir: string;
 }) {
+  const workerEnv = builder.environments.worker;
   await runDirectivesScan({
     rootConfig: builder.config,
-    envName: "worker",
+    environment: workerEnv,
     clientFiles,
     serverFiles,
   });
 
   console.log("Building worker to discover used client components...");
-  const workerEnv = builder.environments.worker;
   process.env.RWSDK_BUILD_PASS = "worker";
   await builder.build(workerEnv);
 

--- a/sdk/src/vite/directiveModulesDevPlugin.mts
+++ b/sdk/src/vite/directiveModulesDevPlugin.mts
@@ -1,10 +1,13 @@
 import path from "node:path";
-import { Environment, Plugin } from "vite";
+import { Plugin, DevEnvironment } from "vite";
 import { writeFileSync, mkdirSync } from "node:fs";
 import { normalizeModulePath } from "../lib/normalizeModulePath.mjs";
+import { CLIENT_BARREL_PATH, SERVER_BARREL_PATH } from "../lib/constants.mjs";
 import { runDirectivesScan } from "./runDirectivesScan.mjs";
-import { CLIENT_BARREL_PATH } from "../lib/constants.mjs";
-import { SERVER_BARREL_PATH } from "../lib/constants.mjs";
+
+// Awaiting this promise will ensure that the worker environment's directive
+// scan is complete.
+let workerScanComplete: Promise<void>;
 
 export const VIRTUAL_CLIENT_BARREL_ID = "virtual:rwsdk:client-module-barrel";
 export const VIRTUAL_SERVER_BARREL_ID = "virtual:rwsdk:server-module-barrel";
@@ -45,53 +48,16 @@ export const directiveModulesDevPlugin = ({
   serverFiles: Set<string>;
   projectRootDir: string;
 }): Plugin => {
-  return {
-    name: "rwsdk:directive-modules-dev",
-    enforce: "pre",
-    configResolved(config) {
-      if (config.command !== "serve") {
-        return;
-      }
-
-      for (const [envName, env] of Object.entries(config.environments)) {
-        if (envName === "client" || envName === "ssr") {
-          env.optimizeDeps.include = [
-            ...(env.optimizeDeps.include || []),
-            CLIENT_BARREL_EXPORT_PATH,
-            SERVER_BARREL_EXPORT_PATH,
-          ];
-        }
-      }
-    },
-
-    configureServer(server) {
-      // context(justinvdm, 3 Sep 2025): This is a workaround for a timing issue
-      // in Vite's startup process. We need to run our directive scan after
-      // the environments are fully initialized but before the dependency
-      // optimizer starts. No public hook exists for this, so we wrap the
-      // internal _initEnvironments method to inject our logic at the right time.
-      // See the full explanation in the work log:
-      // .worklogs/justin/2025-09-03-directive-scan-timing-in-dev.md
-      const originalInit = (server as any)._initEnvironments;
-
-      (server as any)._initEnvironments = async () => {
-        await originalInit.call(server);
-
-        const workerEnv = server.config.environments[
-          "worker"
-        ] as unknown as Environment;
-
-        if (workerEnv) {
-          await runDirectivesScan({
-            rootConfig: server.config,
-            environment: workerEnv,
-            clientFiles,
-            serverFiles,
-          });
-        }
-
-        // Generate the barrel content and write it to the dummy files.
-        // We can do this now because our scan is complete.
+  const esbuildBlockingPlugin = {
+    name: "rwsdk:esbuild-barrel-blocker",
+    setup(build: any) {
+      const barrelFilter = new RegExp(
+        `(${CLIENT_BARREL_PATH}|${SERVER_BARREL_PATH})`,
+      );
+      build.onResolve({ filter: barrelFilter }, async (args: any) => {
+        await workerScanComplete;
+        // After awaiting, we generate the barrel files with the now-populated
+        // clientFiles and serverFiles sets.
         const clientBarrelContent = generateBarrelContent(
           clientFiles,
           projectRootDir,
@@ -100,13 +66,78 @@ export const directiveModulesDevPlugin = ({
           serverFiles,
           projectRootDir,
         );
-
         mkdirSync(path.dirname(CLIENT_BARREL_PATH), { recursive: true });
         writeFileSync(CLIENT_BARREL_PATH, clientBarrelContent);
-
         mkdirSync(path.dirname(SERVER_BARREL_PATH), { recursive: true });
         writeFileSync(SERVER_BARREL_PATH, serverBarrelContent);
-      };
+        return args;
+      });
+    },
+  };
+
+  return {
+    name: "rwsdk:directive-modules-dev",
+    config(config, { command }) {
+      if (command !== "serve") {
+        return;
+      }
+
+      // --- Orchestration Logic (must run early) ---
+      const workerEnvOptions = config.environments?.["worker"]?.dev;
+      if (workerEnvOptions?.createEnvironment) {
+        // context(justinvdm, 3 Sep 2025): This is a workaround for a timing
+        // issue in Vite's startup process. We need to run our directive scan
+        // after the worker environment is fully initialized but before the
+        // client/ssr dependency optimizers start. No public hook exists for
+        // this, so we must patch the environment creation and init process.
+        // See the full explanation in the work log:
+        // .worklogs/justin/2025-09-03-directive-scan-timing-in-dev.md
+        const originalCreate = workerEnvOptions.createEnvironment;
+        workerEnvOptions.createEnvironment = async (...args) => {
+          const environment = await originalCreate.call(
+            workerEnvOptions,
+            ...args,
+          );
+          const originalInit = environment.init;
+          let resolveWorkerScanComplete: () => void;
+          workerScanComplete = new Promise((resolve) => {
+            resolveWorkerScanComplete = resolve;
+          });
+
+          environment.init = async (...initArgs) => {
+            await originalInit.apply(environment, initArgs);
+            await runDirectivesScan({
+              rootConfig: environment.config,
+              environment: environment as unknown as DevEnvironment,
+              clientFiles,
+              serverFiles,
+            });
+            resolveWorkerScanComplete();
+          };
+          return environment;
+        };
+      }
+    },
+    configResolved(config) {
+      if (config.command !== "serve") {
+        return;
+      }
+
+      // --- Synchronization Logic (must run on resolved config) ---
+      for (const [envName, env] of Object.entries(config.environments || {})) {
+        if (envName === "client" || envName === "ssr") {
+          env.optimizeDeps.include = [
+            ...(env.optimizeDeps.include || []),
+            CLIENT_BARREL_EXPORT_PATH,
+            SERVER_BARREL_EXPORT_PATH,
+          ];
+          env.optimizeDeps.esbuildOptions ??= {};
+          env.optimizeDeps.esbuildOptions.plugins = [
+            ...(env.optimizeDeps.esbuildOptions.plugins || []),
+            esbuildBlockingPlugin,
+          ];
+        }
+      }
     },
   };
 };

--- a/sdk/src/vite/runDirectivesScan.mts
+++ b/sdk/src/vite/runDirectivesScan.mts
@@ -1,7 +1,7 @@
 // @ts-ignore
 import { OnLoadArgs, OnResolveArgs, PluginBuild } from "esbuild";
 
-import { Alias, ResolvedConfig } from "vite";
+import { Alias, Environment, ResolvedConfig } from "vite";
 import fsp from "node:fs/promises";
 import { hasDirective } from "./hasDirective.mjs";
 import path from "node:path";
@@ -9,6 +9,8 @@ import debug from "debug";
 import { ensureAliasArray } from "./ensureAliasArray.mjs";
 import { getViteEsbuild } from "./getViteEsbuild.mjs";
 import { normalizeModulePath } from "../lib/normalizeModulePath.mjs";
+
+import { createIdResolver } from "vite";
 
 const log = debug("rwsdk:vite:run-directives-scan");
 
@@ -25,14 +27,16 @@ const isExternalUrl = (url: string): boolean => externalRE.test(url);
 function createEsbuildScanPlugin({
   clientFiles,
   serverFiles,
-  aliases,
-  projectRootDir,
+  environment,
+  rootConfig,
 }: {
   clientFiles: Set<string>;
   serverFiles: Set<string>;
-  aliases: Alias[];
-  projectRootDir: string;
+  environment: Environment;
+  rootConfig: ResolvedConfig;
 }) {
+  const resolveId = createIdResolver(rootConfig);
+
   return {
     name: "rwsdk:esbuild-scan-plugin",
     setup(build: PluginBuild) {
@@ -70,42 +74,26 @@ function createEsbuildScanPlugin({
           return null;
         }
 
-        // 1. First, try to resolve aliases.
-        for (const { find, replacement } of aliases) {
-          const findPattern =
-            find instanceof RegExp ? find : new RegExp(`^${find}(\\/.*)?$`);
+        const resolvedPath = await resolveId(
+          environment,
+          args.path,
+          args.importer,
+        );
 
-          if (findPattern.test(args.path)) {
-            const newPath = args.path.replace(
-              findPattern,
-              (_match: any, rest: any) => {
-                // `rest` is the captured group `(\\/.*)?` from the regex.
-                return replacement + (rest || "");
-              },
-            );
+        if (resolvedPath) {
+          const resolved = await build.resolve(resolvedPath, {
+            importer: args.importer,
+            resolveDir: args.resolveDir,
+            kind: args.kind,
+            pluginData: { rwsdkScanResolver: true },
+          });
 
-            const resolved = await build.resolve(newPath, {
-              importer: args.importer,
-              resolveDir: args.resolveDir,
-              kind: args.kind,
-              pluginData: { rwsdkScanResolver: true },
-            });
-
-            if (resolved.errors.length === 0) {
-              return resolved;
-            }
-
-            log(
-              "Could not resolve aliased path '%s' (from '%s'). Marking as external. Errors: %s",
-              newPath,
-              args.path,
-              resolved.errors.map((e: any) => e.text).join(", "),
-            );
-            return { external: true };
+          if (resolved.errors.length === 0) {
+            return resolved;
           }
         }
 
-        // 2. If no alias matches, try esbuild's default resolver.
+        // Fallback to esbuild's default resolver
         const resolved = await build.resolve(args.path, {
           importer: args.importer,
           resolveDir: args.resolveDir,
@@ -113,7 +101,6 @@ function createEsbuildScanPlugin({
           pluginData: { rwsdkScanResolver: true },
         });
 
-        // If it fails, mark as external but don't crash.
         if (resolved.errors.length > 0) {
           log(
             "Could not resolve '%s'. Marking as external. Errors: %s",
@@ -139,11 +126,11 @@ function createEsbuildScanPlugin({
           const contents = await fsp.readFile(args.path, "utf-8");
           if (hasDirective(contents, "use client")) {
             log("Discovered 'use client' in:", args.path);
-            clientFiles.add(normalizeModulePath(args.path, projectRootDir));
+            clientFiles.add(normalizeModulePath(args.path, rootConfig.root));
           }
           if (hasDirective(contents, "use server")) {
             log("Discovered 'use server' in:", args.path);
-            serverFiles.add(normalizeModulePath(args.path, projectRootDir));
+            serverFiles.add(normalizeModulePath(args.path, rootConfig.root));
           }
           return { contents, loader: "default" };
         } catch (e) {
@@ -156,19 +143,18 @@ function createEsbuildScanPlugin({
 }
 
 export async function runDirectivesScan({
-  rootConfig,
-  envName,
+  environment,
   clientFiles,
   serverFiles,
+  rootConfig,
 }: {
-  rootConfig: ResolvedConfig;
-  envName: string;
+  environment: Environment;
   clientFiles: Set<string>;
   serverFiles: Set<string>;
+  rootConfig: ResolvedConfig;
 }) {
   const esbuild = await getViteEsbuild(rootConfig.root);
-  const env = rootConfig.environments[envName];
-  const input = env.build.rollupOptions?.input;
+  const input = environment.config.build.rollupOptions?.input;
   let entries: string[];
 
   if (Array.isArray(input)) {
@@ -184,7 +170,7 @@ export async function runDirectivesScan({
   if (entries.length === 0) {
     log(
       "No entries found for directives scan in environment '%s', skipping.",
-      envName,
+      environment.name,
     );
     return;
   }
@@ -195,7 +181,7 @@ export async function runDirectivesScan({
 
   log(
     "Starting directives scan for environment '%s' with entries:",
-    envName,
+    environment.name,
     absoluteEntries,
   );
 
@@ -212,8 +198,8 @@ export async function runDirectivesScan({
         createEsbuildScanPlugin({
           clientFiles,
           serverFiles,
-          aliases: ensureAliasArray(env),
-          projectRootDir: rootConfig.root,
+          environment,
+          rootConfig,
         }),
       ],
     });


### PR DESCRIPTION
## Problem and Solution

The directive scanner was failing because our configuration plugin ran *before* other plugins (like `vite-tsconfig-paths`) had a chance to add their path aliases to the Vite config. This meant our scanner was working with an incomplete alias map.

The fix was two-fold:

1.  **Correct Plugin Ordering:** The direct cause of the bug was solved by adding `enforce: 'post'` to our `configPlugin`. This ensures our plugin runs *after* all others, giving it access to the complete and final list of aliases.

2.  **Improved Resolution Logic:** While investigating, we also replaced our scanner's simplistic, custom alias resolver with Vite's internal `createIdResolver`. Although the ordering change was the definitive fix for this bug, we've kept this architectural improvement because it makes our scanner significantly more robust and aligns its resolution logic with Vite's core engine.