### PR TITLE
fix: Use permissive range for React peer dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,16 +141,16 @@ importers:
         specifier: ^22.8.1
         version: 22.15.0
       react:
-        specifier: 19.2.0-canary-3fb190f7-20250908
+        specifier: 19.2.0-canary-3fb190f7-20250908 <20.0.0
         version: 19.2.0-canary-3fb190f7-20250908
       react-dom:
-        specifier: 19.2.0-canary-3fb190f7-20250908
+        specifier: 19.2.0-canary-3fb190f7-20250908 <20.0.0
         version: 19.2.0-canary-3fb190f7-20250908(react@19.2.0-canary-3fb190f7-20250908)
       react-is:
         specifier: ^19.0.0
         version: 19.0.0
       react-server-dom-webpack:
-        specifier: 19.2.0-canary-3fb190f7-20250908
+        specifier: '>=19.2.0-canary-3fb190f7-20250908 <20.0.0'
         version: 19.2.0-canary-3fb190f7-20250908(react-dom@19.2.0-canary-3fb190f7-20250908(react@19.2.0-canary-3fb190f7-20250908))(react@19.2.0-canary-3fb190f7-20250908)(webpack@5.97.1)
       rsc-html-stream:
         specifier: ^0.0.6

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -159,9 +159,9 @@
   },
   "peerDependencies": {
     "@cloudflare/vite-plugin": "^1.12.4",
-    "react": "19.2.0-canary-3fb190f7-20250908",
-    "react-dom": "19.2.0-canary-3fb190f7-20250908",
-    "react-server-dom-webpack": "19.2.0-canary-3fb190f7-20250908",
+    "react": "19.2.0-canary-3fb190f7-20250908 <20.0.0",
+    "react-dom": "19.2.0-canary-3fb190f7-20250908 <20.0.0",
+    "react-server-dom-webpack": ">=19.2.0-canary-3fb190f7-20250908 <20.0.0",
     "vite": "^6.2.6 || 7.x",
     "wrangler": "^4.35.0"
   },


### PR DESCRIPTION
### Problem

The `peerDependencies` for React packages (`react`, `react-dom`, `react-server-dom-webpack`) were pinned to an exact canary version. This caused `npm install` to fail with an `ERESOLVE` error when downstream projects (like our starters) attempted to install a newer canary version.

### Solution

This change updates the version specifiers for the React peer dependencies to any versions within `19.2.0-canary-3fb190f7-20250908 <20.0.0`