### PR TITLE
fix(e2e): Disable inspector port in tests to prevent collisions

### DIFF
--- a/playground/hello-world/vite.config.mts
+++ b/playground/hello-world/vite.config.mts
@@ -6,6 +6,7 @@ export default defineConfig({
   plugins: [
     cloudflare({
       viteEnvironment: { name: "worker" },
+      inspectorPort: process.env.CI ? false : undefined,
     }),
     redwood(),
   ],

--- a/playground/render-apis/vite.config.mts
+++ b/playground/render-apis/vite.config.mts
@@ -6,6 +6,7 @@ export default defineConfig({
   plugins: [
     cloudflare({
       viteEnvironment: { name: "worker" },
+      inspectorPort: process.env.CI ? false : undefined,
     }),
     redwood(),
   ],

--- a/playground/useid-test/vite.config.mts
+++ b/playground/useid-test/vite.config.mts
@@ -6,6 +6,7 @@ export default defineConfig({
   plugins: [
     cloudflare({
       viteEnvironment: { name: "worker" },
+      inspectorPort: process.env.CI ? false : undefined,
     }),
     redwood(),
   ],


### PR DESCRIPTION
This change addresses an intermittent failure in the end-to-end tests caused by inspector port collisions. When multiple dev server tests run in parallel, they would sometimes attempt to bind to the same default inspector port, leading to a race condition and test failures.

The fix is to disable the inspector port within the Vite configuration for all playground applications when the CI environment variable is set. This prevents the port conflict during automated testing while keeping the inspector available for local development.