### PR TITLE
fix: Unify request handling for pages and RSC actions

### DIFF
--- a/.worklogs/justin/2025-09-10-rsc-actions-in-middleware.md
+++ b/.worklogs/justin/2025-09-10-rsc-actions-in-middleware.md
@@ -1,0 +1,35 @@
+# RSC Actions in Middleware
+
+## Problem
+
+React Server Component (RSC) action handlers currently bypass the middleware pipeline. This means that common logic, such as setting security headers via a dedicated middleware, is not applied to the responses of these action requests. This creates an inconsistency in request handling and a potential security gap.
+
+## Goal
+
+Ensure that RSC action requests are processed by the same middleware pipeline as regular page requests before the action handler is invoked. This will guarantee consistent application of middleware logic across the board.
+
+## Plan
+
+The proposed solution involves integrating the action-handling logic directly into the middleware flow.
+
+1.  **Introduce an `actionResult` to `RwContext`**: Add an optional `actionResult` property to the `RwContext` type. This will allow us to pass the result of a server action from our action-handling middleware to the rendering logic.
+2.  **Create a dedicated Action-Handling Middleware**: In `sdk/src/runtime/worker.tsx`, we will define a new middleware. This middleware will be responsible for:
+    *   Detecting if an incoming request is an RSC action.
+    *   If it is, calling the `rscActionHandler` to execute the server action.
+    *   Storing the result of the action in `requestInfo.rw.actionResult`.
+3.  **Inject the Middleware**: Prepend this action-handling middleware to the user's list of routes and middleware. This ensures it runs after all user-defined middleware but before any page route is matched.
+4.  **Refactor Rendering Logic**: Modify the `renderPage` function in `sdk/src/runtime/worker.tsx` to read the `actionResult` from the context instead of calling `rscActionHandler` directly. This decouples the rendering logic from the action execution.
+
+## Revised Plan
+
+The initial approach of prepending a dedicated middleware was rejected because it did not correctly handle arbitrary user-defined middleware. The action handler middleware would always run first, which could break middleware that needs to execute before the action, such as authentication.
+
+The new plan is to integrate the action handling logic directly into the router's request-handling process.
+
+1.  **Add `actionResult` to `RwContext`**: The `RwContext` type will be updated to include an optional `actionResult` property to carry the result of a server action.
+2.  **Refactor the Router's `handle` Method**: The `handle` method in `sdk/src/runtime/lib/router.ts` will be modified to:
+    *   Accept the `rscActionHandler` function as an argument.
+    *   First, iterate through and execute all global middleware.
+    *   After the middleware has run, check if the request is for an RSC action. If so, execute the `rscActionHandler` and store its result in `rw.actionResult`.
+    *   Finally, proceed with route matching for page components.
+3.  **Update `worker.tsx`**: The call to `router.handle` in `sdk/src/runtime/worker.tsx` will be updated to pass the `rscActionHandler` function.

--- a/.worklogs/justin/2025-09-10-rsc-actions-in-middleware.md
+++ b/.worklogs/justin/2025-09-10-rsc-actions-in-middleware.md
@@ -10,26 +10,12 @@ Ensure that RSC action requests are processed by the same middleware pipeline as
 
 ## Plan
 
-The proposed solution involves integrating the action-handling logic directly into the middleware flow.
+The solution integrates the action handling logic directly into the router's request-handling process. This ensures it executes after all user-defined middleware.
 
-1.  **Introduce an `actionResult` to `RwContext`**: Add an optional `actionResult` property to the `RwContext` type. This will allow us to pass the result of a server action from our action-handling middleware to the rendering logic.
-2.  **Create a dedicated Action-Handling Middleware**: In `sdk/src/runtime/worker.tsx`, we will define a new middleware. This middleware will be responsible for:
-    *   Detecting if an incoming request is an RSC action.
-    *   If it is, calling the `rscActionHandler` to execute the server action.
-    *   Storing the result of the action in `requestInfo.rw.actionResult`.
-3.  **Inject the Middleware**: Prepend this action-handling middleware to the user's list of routes and middleware. This ensures it runs after all user-defined middleware but before any page route is matched.
-4.  **Refactor Rendering Logic**: Modify the `renderPage` function in `sdk/src/runtime/worker.tsx` to read the `actionResult` from the context instead of calling `rscActionHandler` directly. This decouples the rendering logic from the action execution.
-
-## Revised Plan
-
-The initial approach of prepending a dedicated middleware was rejected because it did not correctly handle arbitrary user-defined middleware. The action handler middleware would always run first, which could break middleware that needs to execute before the action, such as authentication.
-
-The new plan is to integrate the action handling logic directly into the router's request-handling process.
-
-1.  **Add `actionResult` to `RwContext`**: The `RwContext` type will be updated to include an optional `actionResult` property to carry the result of a server action.
-2.  **Refactor the Router's `handle` Method**: The `handle` method in `sdk/src/runtime/lib/router.ts` will be modified to:
+1.  **Add `actionResult` to `RwContext`**: The `RwContext` type is updated to include an optional `actionResult` property to carry the result of a server action.
+2.  **Refactor the Router's `handle` Method**: The `handle` method in `sdk/src/runtime/lib/router.ts` is modified to:
     *   Accept the `rscActionHandler` function as an argument.
     *   First, iterate through and execute all global middleware.
     *   After the middleware has run, check if the request is for an RSC action. If so, execute the `rscActionHandler` and store its result in `rw.actionResult`.
     *   Finally, proceed with route matching for page components.
