### PR TITLE
fix(e2e): ensure test workers are deleted after tests

### DIFF
--- a/.notes/justin/worklogs/2025-01-27-e2e-worker-cleanup-investigation.md
+++ b/.notes/justin/worklogs/2025-01-27-e2e-worker-cleanup-investigation.md
@@ -148,6 +148,4 @@ The problem was that the `resourceUniqueKey` used for the cleanup check was gene
 
 The fix is to ensure the `resourceUniqueKey` is derived from the same source as the unique ID in the worker's name. The worker's name is based on the temporary directory created for the test, which has a name format like `{projectName}-e2e-test-{randomId}`.
 
-The solution modifies the `createDeployment()` function in the E2E test harness (`sdk/src/lib/e2e/testHarness.mts`). Instead of generating a new random `resourceUniqueKey`, it now extracts the `{randomId}` from the test's temporary directory path. This ensures that the key used for the cleanup check matches the one in the worker's name, allowing the worker to be correctly identified and deleted after the test.
-
-This change aligns the identification key with the deployed worker's name, fixing the cleanup process without removing the safety check.
+The solution modifies the `createDeployment()` function in the E2E test harness. Instead of generating a new random `resourceUniqueKey`, it now extracts the `{randomId}` from the test's temporary directory path. This ensures that the key used for the cleanup check matches the one in the worker's name => allows the worker to be correctly identified and deleted after the test.

--- a/.notes/justin/worklogs/2025-01-27-e2e-worker-cleanup-investigation.md
+++ b/.notes/justin/worklogs/2025-01-27-e2e-worker-cleanup-investigation.md
@@ -1,0 +1,112 @@
+# E2E Worker Cleanup Investigation
+
+## Problem
+End-to-end tests are not deleting workers that are deployed during testing. This leads to accumulation of test workers in Cloudflare that should be cleaned up automatically.
+
+## Context
+- Tests use deployment functionality to create temporary workers
+- There should be cleanup logic to remove these workers after tests complete
+- Environment variable `RWSDK_SKIP_DEV=1` can be used to focus on deployment tests only
+
+## Plan
+1. Examine the E2E test infrastructure to understand cleanup flow
+2. Run deployment tests with dev tests skipped to observe behavior
+3. Identify where cleanup logic should be triggered
+4. Debug why cleanup isn't happening
+5. Fix the cleanup mechanism
+
+## Investigation Log
+
+### Initial Analysis
+Looking at the test files, I can see:
+- `playground/hello-world/__tests__/e2e.test.mts` uses `testDevAndDeploy` from `rwsdk/e2e`
+- The `release.mts` file contains worker deletion logic (`deleteWorker` function)
+- Need to trace how cleanup is supposed to be triggered after tests
+
+### Fixed E2E Export Issue
+- Found that `rwsdk/e2e` export was missing from `sdk/package.json`
+- Added the export configuration pointing to `./dist/lib/e2e/index.mjs`
+- Built the SDK to generate the dist files
+- Tests now load properly but fail due to missing Cloudflare authentication
+
+### Cleanup Mechanism Analysis
+From examining the code, the cleanup flow should work as follows:
+1. `createDeployment()` in `testHarness.mts` creates a deployment and registers cleanup task
+2. The cleanup task calls `deleteWorker()` and `deleteD1Database()` from `release.mts`
+3. Cleanup is triggered by `afterEach` hook that processes all registered cleanup tasks
+4. The cleanup runs in background (non-blocking) to avoid test timeouts
+
+### Authentication Issue
+Tests require Cloudflare authentication to deploy workers. Need to either:
+1. Set up wrangler authentication
+2. Use environment variables for account ID and API token
+
+### Successful Test Run Analysis
+Successfully ran the hello-world deployment test with authentication. Key observations:
+
+**Deployment Process:**
+- Worker deployed successfully: `hello-world-e2e-test-054bcd2c.redwoodjs.workers.dev`
+- Worker name includes unique key: `054bcd2c` (from resourceUniqueKey)
+
+**Cleanup Behavior:**
+- Test completed successfully (✓ passed)
+- Saw cleanup message: "Cleaning up: Deleting D1 database 92v2c9qt2sj..."
+- **ISSUE IDENTIFIED**: No worker deletion message in the output!
+- Only D1 database cleanup was logged, but no worker cleanup
+
+**Problem Analysis:**
+The cleanup mechanism is running (D1 database deletion was attempted), but the worker deletion is not happening or not being logged. Looking at the code:
+1. `createDeployment()` registers cleanup task that calls both `deleteWorker()` and `deleteD1Database()`
+2. The cleanup runs in background (non-blocking)
+3. D1 cleanup is happening, but worker cleanup is missing
+
+**Hypothesis:**
+The worker deletion might be:
+1. Failing silently in the background cleanup
+2. Not being called due to a logic error
+3. Being called but failing due to worker name mismatch
+
+### Root Cause Identified
+Added debug logging and ran the test again. The issue is now clear:
+
+**Debug Output:**
+```
+🧹 Starting cleanup for deployment: hello-world-e2e-test-4c2db11b
+🔑 Resource unique key: e2g4v8dkvyh
+🔍 isRelatedToTest check: false
+⚠️ Skipping worker deletion - worker name doesn't contain unique key
+   Worker name: "hello-world-e2e-test-4c2db11b"
+   Unique key: "e2g4v8dkvyh"
+```
+
+**The Problem:**
+The worker name (`hello-world-e2e-test-4c2db11b`) does not contain the resource unique key (`e2g4v8dkvyh`). The `isRelatedToTest()` function returns `false`, so the worker deletion is skipped for safety.
+
+**Analysis:**
+- Worker name contains: `4c2db11b` (from deployment process)
+- Resource unique key is: `e2g4v8dkvyh` (generated separately)
+- These are different values, causing the safety check to fail
+
+The issue is that the worker naming and resource unique key generation are happening in different places with different logic.
+
+### Solution Implemented
+Fixed the issue by modifying `createDeployment()` in `testHarness.mts` to extract the unique key from the project directory name instead of generating a new random one.
+
+**The Fix:**
+- Extract unique key from directory name using regex: `/-e2e-test-([a-f0-9]+)$/`
+- Directory format: `{projectName}-e2e-test-{randomId}` (from `setupTarballEnvironment`)
+- Use extracted key as `resourceUniqueKey` for cleanup matching
+
+**Test Results:**
+```
+🧹 Starting cleanup for deployment: hello-world-e2e-test-cd110389
+🔑 Resource unique key: cd110389
+🔍 isRelatedToTest check: true
+🗑️ Attempting to delete worker: hello-world-e2e-test-cd110389
+```
+
+The fix works! Worker cleanup now succeeds because:
+- Worker name: `hello-world-e2e-test-cd110389`
+- Resource unique key: `cd110389` (extracted from directory name)
+- `isRelatedToTest()` returns `true`
+- Worker deletion proceeds successfully

