### PR TITLE
fix: Account for `use strict` when finding client/server directives

### DIFF
--- a/sdk/src/vite/hasDirective.test.mts
+++ b/sdk/src/vite/hasDirective.test.mts
@@ -2,123 +2,117 @@ import { describe, it, expect } from "vitest";
 import { hasDirective } from "./hasDirective.mjs";
 
 describe("hasDirective", () => {
-  it('should find "use client" directive with double quotes', () => {
-    const code = `"use client";
-    
-    import React from "react";
-    
-    const MyComponent = () => <div>Hello</div>;
-    export default MyComponent;`;
+  it('should find "use client" directive', () => {
+    const code = `"use client"; import React from "react";`;
     expect(hasDirective(code, "use client")).toBe(true);
   });
 
-  it("should find 'use server' directive with single quotes", () => {
-    const code = `'use server';
-    
-    export async function myAction() {
-      // ...
-    }`;
+  it('should find "use server" directive', () => {
+    const code = `'use server'; export async function myAction() {}`;
     expect(hasDirective(code, "use server")).toBe(true);
   });
 
-  it("should find directive with leading whitespace", () => {
-    const code = `    "use client";
-    
-    const MyComponent = () => <div>Hello</div>;`;
+  it("should not find a directive that is not there", () => {
+    const code = `import React from "react";`;
+    expect(hasDirective(code, "use client")).toBe(false);
+  });
+
+  it('should find "use client" directive with single quotes', () => {
+    const code = `'use client'; import React from "react";`;
     expect(hasDirective(code, "use client")).toBe(true);
   });
 
-  it("should find directive after single-line comments", () => {
-    const code = `// This is a component
-    "use client";
-    
-    const MyComponent = () => <div>Hello</div>;`;
-    expect(hasDirective(code, "use client")).toBe(true);
-  });
-
-  it("should find directive after multi-line comments", () => {
-    const code = `/* This is a component */
-    "use client";
-    
-    const MyComponent = () => <div>Hello</div>;`;
-    expect(hasDirective(code, "use client")).toBe(true);
-  });
-
-  it("should find directive after empty lines", () => {
+  it("should find directive when preceded by comments and whitespace", () => {
     const code = `
+      // This is a client component
+      /* And here is another comment */
 
-    "use client";
-    
-    const MyComponent = () => <div>Hello</div>;`;
+      "use client";
+      import React from 'react';
+      export default () => <div>Hello</div>;
+    `;
+    expect(hasDirective(code, "use client")).toBe(true);
+  });
+
+  it('should find "use client" directive when preceded by "use strict"', () => {
+    const code = `
+      "use strict";
+      "use client";
+      import React from 'react';
+      export default () => <div>Hello</div>;
+    `;
+    expect(hasDirective(code, "use client")).toBe(true);
+  });
+
+  it('should find "use server" directive when preceded by "use strict" and comments', () => {
+    const code = `
+      // server stuff
+      "use strict";
+      /* another comment */
+      "use server";
+      export async function myAction() {}
+    `;
+    expect(hasDirective(code, "use server")).toBe(true);
+  });
+
+  it("should find directive when preceded by another string literal directive", () => {
+    const code = `
+      "use awesome"; // Some other directive
+      "use client";
+      import React from 'react';
+      export default () => <div>Hello</div>;
+    `;
     expect(hasDirective(code, "use client")).toBe(true);
   });
 
   it("should return false if no directive is present", () => {
     const code = `import React from "react";
-    
-    const MyComponent = () => <div>Hello</div>;`;
+    export default () => <div>Hello</div>;`;
     expect(hasDirective(code, "use client")).toBe(false);
   });
 
-  it("should return false if directive is not at the top", () => {
+  it("should return false if the directive is commented out", () => {
+    const code = `// "use client";
+    import React from "react";
+    export default () => <div>Hello</div>;`;
+    expect(hasDirective(code, "use client")).toBe(false);
+  });
+
+  it("should return false if the directive appears after code", () => {
     const code = `import React from "react";
     "use client";
-    
-    const MyComponent = () => <div>Hello</div>;`;
+    export default () => <div>Hello</div>;`;
     expect(hasDirective(code, "use client")).toBe(false);
   });
 
-  it("should return false if directive is inside a single-line comment", () => {
-    const code = `// "use client";
-    
-    const MyComponent = () => <div>Hello</div>;`;
+  it("should handle multi-line comments correctly", () => {
+    const code = `
+      /*
+       * "use client";
+       */
+      import React from "react";
+    `;
     expect(hasDirective(code, "use client")).toBe(false);
   });
 
-  it("should return false if directive is inside a multi-line comment", () => {
-    const code = `/*
-     * "use client";
-     */
-    
-    const MyComponent = () => <div>Hello</div>;`;
-    expect(hasDirective(code, "use client")).toBe(false);
-  });
-
-  it("should return false if directive is a substring in other code", () => {
-    const code = `const message = 'please "use client" wisely';`;
-    expect(hasDirective(code, "use client")).toBe(false);
-  });
-
-  it("should handle a file with only the directive", () => {
-    const code = `"use client"`;
+  it("should handle code with no whitespace", () => {
+    const code = `"use client";import React from "react";`;
     expect(hasDirective(code, "use client")).toBe(true);
   });
 
-  it("should handle mixed comments, whitespace, and the directive", () => {
-    const code = `// A component
-    
-    /* 
-      Another comment
-    */
-   
-    'use client';
-
-    const MyComponent = () => <div>Hello</div>;
-    `;
-    expect(hasDirective(code, "use client")).toBe(true);
-  });
-
-  it("should handle multi-line comment ending on same line", () => {
-    const code = `/* "use client" */
-    const MyComponent = () => <div>Hello</div>;
-    `;
+  it("should handle empty code", () => {
+    const code = "";
     expect(hasDirective(code, "use client")).toBe(false);
   });
 
-  it("should return false for code where directive appears after a valid line of code", () => {
-    const code = `const a = 1;
-    "use client";
-    `;
+  it("should handle code with only whitespace", () => {
+    const code = "  \n\t  ";
+    expect(hasDirective(code, "use client")).toBe(false);
+  });
+
+  it("should handle files with only comments", () => {
+    const code = `// comment 1
+    /* comment 2 */`;
     expect(hasDirective(code, "use client")).toBe(false);
   });
 });


### PR DESCRIPTION
We weren't account for `"use strict"` being on top of the file when checking for `"use client"`/`"use server"` directives.