### PR TITLE
fix: Use more complete client resolver

### DIFF
--- a/sdk/src/vite/buildApp.mts
+++ b/sdk/src/vite/buildApp.mts
@@ -30,7 +30,7 @@ export async function buildApp({
   const workerEnv = builder.environments.worker;
   await runDirectivesScan({
     rootConfig: builder.config,
-    environment: workerEnv,
+    environments: builder.environments,
     clientFiles,
     serverFiles,
   });

--- a/sdk/src/vite/createViteAwareResolver.mts
+++ b/sdk/src/vite/createViteAwareResolver.mts
@@ -4,7 +4,7 @@ import fs from "fs";
 import path from "path";
 import createDebug from "debug";
 import { normalizeModulePath } from "../lib/normalizeModulePath.mjs";
-
+import { Environment } from "vite";
 const debug = createDebug("rwsdk:vite:enhanced-resolve-plugin");
 
 // Enhanced-resolve plugin that wraps Vite plugin resolution
@@ -358,12 +358,11 @@ export const mapViteResolveToEnhancedResolveOptions = (
 
 export const createViteAwareResolver = (
   viteConfig: ResolvedConfig,
-  envName: string,
-  environment?: any, // Optional environment for plugin resolution
+  environment: Environment,
 ) => {
   const baseOptions = mapViteResolveToEnhancedResolveOptions(
     viteConfig,
-    envName,
+    environment.name,
   );
 
   // Add Vite plugin resolver if environment is provided

--- a/sdk/src/vite/directiveModulesDevPlugin.mts
+++ b/sdk/src/vite/directiveModulesDevPlugin.mts
@@ -58,7 +58,7 @@ export const directiveModulesDevPlugin = ({
       // We don't await it here, allowing Vite to continue its startup.
       scanPromise = runDirectivesScan({
         rootConfig: server.config,
-        environment: server.environments.worker,
+        environments: server.environments,
         clientFiles,
         serverFiles,
       }).then(() => {


### PR DESCRIPTION
#675 added the ability to switch between resolving as worker, or resolving as client, depending on whether in the traversal context we are currently "in" client modules or server modules.

It went for a very limited approach to using client resolvers though - instead of using the full client env's config for resolution, it just set the import conditions only.

This PR uses the actual client environment for resolving for the client.