-3.  **Update `worker.tsx`**: The call to `router.handle` in `sdk/src/runtime/worker.tsx` will be updated to pass the `rscActionHandler` function.
+3.  **Update `worker.tsx`**: The call to `router.handle` in `sdk/src/runtime/worker.tsx` is updated to pass the `rscActionHandler` function.

--- a/docs/architecture/requestHandling.md
+++ b/docs/architecture/requestHandling.md
@@ -1,0 +1,39 @@
+# Unified Request Handling Pipeline
+
+This document outlines the ordered, multi-stage pipeline for processing all incoming requests, ensuring that both page requests and React Server Component (RSC) actions are handled consistently.
+
+## The Request Pipeline
+
+All incoming requests are processed through a deterministic, three-stage pipeline inside the router. This design ensures that cross-cutting concerns are handled uniformly before any request-specific logic is executed. The pipeline proceeds as follows:
+
+1.  **Global Middleware Execution:** The router first identifies and executes all global middleware functions in the order they are defined. Middleware can modify the request's context (e.g., by loading a user session) or terminate the request early by returning a `Response` object (e.g., redirecting an unauthenticated user). If any middleware returns a response, the subsequent stages are skipped.
+
+2.  **RSC Action Handling:** After all global middleware has successfully completed, the router inspects the request to determine if it is an RSC action. If it is, the router invokes the appropriate action handler.
+
+3.  **Page Route Matching & Rendering:** Finally, if the request was not terminated by middleware, the router attempts to match the URL against the application's defined page routes. If a matching route is found, its handler (typically a page component) is executed and rendered. For an RSC action request, this stage still runs to re-render the page and provide the client with the updated UI.
+
+## Technical Challenges in Request Handling
+
+The pipeline's design directly addresses several complex challenges inherent in a server-rendering framework.
+
+### Challenge: Aborting a Streamed Render to Return a Response
+
+A significant challenge is handling cases where a route handler, which normally renders a React component, must instead abort the render and return a standard `Response` object (e.g., for a redirect or "not found" error). Because component rendering is an asynchronous, streamed process, a simple `return` statement is not possible from within the React tree.
+
+The framework solves this using a combination of a deferred promise and controlled error throwing:
+
+1.  **Promise Creation:** Before rendering a page component, a deferred promise (`pageRouteResolved`) is created and stored on the request context. This promise acts as a signal to synchronize the outer request handler with the inner rendering process.
+2.  **Component Wrapping:** The route's page component is wrapped in a higher-order component. If the inner component's logic attempts to return a `Response`, this wrapper intercepts it.
+3.  **Throwing and Signaling:** The wrapper then `throws` the `Response` object. This action immediately aborts React's rendering process.
+4.  **Top-Level Catch:** The thrown `Response` propagates up and is caught by a top-level error handler in the main fetch dispatcher, which then returns the `Response` directly to the client.
+
+This mechanism provides a robust way to break out of the asynchronous rendering flow and allows any component in the tree to trigger a standard HTTP response.
+
+<aside>
+
+**A Note on RSC Action Handling**
+A core design principle is that all request types, including page loads and RSC actions, must be subject to the same middleware. This guarantees that security policies and context population (e.g., loading a user session) are applied consistently.
+
+To achieve this, RSC action handling is a dedicated stage in the pipeline that executes *after* all global middleware has run. This ensures that action handlers have access to a fully-prepared request context.
+
+</aside>

--- a/docs/src/content/docs/core/routing.mdx
+++ b/docs/src/content/docs/core/routing.mdx
@@ -144,6 +144,12 @@ The context object (`ctx`) is a mutable object that is passed to each request ha
 
 Middleware runs before the request is matched to a route. You can specify multiple middleware functions, they'll be executed in the order they are defined.
 
