### PR TITLE
chore: Remove deprecated `requestInfo.headers` API

### DIFF
--- a/.notes/justin/worklogs/2025-09-21-deprecated-apis.md
+++ b/.notes/justin/worklogs/2025-09-21-deprecated-apis.md
@@ -1,0 +1,35 @@
+# Work Log: Deprecated APIs
+
+**Date:** 2025-09-21
+
+## Problem
+
+Identify and document deprecated APIs within the SDK codebase to prepare for their eventual removal.
+
+## Plan
+
+1.  Search the codebase for `@deprecated` JSDoc annotations and other comments indicating deprecation.
+2.  Document all findings in this work log.
+3.  Create a plan for removing the deprecated APIs in a future release.
+
+## Findings
+
+A search for "deprecated" revealed the following deprecated API:
+
+-   **`headers` property on `RequestInfo` interface**
+    -   **Location:** `sdk/src/runtime/requestInfo/types.ts`
+    -   **Details:** The `headers` property on the `RequestInfo` interface is marked as deprecated.
+    -   **Recommended Replacement:** `response.headers` should be used instead.
+
+```typescript
+// sdk/src/runtime/requestInfo/types.ts
+
+export interface RequestInfo<Params = any, AppContext = DefaultAppContext> {
+  // ...
+  /** @deprecated: Use `response.headers` instead */
+  headers: Headers;
+  // ...
+  response: ResponseInit & { headers: Headers };
+  // ...
+}
+```

--- a/.notes/justin/worklogs/2025-09-21-deprecated-apis.md
+++ b/.notes/justin/worklogs/2025-09-21-deprecated-apis.md
@@ -26,10 +26,20 @@ A search for "deprecated" revealed the following deprecated API:
 
 export interface RequestInfo<Params = any, AppContext = DefaultAppContext> {
   // ...
-  /** @deprecated: Use `response.headers` instead */
-  headers: Headers;
-  // ...
   response: ResponseInit & { headers: Headers };
   // ...
 }
 ```
+
+## Implementation
+
+1.  **`sdk/src/runtime/requestInfo/types.ts`**: Removed the `headers` property from the `RequestInfo` interface.
+2.  **`sdk/src/runtime/requestInfo/worker.ts`**: Removed `"headers"` from the `REQUEST_INFO_KEYS` array.
+3.  **`sdk/src/runtime/worker.tsx`**:
+    -   Removed the `headers` property from the `outerRequestInfo` object.
+    -   Removed the logic that merged `userHeaders` into the response, as `response.headers` is now the single source of truth.
+4.  **`sdk/src/llms/rules/middleware.ts`**: Updated the example middleware to destructure `response` and use `response.headers` instead of `headers`.
+5.  **`sdk/src/runtime/lib/auth/session.ts`**: Updated the `save` and `remove` functions to accept `responseHeaders` as an argument instead of `headers`.
+6.  **`sdk/src/runtime/lib/router.test.ts`**: Removed the `headers` property from the `mockRequestInfo` object in the tests.
+
+After making these changes, I ran the TypeScript compiler to ensure there were no type errors.

--- a/.notes/justin/worklogs/2025-09-21-deprecated-apis.md
+++ b/.notes/justin/worklogs/2025-09-21-deprecated-apis.md
@@ -43,3 +43,33 @@ export interface RequestInfo<Params = any, AppContext = DefaultAppContext> {
 6.  **`sdk/src/runtime/lib/router.test.ts`**: Removed the `headers` property from the `mockRequestInfo` object in the tests.
 
 After making these changes, I ran the TypeScript compiler to ensure there were no type errors.
+
+---
+
+## PR Description
+
+This change removes the deprecated `headers` property from the `RequestInfo` interface to simplify the API. All response header modifications should now be done through the `response.headers` object.
+
+### BREAKING CHANGE
+
+The `headers` property on the `RequestInfo` object has been removed. Code that previously used `requestInfo.headers` to set response headers will no longer work.
+
+### Migration Guide
+
+To update your code, replace any usage of `requestInfo.headers` with `requestInfo.response.headers`.
+
+**Before:**
+
+```typescript
+const myMiddleware = (requestInfo) => {
+  requestInfo.headers.set('X-Custom-Header', 'my-value');
+};
+```
+
+**After:**
+
+```typescript
+const myMiddleware = (requestInfo) => {
+  requestInfo.response.headers.set('X-Custom-Header', 'my-value');
+};
+```

--- a/docs/src/content/docs/reference/sdk-worker.mdx
+++ b/docs/src/content/docs/reference/sdk-worker.mdx
@@ -51,7 +51,6 @@ defineApp([
 ---
 In this example above a request would be processed by the middleware, then the correct route would match and execute the handler.
 ---
-```
 
 ## `ErrorResponse`
 