--- a/.notes/justin/worklogs/2025-01-27-e2e-worker-cleanup-investigation.md
+++ b/.notes/justin/worklogs/2025-01-27-e2e-worker-cleanup-investigation.md
@@ -110,3 +110,20 @@ The fix works! Worker cleanup now succeeds because:
 - Resource unique key: `cd110389` (extracted from directory name)
 - `isRelatedToTest()` returns `true`
 - Worker deletion proceeds successfully
+
+### Verification Test
+Ran the test again after removing debug logging and re-adding the e2e export. The cleanup works as expected:
+
+```
+Cleaning up: Deleting worker hello-world-e2e-test-6ab557a2...
+Running command: npx wrangler delete hello-world-e2e-test-6ab557a2
+```
+
+## Summary
+**Problem:** E2E tests were not deleting deployed workers after completion, leading to accumulation of test workers in Cloudflare.
+
+**Root Cause:** The `resourceUniqueKey` used for cleanup was generated independently from the unique ID used in the worker directory name, causing a mismatch that prevented the `isRelatedToTest` check from passing.
+
+**Solution:** Modified `createDeployment()` in `testHarness.mts` to extract the unique key from the project directory name using regex pattern `/-e2e-test-([a-f0-9]+)$/` instead of generating a new random key.
+
+**Result:** Workers are now properly cleaned up after E2E tests complete, preventing accumulation of test workers in Cloudflare.

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -59,6 +59,10 @@
       "types": "./dist/runtime/entries/auth.d.ts",
       "default": "./dist/runtime/entries/auth.js"
     },
+    "./e2e": {
+      "types": "./dist/lib/e2e/index.d.mts",
+      "default": "./dist/lib/e2e/index.mjs"
+    },
     "./db": {
       "types": "./dist/runtime/lib/db/index.d.ts",
       "default": "./dist/runtime/lib/db/index.js"
@@ -90,10 +94,6 @@
     "./realtime/durableObject": {
       "types": "./dist/runtime/lib/realtime/durableObject.d.ts",
       "default": "./dist/runtime/lib/realtime/durableObject.js"
-    },
-    "./e2e": {
-      "types": "./dist/lib/e2e/index.d.mts",
-      "default": "./dist/lib/e2e/index.mjs"
     }
   },
   "keywords": [

--- a/sdk/src/lib/e2e/testHarness.mts
+++ b/sdk/src/lib/e2e/testHarness.mts
@@ -7,6 +7,7 @@ import {
   expect,
   vi,
 } from "vitest";
+import { basename } from "path";
 import { setupTarballEnvironment } from "./tarball.mjs";
 import { runDevServer } from "./dev.mjs";
 import {
@@ -229,7 +230,14 @@ export async function createDeployment(): Promise<DeploymentInstance> {
   }
 
   const env = getPlaygroundEnvironment();
-  const resourceUniqueKey = Math.random().toString(36).substring(2, 15);
+
+  // Extract the unique key from the project directory name instead of generating a new one
+  // The directory name format is: {projectName}-e2e-test-{randomId}
+  const dirName = basename(env.projectDir);
+  const match = dirName.match(/-e2e-test-([a-f0-9]+)$/);
+  const resourceUniqueKey = match
+    ? match[1]
+    : Math.random().toString(36).substring(2, 15);
 
   const deployResult = await runRelease(
     env.projectDir,


### PR DESCRIPTION
### Problem

End-to-end tests that deploy Cloudflare workers were not cleaning up (deleting) those workers after the tests completed. This resulted in an accumulation of test workers in the Cloudflare account.

The cleanup mechanism includes a safety check to ensure it only deletes workers related to the specific test run. It does this by comparing a `resourceUniqueKey` with the worker's name.

The problem was that the `resourceUniqueKey` used for the cleanup check was generated randomly and separately from the unique ID embedded in the deployed worker's name. Because these two identifiers never matched, the safety check would fail, and the worker deletion would be skipped.

### Solution

The fix is to ensure the `resourceUniqueKey` is derived from the same source as the unique ID in the worker's name. The worker's name is based on the temporary directory created for the test, which has a name format like `{projectName}-e2e-test-{randomId}`.

The solution modifies the `createDeployment()` function in the E2E test harness. Instead of generating a new random `resourceUniqueKey`, it now extracts the `{randomId}` from the test's temporary directory path. This ensures that the key used for the cleanup check matches the one in the worker's name => allows the worker to be correctly identified and deleted after the test.