### PR TITLE
feat: Support importing SSR-based dependencies in worker env

### DIFF
--- a/sdk/src/runtime/entries/worker.ts
+++ b/sdk/src/runtime/entries/worker.ts
@@ -8,3 +8,4 @@ export * from "../requestInfo/types";
 export * from "../requestInfo/worker";
 export * from "../render/renderToString";
 export * from "../render/renderToStream";
+export * from "../imports/resolveSSRValue";

--- a/sdk/src/runtime/imports/resolveSSRValue.ts
+++ b/sdk/src/runtime/imports/resolveSSRValue.ts
@@ -1,0 +1,12 @@
+import { ssrGetModuleExport } from "rwsdk/__ssr_bridge";
+
+export const resolveSSRValue = <Value>(
+  clientReference: Value,
+): Promise<Value> => {
+  const id = (clientReference as any).__rwsdk_clientReferenceId;
+  if (!id) {
+    throw new Error("RWSDK: Client reference is not a client reference");
+  }
+
+  return ssrGetModuleExport(id) as Promise<Value>;
+};

--- a/sdk/src/runtime/register/worker.ts
+++ b/sdk/src/runtime/register/worker.ts
@@ -30,6 +30,8 @@ export function registerClientReference<Target extends Record<string, any>>(
       : () => null;
 
   const reference = baseRegisterClientReference({}, id, exportName);
+  (reference as any).__rwsdk_clientReferenceId = `${id}#${exportName}`;
+
   const finalDescriptors = Object.getOwnPropertyDescriptors(reference);
   const idDescriptor = finalDescriptors.$$id;
 

--- a/sdk/src/vite/buildApp.mts
+++ b/sdk/src/vite/buildApp.mts
@@ -30,7 +30,7 @@ export async function buildApp({
   const workerEnv = builder.environments.worker;
   await runDirectivesScan({
     rootConfig: builder.config,
-    environment: workerEnv,
+    environments: builder.environments,
     clientFiles,
     serverFiles,
   });

--- a/sdk/src/vite/createViteAwareResolver.mts
+++ b/sdk/src/vite/createViteAwareResolver.mts
@@ -4,7 +4,7 @@ import fs from "fs";
 import path from "path";
 import createDebug from "debug";
 import { normalizeModulePath } from "../lib/normalizeModulePath.mjs";
-
+import { Environment } from "vite";
 const debug = createDebug("rwsdk:vite:enhanced-resolve-plugin");
 
 // Enhanced-resolve plugin that wraps Vite plugin resolution
@@ -358,12 +358,11 @@ export const mapViteResolveToEnhancedResolveOptions = (
 
 export const createViteAwareResolver = (
   viteConfig: ResolvedConfig,
-  envName: string,
-  environment?: any, // Optional environment for plugin resolution
+  environment: Environment,
 ) => {
   const baseOptions = mapViteResolveToEnhancedResolveOptions(
     viteConfig,
-    envName,
+    environment.name,
   );
 
   // Add Vite plugin resolver if environment is provided

--- a/sdk/src/vite/directiveModulesDevPlugin.mts
+++ b/sdk/src/vite/directiveModulesDevPlugin.mts
@@ -58,7 +58,7 @@ export const directiveModulesDevPlugin = ({
       // We don't await it here, allowing Vite to continue its startup.
       scanPromise = runDirectivesScan({
         rootConfig: server.config,
-        environment: server.environments.worker,
+        environments: server.environments,
         clientFiles,
         serverFiles,
       }).then(() => {


### PR DESCRIPTION
## Problem
Sometimes one needs to use dependencies that use react-dom/server themselves. For example, resend uses `@react-email/render`, which uses `react-dom`.

Trouble is, if we have these imports around in on the worker side, the `react-server` import condition we need to use on the worker side for RSC will cause `react-dom/server` to resolve to a dummy module that throws with `"react-dom/server is not supported in React Server Components"`. React does this intentionally - since RSC react packages have their own separate runtime compared to 'normal" React.

As a result, naively bundling with resend will cause that `"react-dom/server is not supported in React Server Components"` runtime error.

## Solution
We already have an [SSR bridge](https://github.com/redwoodjs/sdk/blob/0f7ba26a939eaa80f907d4883e50d2d55e0f989a/docs/architecture/ssrBridge.md) - to allow for these two different react runtimes to co-exist in the same CF worker runtime environment.

The idea is to add a new method - `resolveSSRValue` - for allowing one to use the bridge to get values defined on the SSR side in `use client` modules:

```
// actions.ts
"use server"
import { ssrSendEmail } from './ssrSendEmail';
import { resolveSSRValue } from 'rwsdk/worker';

export const sendEmail = async () => {
  const sendEmail = await resolveSSRValue(ssrSendEmail);
  return sendEmail(...);
}

// ssrSendEmail.ts
"use client";

export const ssrSendEmail = () => resend.email.send(...);
```