@@ -61,18 +60,21 @@ The `ErrorResponse` class is used to return an errors that includes a status cod
 import { ErrorResponse } from "rwsdk/worker";
 
 export default defineApp([
-  function middleware({ request, ctx }) {
+  async ({ ctx, request, response }) => {
     try {
       ctx.session = await sessions.load(request);
     } catch (error) {
       if (error instanceof ErrorResponse && error.code === 401) {
-        await sessions.remove(request, headers);
-        headers.set("Location", "/user/login");
+        await sessions.remove(request, response.headers);
+        response.headers.set("Location", "/user/login");
+
         return new Response(null, {
           status: 302,
-          headers,
+          headers: response.headers,
         });
       }
+
+      throw error;
     }
   },
   route("/", () => new ErrorResponse(404, "Not Found")),

--- a/docs/src/content/docs/tutorial/full-stack-app/4-auth.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/4-auth.mdx
@@ -73,7 +73,7 @@ export type AppContext = {
 
 export default defineApp([
   setCommonHeaders(),
-  async ({ ctx, request, headers }) => {
+  async ({ ctx, request, response }) => {
     await setupDb(env);
     setupSessionStore(env);
 
@@ -81,12 +81,12 @@ export default defineApp([
       ctx.session = await sessions.load(request);
     } catch (error) {
       if (error instanceof ErrorResponse && error.code === 401) {
-        await sessions.remove(request, headers);
-        headers.set("Location", "/user/login");
+        await sessions.remove(request, response.headers);
+        response.headers.set("Location", "/user/login");
 
         return new Response(null, {
           status: 302,
-          headers,
+          headers: response.headers,
         });
       }
 
@@ -137,7 +137,7 @@ setCommonHeaders(),
 - On **line 19** we're setting up our common headers. This is a function inside of `app/src/headers.ts`. (Imported on line 5.) It creates the Security Policies, Transport Policy, Referrer Policy, and Permissions Policy. [You can find additional documentation here.](/core/security/#-security-headers)
 
 ```tsx title="src/worker.tsx" startLineNumber=20
-async ({ ctx, request, headers }) => {
+async ({ ctx, request, response }) => {
   await setupDb(env);
   setupSessionStore(env);
 
@@ -145,12 +145,12 @@ async ({ ctx, request, headers }) => {
     ctx.session = await sessions.load(request);
   } catch (error) {
     if (error instanceof ErrorResponse && error.code === 401) {
-      await sessions.remove(request, headers);
-      headers.set("Location", "/user/login");
+      await sessions.remove(request, response.headers);
+      response.headers.set("Location", "/user/login");
 
       return new Response(null, {
         status: 302,
-        headers,
+        headers: response.headers,
       });
     }
 
@@ -263,14 +263,13 @@ import { sessions } from "@/session/store";
 
 export const userRoutes = [
   route("/login", [Login]),
-  route("/logout", async function ({ request }) {
-    const headers = new Headers();
-    await sessions.remove(request, headers);
-    headers.set("Location", "/");
+  route("/logout", async function ({ request, response }) {
+    await sessions.remove(request, response.headers);
+    response.headers.set("Location", "/");
 
     return new Response(null, {
       status: 302,
-      headers,
+      headers: response.headers,
     });
   }),
 ];
@@ -306,14 +305,13 @@ import { sessions } from "@/session/store";
 export const userRoutes = [
   route("/login", [Login]),
   route("/signup", [Signup]),
-  route("/logout", async function ({ request }) {
-    const headers = new Headers();
-    await sessions.remove(request, headers);
-    headers.set("Location", "/");
+  route("/logout", async function ({ request, response }) {
+    await sessions.remove(request, response.headers);
+    response.headers.set("Location", "/");
 
     return new Response(null, {
       status: 302,
-      headers,
+      headers: response.headers,
     });
   }),
 ];
@@ -1098,7 +1096,7 @@ Now, let's style the Apply Wize text.
 
 In our mock-up, we also had a quote in the bottom left corner:
 
-> “Transform the job hunt from a maze into a map.”
+> "Transform the job hunt from a maze into a map."
 
 <figure>
   ![](./images/figma-login.png)
@@ -1121,7 +1119,7 @@ To style the text:
 
 ```tsx title="src/app/layouts/AuthLayout.tsx" startLineNumber=12 {1}
 <div className="text-white text-sm absolute bottom-0 left-0 right-0 p-10">
-  “Transform the job hunt from a maze into a map.”
+  "Transform the job hunt from a maze into a map."
 </div>
 ---
 - We want to it to be white, `text-white` and small (`14px`) `text-sm`
@@ -1685,7 +1683,7 @@ Within our `src/worker.tsx` file, we're exporting `defineApp`. Remember, this in
 ```tsx title="src/worker.tsx" collapse={2-30, 33-43} ins={45-46} showLineNumbers=false startLineNumber=19
 export default defineApp([
   setCommonHeaders(),
-  async ({ ctx, request, headers }) => {
+  async ({ ctx, request, response }) => {
     await setupDb(env);
     setupSessionStore(env);
 
@@ -1693,12 +1691,12 @@ export default defineApp([
       ctx.session = await sessions.load(request);
     } catch (error) {
       if (error instanceof ErrorResponse && error.code === 401) {
-        await sessions.remove(request, headers);
-        headers.set("Location", "/user/login");
+        await sessions.remove(request, response.headers);
+        response.headers.set("Location", "/user/login");
 
         return new Response(null, {
           status: 302,
-          headers,
+          headers: response.headers,
         });
       }
 
@@ -1886,8 +1884,9 @@ Then, right below the button, we can add our legal statement:
 
 ```tsx title="src/app/pages/user/Signup.tsx" startLineNumber=72
 <p>
-  By clicking continue, you agree to our 
-  <a href={link("/legal/terms")}>Terms of Service</a> and 
+  By clicking continue, you agree to our 
+  <a href={link("/legal/terms")}>Terms of Service</a> 
+  and 
   <a href={link("/legal/privacy")}>Privacy Policy</a>.
 </p>
 ```

--- a/docs/src/content/docs/tutorial/full-stack-app/5-jobs-list.mdx
+++ b/docs/src/content/docs/tutorial/full-stack-app/5-jobs-list.mdx
@@ -2133,7 +2133,7 @@ Before we call this done, let's ensure that our Archive filter is working.
 
 ### Using Query Params to Filter Applications
 
-On every page we get an object that contains `ctx`, `request`, and `headers`. In our case, the `request` contains the query parameters that we're looking for.
+On every page we get an object that contains `ctx`, `request`, and `response`. In our case, the request contains the query parameters that we're looking for.
 
 On `List.tsx`, when we define our `List` function, let's accept `request` as a prop:
 

--- a/sdk/src/llms/rules/middleware.ts
+++ b/sdk/src/llms/rules/middleware.ts
@@ -36,7 +36,7 @@ Middleware functions in RedwoodSDK are functions that run on every request befor
 \`\`\`tsx
 export default defineApp([
   setCommonHeaders(),
-  async ({ ctx, request, headers }) => {
+  async ({ ctx, request, response }) => {
     await setupDb(env);
     setupSessionStore(env);
     try {
@@ -44,12 +44,12 @@ export default defineApp([
       ctx.session = await sessions.load(request);
     } catch (error) {
       if (error instanceof ErrorResponse && error.code === 401) {
-        await sessions.remove(request, headers);
-        headers.set("Location", "/user/login");
+        await sessions.remove(request, response.headers);
+        response.headers.set("Location", "/user/login");
 
         return new Response(null, {
           status: 302,
-          headers,
+          headers: response.headers,
         });
       }
 

--- a/sdk/src/runtime/lib/auth/session.ts
+++ b/sdk/src/runtime/lib/auth/session.ts
@@ -187,24 +187,27 @@ export const defineSessionStore = <Session, SessionInputData>({
   };
 
   const save = async (
-    headers: Headers,
+    responseHeaders: Headers,
     sessionInputData: SessionInputData,
     { maxAge }: { maxAge?: number | true } = {},
   ): Promise<void> => {
     const sessionId = await generateSessionId({ secretKey });
     await set(sessionId, sessionInputData);
-    headers.set(
+    responseHeaders.set(
       "Set-Cookie",
       createCookie({ name: cookieName, sessionId, maxAge }),
     );
   };
 
-  const remove = async (request: Request, headers: Headers): Promise<void> => {
+  const remove = async (
+    request: Request,
+    responseHeaders: Headers,
+  ): Promise<void> => {
     const sessionId = getSessionIdFromCookie(request);
     if (sessionId) {
       await unset(sessionId);
     }
-    headers.set(
+    responseHeaders.set(
       "Set-Cookie",
       createCookie({ name: cookieName, sessionId: "", maxAge: 0 }),
     );

--- a/sdk/src/runtime/lib/router.test.ts
+++ b/sdk/src/runtime/lib/router.test.ts
@@ -91,7 +91,6 @@ describe("defineRoutes - Request Handling Behavior", () => {
       request: new Request("http://localhost:3000/"),
       params: {},
       ctx: {},
-      headers: new Headers(),
       rw: {
         nonce: "test-nonce",
         Document: () => React.createElement("html"),

--- a/sdk/src/runtime/requestInfo/types.ts
+++ b/sdk/src/runtime/requestInfo/types.ts
@@ -10,8 +10,6 @@ export interface RequestInfo<Params = any, AppContext = DefaultAppContext> {
   request: Request;
   params: Params;
   ctx: AppContext;
-  /** @deprecated: Use `response.headers` instead */
-  headers: Headers;
   rw: RwContext;
   cf: ExecutionContext;
   // context(justinvdm, 2025-08-18): Ensure headers is always available

--- a/sdk/src/runtime/requestInfo/worker.ts
+++ b/sdk/src/runtime/requestInfo/worker.ts
@@ -9,15 +9,7 @@ const requestInfoStore = new AsyncLocalStorage<Record<string, any>>();
 
 const requestInfoBase = {};
 
-const REQUEST_INFO_KEYS = [
-  "request",
-  "params",
-  "ctx",
-  "headers",
-  "rw",
-  "cf",
-  "response",
-];
+const REQUEST_INFO_KEYS = ["request", "params", "ctx", "rw", "cf", "response"];
 
 REQUEST_INFO_KEYS.forEach((key) => {
   Object.defineProperty(requestInfoBase, key, {

--- a/sdk/src/runtime/worker.tsx
+++ b/sdk/src/runtime/worker.tsx
@@ -63,7 +63,6 @@ export const defineApp = <
           url.searchParams.has("__rsc") ||
           request.headers.get("accept")?.includes("text/x-component");
         const isAction = url.searchParams.has("__rsc_action_id");
-        const userHeaders = new Headers();
 
         const rw: RwContext = {
           Document: DefaultDocument,
@@ -82,7 +81,6 @@ export const defineApp = <
 
         const outerRequestInfo: RequestInfo<any, T["ctx"]> = {
           request,
-          headers: userHeaders,
           cf,
           params: {},
           ctx: {},
@@ -211,13 +209,6 @@ export const defineApp = <
         // context(justinvdm, 18 Mar 2025): In some cases, such as a .fetch() call to a durable object instance, or Response.redirect(),
         // we need to return a mutable response object.
         const mutableResponse = new Response(response.body, response);
-
-        // Merge user headers from the legacy headers object
-        for (const [key, value] of userHeaders.entries()) {
-          if (!response.headers.has(key)) {
-            mutableResponse.headers.set(key, value);
-          }
-        }
 
         // Merge headers from user response init (these take precedence)
         if (userResponseInit.headers) {


### PR DESCRIPTION
This change removes the deprecated `headers` property from the `RequestInfo` interface to simplify the API. All response header modifications should now be done through the `response.headers` object.

### BREAKING CHANGE

The `headers` property on the `RequestInfo` object has been removed. Code that previously used `requestInfo.headers` to set response headers will no longer work.

### Migration Guide

To update your code, replace any usage of `requestInfo.headers` with `requestInfo.response.headers`.

**Before:**

```typescript
const myMiddleware = (requestInfo) => {
  requestInfo.headers.set('X-Custom-Header', 'my-value');
};
```

**After:**

```typescript
const myMiddleware = (requestInfo) => {
  requestInfo.response.headers.set('X-Custom-Header', 'my-value');
};
```