+<Aside type="note" title="Server Actions">
+  Requests made by Server Actions also pass through the middleware pipeline. This
+  means you can rely on middleware to populate context or perform checks for your
+  actions, just as you would for page requests.
+</Aside>
+
 ```tsx title="src/worker.tsx" mark={5-10}
 import { defineApp } from "rwsdk/worker";
 import { route } from "rwsdk/router";

--- a/sdk/src/runtime/lib/router.ts
+++ b/sdk/src/runtime/lib/router.ts
@@ -21,6 +21,7 @@ export type RwContext = {
   databases: Map<string, Kysely<any>>;
   scriptsToBeLoaded: Set<string>;
   pageRouteResolved: PromiseWithResolvers<void> | undefined;
+  actionResult?: unknown;
 };
 
 export type RouteMiddleware<T extends RequestInfo = RequestInfo> = (
@@ -149,6 +150,7 @@ export function defineRoutes<T extends RequestInfo = RequestInfo>(
     getRequestInfo,
     onError,
     runWithRequestInfoOverrides,
+    rscActionHandler,
   }: {
     request: Request;
     renderPage: (
@@ -162,6 +164,7 @@ export function defineRoutes<T extends RequestInfo = RequestInfo>(
       overrides: Partial<T>,
       fn: () => Promise<Result>,
     ) => Promise<Result>;
+    rscActionHandler: (request: Request) => Promise<unknown>;
   }) => Response | Promise<Response>;
 } {
   const flattenedRoutes = flattenRoutes<T>(routes);
@@ -173,6 +176,7 @@ export function defineRoutes<T extends RequestInfo = RequestInfo>(
       getRequestInfo,
       onError,
       runWithRequestInfoOverrides,
+      rscActionHandler,
     }) {
       const url = new URL(request.url);
       let path = url.pathname;
@@ -182,57 +186,8 @@ export function defineRoutes<T extends RequestInfo = RequestInfo>(
         path = path + "/";
       }
 
-      // Flow below; helpers are declared after the main flow for readability
-
-      // 1) Global middlewares: run any middleware functions encountered (Response short-circuits, element renders)
-      // 2) Route matching: skip non-matching route definitions; stop at first match
-      // 3) Route-specific middlewares: run middlewares attached to the matched route
-      // 4) Final component: render the matched route's final component (layouts apply only here)
-      for (const route of flattenedRoutes) {
-        // 1) Global middlewares (encountered before a match)
-        if (typeof route === "function") {
-          const result = await route(getRequestInfo());
-          const handled = await handleMiddlewareResult(result);
-          if (handled) {
-            return handled;
-          }
-          continue;
-        }
-
-        // 2) Route matching (skip if not matched)
-        const params = matchPath<T>(route.path, path);
-        if (!params) {
-          continue;
-        }
-
-        // Found a match: 3) route middlewares, then 4) final component, then stop
-        return await runWithRequestInfoOverrides(
-          { params } as Partial<T>,
-          async () => {
-            const { routeMiddlewares, componentHandler } = parseHandlers(
-              route.handler,
-            );
-
-            // 3) Route-specific middlewares
-            const mwHandled = await handleRouteMiddlewares(routeMiddlewares);
-            if (mwHandled) {
-              return mwHandled;
-            }
-
-            // 4) Final component (always last item)
-            return await handleRouteComponent(
-              componentHandler,
-              route.layouts || [],
-            );
-          },
-        );
-      }
-
-      // No route matched and no middleware handled the request
-      // todo(peterp, 2025-01-28): Allow the user to define their own "not found" route.
-      return new Response("Not Found", { status: 404 });
-
       // --- Helpers ---
+      // (Hoisted for readability)
       function parseHandlers(handler: RouteHandler<T>) {
         const handlers = Array.isArray(handler) ? handler : [handler];
         const routeMiddlewares = handlers.slice(
@@ -264,57 +219,89 @@ export function defineRoutes<T extends RequestInfo = RequestInfo>(
         return undefined;
       }
 
-      // Note: We no longer have separate global pass or match-only pass;
-      // the outer single pass above handles both behaviors correctly.
+      // --- Main flow ---
+      const globalMiddlewares = flattenedRoutes.filter(
+        (route): route is RouteMiddleware<T> => typeof route === "function",
+      );
 
-      async function handleRouteMiddlewares(
-        mws: RouteMiddleware<T>[],
-      ): Promise<Response | undefined> {
-        for (const mw of mws) {
-          const result = await (mw(getRequestInfo()) as Promise<
-            Response | React.JSX.Element | void
-          >);
-          const handled = await handleMiddlewareResult(result);
-          if (handled) return handled;
+      const routeDefinitions = flattenedRoutes.filter(
+        (route): route is RouteDefinition<T> => typeof route !== "function",
+      );
+
+      // 1. Run global middlewares
+      for (const middleware of globalMiddlewares) {
+        const result = await middleware(getRequestInfo());
+        const handled = await handleMiddlewareResult(result);
+        if (handled) {
+          return handled;
         }
-        return undefined;
       }
 
-      async function handleRouteComponent(
-        component: RouteFunction<T> | RouteComponent<T>,
-        layouts: React.FC<LayoutProps<T>>[],
-      ): Promise<Response> {
-        if (isRouteComponent(component)) {
-          const requestInfo = getRequestInfo();
-          const WrappedComponent = wrapWithLayouts(
-            wrapHandlerToThrowResponses(
-              component as RouteComponent<T>,
-            ) as React.FC,
-            layouts,
-            requestInfo,
-          );
+      // 2. Handle RSC actions
+      if (url.searchParams.has("__rsc_action_id")) {
+        getRequestInfo().rw.actionResult = await rscActionHandler(request);
+      }
 
-          if (!isClientReference(component)) {
-            // context(justinvdm, 31 Jul 2025): We now know we're dealing with a page route,
-            // so we create a deferred so that we can signal when we're done determining whether
-            // we're returning a response or a react element
-            requestInfo.rw.pageRouteResolved = Promise.withResolvers();
-          }
-
-          return await renderPage(requestInfo, WrappedComponent, onError);
+      // 3. Match and handle routes
+      for (const route of routeDefinitions) {
+        const params = matchPath<T>(route.path, path);
+        if (!params) {
+          continue;
         }
 
-        // If the last handler is not a component, handle as middleware result (no layouts)
-        const tailResult = await (component(getRequestInfo()) as Promise<
-          Response | React.JSX.Element | void
-        >);
-        const handledTail = await handleMiddlewareResult(tailResult);
-        if (handledTail) return handledTail;
+        // Found a match: run route-specific middlewares, then the final component
+        return await runWithRequestInfoOverrides(
+          { params } as Partial<T>,
+          async () => {
+            const { routeMiddlewares, componentHandler } = parseHandlers(
+              route.handler,
+            );
 
-        return new Response("Response not returned from route handler", {
-          status: 500,
-        });
+            // 3a. Route-specific middlewares
+            for (const mw of routeMiddlewares) {
+              const result = await mw(getRequestInfo());
+              const handled = await handleMiddlewareResult(result);
+              if (handled) {
+                return handled;
+              }
+            }
+
+            // 3b. Final component/handler
+            if (isRouteComponent(componentHandler)) {
+              const requestInfo = getRequestInfo();
+              const WrappedComponent = wrapWithLayouts(
+                wrapHandlerToThrowResponses(
+                  componentHandler as RouteComponent<T>,
+                ) as React.FC,
+                route.layouts || [],
+                requestInfo,
+              );
+
+              if (!isClientReference(componentHandler)) {
+                requestInfo.rw.pageRouteResolved = Promise.withResolvers();
+              }
+
+              return await renderPage(requestInfo, WrappedComponent, onError);
+            }
+
+            // Handle non-component final handler (e.g., returns new Response)
+            const tailResult = await (componentHandler(
+              getRequestInfo(),
+            ) as Promise<Response | React.JSX.Element | void>);
+            const handledTail = await handleMiddlewareResult(tailResult);
+            if (handledTail) {
+              return handledTail;
+            }
+
+            return new Response("Response not returned from route handler", {
+              status: 500,
+            });
+          },
+        );
       }
+
+      // No route matched
+      return new Response("Not Found", { status: 404 });
     },
   };
 }

--- a/sdk/src/runtime/worker.tsx
+++ b/sdk/src/runtime/worker.tsx
@@ -117,12 +117,7 @@ export const defineApp = <
             });
           }
 
-          let actionResult: unknown = undefined;
-          const isRSCActionHandler = url.searchParams.has("__rsc_action_id");
-
-          if (isRSCActionHandler) {
-            actionResult = await rscActionHandler(request);
-          }
+          const actionResult = requestInfo.rw.actionResult;
 
           const pageElement = createPageElement(requestInfo, Page);
 
@@ -195,6 +190,7 @@ export const defineApp = <
                     getRequestInfo: getRequestInfo as () => T,
                     runWithRequestInfoOverrides,
                     onError: reject,
+                    rscActionHandler,
                   }),
                 );
               } catch (e) {


### PR DESCRIPTION
### Problem

Previously, RSC action requests bypassed the middleware pipeline and were handled directly. This created an inconsistency where logic defined in middleware (e.g. session validation, authentication checks, setting security headers) was not applied to action requests. This could lead to security vulnerabilities and required developers to duplicate context-aware logic inside action handlers.

### Solution

The router's `handle` method has been restructured into a deterministic, three-stage pipeline that processes all incoming requests:

1.  **Global Middleware Execution**: All global middleware is executed in order.
2.  **RSC Action Handling**: If the request is an RSC action, the action handler is now invoked *after* all middleware has completed.
3.  **Page Route Matching**: The router proceeds to match the request to a page route for rendering.