### PR TITLE
chore: Fix E2E flake

### DIFF
--- a/.notes/justin/worklogs/2025-09-22-e2e-retry-and-cleanup.md
+++ b/.notes/justin/worklogs/2025-09-22-e2e-retry-and-cleanup.md
@@ -1,0 +1,29 @@
+# 2025-09-22: E2E Test Retries and Worker Cleanup
+
+## Problem
+
+E2E tests are failing due to two main reasons:
+1.  Flaky network errors like `ECONNRESET` during dev server tests.
+2.  Hitting the Cloudflare account limit of 500 workers during deployment tests.
+
+## Plan
+
+1.  **Implement Retry Logic**: Add a retry mechanism to the e2e test harness to automatically retry tests that fail with transient, code-based errors.
+2.  **Verify Cleanup Script**: Systematically test the `scripts/cleanup-test-workers.sh` script to ensure it effectively removes test workers and prevents hitting the account limit, allowing tests to run reliably in CI.
+
+## Context
+
+The `ECONNRESET` error is a common transient issue in Node.js applications, and retrying is a standard way to handle it. The worker limit is a hard constraint from Cloudflare, so a robust cleanup process is essential for our e2e tests that perform deployments.
+
+## Log
+
+### Testing the Worker Cleanup Script
+
+To verify that the cleanup script prevents us from hitting the Cloudflare worker limit, I'll follow a clear testing sequence:
+
+1.  **Initial Cleanup**: Run `scripts/cleanup-test-workers.sh` to establish a clean baseline by deleting any lingering test workers from previous runs.
+2.  **Run Tests**: Execute the `hello-world` e2e test suite. This will create new workers as part of its deployment tests.
+3.  **Secondary Cleanup**: Run the cleanup script again to confirm that it correctly identifies and removes the workers created in the previous step.
+4.  **Final Test Run**: Re-run the `hello-world` tests to ensure that the environment is clean and that tests can pass without being blocked by the worker limit.
+
+This process will validate that our cleanup mechanism is working as expected and that we can reliably run our e2e tests in a CI environment without manual intervention.

--- a/.notes/justin/worklogs/2025-09-22-e2e-retry-and-cleanup.md
+++ b/.notes/justin/worklogs/2025-09-22-e2e-retry-and-cleanup.md
@@ -19,11 +19,8 @@ The `ECONNRESET` error is a common transient issue in Node.js applications, and 
 
 ### Testing the Worker Cleanup Script
 
-To verify that the cleanup script prevents us from hitting the Cloudflare worker limit, I'll follow a clear testing sequence:
+To verify that the in-test cleanup is working correctly and not leaking workers, I'll run the `hello-world` test and then use the Cloudflare API to confirm that the worker created during the test run has been deleted.
 
-1.  **Initial Cleanup**: Run `scripts/cleanup-test-workers.sh` to establish a clean baseline by deleting any lingering test workers from previous runs.
-2.  **Run Tests**: Execute the `hello-world` e2e test suite. This will create new workers as part of its deployment tests.
-3.  **Secondary Cleanup**: Run the cleanup script again to confirm that it correctly identifies and removes the workers created in the previous step.
-4.  **Final Test Run**: Re-run the `hello-world` tests to ensure that the environment is clean and that tests can pass without being blocked by the worker limit.
+### Optimizing D1 Cleanup
 
-This process will validate that our cleanup mechanism is working as expected and that we can reliably run our e2e tests in a CI environment without manual intervention.
+The tests spend time attempting to clean up D1 databases for projects that do not have one configured. This is inefficient and can introduce noise into the test logs. To fix this, the cleanup logic will be updated to first inspect the project's `wrangler.jsonc`. It will only attempt to delete a D1 database if the `d1_databases` key is present and contains at least one database configuration.

--- a/.notes/justin/worklogs/2025-09-22-e2e-retry-and-cleanup.md
+++ b/.notes/justin/worklogs/2025-09-22-e2e-retry-and-cleanup.md
@@ -24,3 +24,20 @@ To verify that the in-test cleanup is working correctly and not leaking workers,
 ### Optimizing D1 Cleanup
 
 The tests spend time attempting to clean up D1 databases for projects that do not have one configured. This is inefficient and can introduce noise into the test logs. To fix this, the cleanup logic will be updated to first inspect the project's `wrangler.jsonc`. It will only attempt to delete a D1 database if the `d1_databases` key is present and contains at least one database configuration.
+
+## Solution
+
+The e2e test harness was successfully updated to be more resilient and efficient. Key changes include:
+- A retry mechanism was added to automatically handle transient, code-based network errors during test runs.
+- The worker cleanup process was made more robust by replacing the `wrangler` CLI command with a direct Cloudflare API call, resolving persistent credential and command-parsing issues.
+- The cleanup logic for D1 databases was optimized to first check the project's `wrangler.jsonc` and only attempt deletion if a database is configured.
+- A polling mechanism was added to the deployment function to wait for the worker to become routable before proceeding with tests, preventing timeout errors.
+- The default polling timeout was increased to provide a larger buffer for deployment warmup.
+
+## PR Description
+
+- **Automatic Retries**: Added a retry mechanism to handle transient network errors.
+- **Reliable Worker Cleanup**: Replaced `wrangler delete` with a direct Cloudflare API call for worker cleanup.
+- **Smarter Database Cleanup**: The D1 cleanup now checks `wrangler.jsonc` before attempting deletion.
+- **Deployment Polling**: Added polling to wait for deployments to be live before running tests.
+- **Increased Test Timeout**: Increased the polling timeout to 2 minutes.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "check-starters:dev": "for starter in starters/*; do ./scripts/check-app.sh dev $starter; done",
     "check-starters:preview": "for starter in starters/*; do ./scripts/check-app.sh preview $starter; done",
     "format": "prettier --write ./sdk/src starters/*/src",
-    "test:e2e": "cd playground && pnpm test:e2e",
+    "test:e2e": "(cd sdk && pnpm build) && cd playground && pnpm test:e2e",
     "setup:e2e": "pnpm setup:wrangler",
     "setup:wrangler": "./scripts/setup-wrangler-auth.sh"
   },

--- a/sdk/src/lib/e2e/release.mts
+++ b/sdk/src/lib/e2e/release.mts
@@ -691,6 +691,22 @@ export async function deleteD1Database(
   cwd: string,
   resourceUniqueKey: string,
 ): Promise<void> {
+  // Check wrangler.jsonc to see if a database is configured
+  const wranglerConfigPath = resolve(cwd, "wrangler.jsonc");
+  try {
+    const configContent = await fs.readFile(wranglerConfigPath, "utf-8");
+    const config = parseJsonc(configContent);
+    if (!config.d1_databases || config.d1_databases.length === 0) {
+      log("No D1 databases configured in wrangler.jsonc, skipping deletion.");
+      return;
+    }
+  } catch (error) {
+    log(
+      `Could not read or parse wrangler.jsonc at ${wranglerConfigPath}, proceeding with deletion attempt anyway.`,
+      error,
+    );
+  }
+
   console.log(`Cleaning up: Deleting D1 database ${name}...`);
   try {
     // First check if the database exists

--- a/sdk/src/lib/e2e/testHarness.mts
+++ b/sdk/src/lib/e2e/testHarness.mts
@@ -441,7 +441,7 @@ export function testDev(
   }) => Promise<void>,
 ) {
   if (SKIP_DEV_SERVER_TESTS) {
-    test.skip(name, () => {});
+    test.skip(name, testFn);
     return;
   }
 
@@ -538,7 +538,7 @@ export function testDeploy(
   }) => Promise<void>,
 ) {
   if (SKIP_DEPLOYMENT_TESTS) {
-    test.skip(name, () => {});
+    test.skip(name, testFn);
     return;
   }
 
@@ -551,7 +551,7 @@ export function testDeploy(
       const cleanup = async () => {
         // We don't await this because we want to let it run in the background
         // The afterEach hook for deployments already does this.
-        cleanupDeployment(deployment);
+        await cleanupDeployment(deployment);
         await browser.close();
       };
 
@@ -600,7 +600,7 @@ testDeploy.only = (
       const cleanup = async () => {
         // We don't await this because we want to let it run in the background
         // The afterEach hook for deployments already does this.
-        cleanupDeployment(deployment);
+        await cleanupDeployment(deployment);
         await browser.close();
       };
 

--- a/sdk/src/lib/e2e/testHarness.mts
+++ b/sdk/src/lib/e2e/testHarness.mts
@@ -356,6 +356,78 @@ export async function createBrowser(): Promise<Browser> {
 }
 
 /**
+ * Executes a test function with a retry mechanism for specific error codes.
+ * @param name - The name of the test, used for logging.
+ * @param attemptFn - A function that executes one attempt of the test.
+ *                     It should set up resources, run the test logic, and
+ *                     return a cleanup function. The cleanup function will be
+ *                     called automatically on failure.
+ */
+export async function runTestWithRetries(
+  name: string,
+  attemptFn: () => Promise<{ cleanup: () => Promise<void> }>,
+) {
+  const MAX_RETRIES_PER_CODE = 6;
+  const retryCounts: Record<string, number> = {};
+  let attempt = 0;
+
+  while (true) {
+    attempt++;
+    let cleanup: (() => Promise<void>) | undefined;
+
+    try {
+      const res = await attemptFn();
+      cleanup = res.cleanup;
+
+      if (attempt > 1) {
+        console.log(
+          `[runTestWithRetries] Test "${name}" succeeded on attempt ${attempt}.`,
+        );
+      }
+      // On success, we don't run cleanup here. It will be handled by afterEach.
+      return; // Success
+    } catch (e: any) {
+      // On failure, run the cleanup from the failed attempt.
+      // The cleanup function is attached to the error object on failure.
+      const errorCleanup = e.cleanup;
+      if (typeof errorCleanup === "function") {
+        await errorCleanup().catch((err: any) =>
+          console.warn(
+            `[runTestWithRetries] Cleanup failed for "${name}" during retry:`,
+            err,
+          ),
+        );
+      }
+
+      const errorCode = e?.code;
+      if (typeof errorCode === "string" && errorCode) {
+        const count = (retryCounts[errorCode] || 0) + 1;
+        retryCounts[errorCode] = count;
+
+        if (count <= MAX_RETRIES_PER_CODE) {
+          console.log(
+            `[runTestWithRetries] Attempt ${attempt} for "${name}" failed with code ${errorCode}. Retrying (failure ${count}/${MAX_RETRIES_PER_CODE} for this code)...`,
+          );
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          continue; // Next attempt
+        } else {
+          console.error(
+            `[runTestWithRetries] Test "${name}" failed with code ${errorCode} after ${MAX_RETRIES_PER_CODE} retries for this code.`,
+          );
+          throw e; // Give up
+        }
+      } else {
+        console.error(
+          `[runTestWithRetries] Test "${name}" failed on attempt ${attempt} with a non-retryable error:`,
+          e,
+        );
+        throw e;
+      }
+    }
+  }
+}
+
+/**
  * High-level test wrapper for dev server tests.
  * Automatically skips if RWSDK_SKIP_DEV=1
  */
@@ -374,17 +446,31 @@ export function testDev(
   }
 
   test(name, async () => {
-    const devServer = await createDevServer();
-    const browser = await createBrowser();
-    const page = await browser.newPage();
+    await runTestWithRetries(name, async () => {
+      const devServer = await createDevServer();
+      const browser = await createBrowser();
+      const page = await browser.newPage();
 
-    await testFn({
-      devServer,
-      browser,
-      page,
-      url: devServer.url,
+      const cleanup = async () => {
+        await browser.close();
+        await devServer.stopDev();
+      };
+
+      try {
+        await testFn({
+          devServer,
+          browser,
+          page,
+          url: devServer.url,
+        });
+
+        return { cleanup };
+      } catch (error) {
+        // Ensure cleanup is available to the retry wrapper even if testFn fails.
+        // We re-throw the error to be handled by runTestWithRetries.
+        throw Object.assign(error as Error, { cleanup });
+      }
     });
-    // Automatic cleanup handled by afterEach hooks
   });
 }
 
@@ -393,6 +479,49 @@ export function testDev(
  */
 testDev.skip = (name: string, testFn?: any) => {
   test.skip(name, testFn || (() => {}));
+};
+
+testDev.only = (
+  name: string,
+  testFn: (context: {
+    devServer: DevServerInstance;
+    browser: Browser;
+    page: Page;
+    url: string;
+  }) => Promise<void>,
+) => {
+  if (SKIP_DEV_SERVER_TESTS) {
+    test.skip(name, () => {});
+    return;
+  }
+
+  test.only(name, async () => {
+    await runTestWithRetries(name, async () => {
+      const devServer = await createDevServer();
+      const browser = await createBrowser();
+      const page = await browser.newPage();
+
+      const cleanup = async () => {
+        await browser.close();
+        await devServer.stopDev();
+      };
+
+      try {
+        await testFn({
+          devServer,
+          browser,
+          page,
+          url: devServer.url,
+        });
+
+        return { cleanup };
+      } catch (error) {
+        // Ensure cleanup is available to the retry wrapper even if testFn fails.
+        // We re-throw the error to be handled by runTestWithRetries.
+        throw Object.assign(error as Error, { cleanup });
+      }
+    });
+  });
 };
 
 /**
@@ -414,17 +543,30 @@ export function testDeploy(
   }
 
   test(name, async () => {
-    const deployment = await createDeployment();
-    const browser = await createBrowser();
-    const page = await browser.newPage();
+    await runTestWithRetries(name, async () => {
+      const deployment = await createDeployment();
+      const browser = await createBrowser();
+      const page = await browser.newPage();
 
-    await testFn({
-      deployment,
-      browser,
-      page,
-      url: deployment.url,
+      const cleanup = async () => {
+        // We don't await this because we want to let it run in the background
+        // The afterEach hook for deployments already does this.
+        cleanupDeployment(deployment);
+        await browser.close();
+      };
+
+      try {
+        await testFn({
+          deployment,
+          browser,
+          page,
+          url: deployment.url,
+        });
+        return { cleanup };
+      } catch (error) {
+        throw Object.assign(error as Error, { cleanup });
+      }
     });
-    // Automatic cleanup handled by afterEach hooks
   });
 }
 
@@ -433,6 +575,48 @@ export function testDeploy(
  */
 testDeploy.skip = (name: string, testFn?: any) => {
   test.skip(name, testFn || (() => {}));
+};
+
+testDeploy.only = (
+  name: string,
+  testFn: (context: {
+    deployment: DeploymentInstance;
+    browser: Browser;
+    page: Page;
+    url: string;
+  }) => Promise<void>,
+) => {
+  if (SKIP_DEPLOYMENT_TESTS) {
+    test.skip(name, () => {});
+    return;
+  }
+
+  test.only(name, async () => {
+    await runTestWithRetries(name, async () => {
+      const deployment = await createDeployment();
+      const browser = await createBrowser();
+      const page = await browser.newPage();
+
+      const cleanup = async () => {
+        // We don't await this because we want to let it run in the background
+        // The afterEach hook for deployments already does this.
+        cleanupDeployment(deployment);
+        await browser.close();
+      };
+
+      try {
+        await testFn({
+          deployment,
+          browser,
+          page,
+          url: deployment.url,
+        });
+        return { cleanup };
+      } catch (error) {
+        throw Object.assign(error as Error, { cleanup });
+      }
+    });
+  });
 };
 
 /**
@@ -449,54 +633,17 @@ export function testDevAndDeploy(
     url: string;
   }) => Promise<void>,
 ) {
-  if (SKIP_DEV_SERVER_TESTS) {
-    test.skip(`${name} (dev)`, () => {});
-  } else {
-    test(`${name} (dev)`, async () => {
-      const devServer = await createDevServer();
-      const browser = await createBrowser();
-      const page = await browser.newPage();
-
-      await testFn({
-        devServer,
-        browser,
-        page,
-        url: devServer.url,
-      });
-      // Automatic cleanup handled by afterEach hooks
-    });
-  }
-
-  if (SKIP_DEPLOYMENT_TESTS) {
-    test.skip(`${name} (deployment)`, () => {});
-  } else {
-    test(`${name} (deployment)`, async () => {
-      const deployment = await createDeployment();
-      const browser = await createBrowser();
-      const page = await browser.newPage();
-
-      await testFn({
-        deployment,
-        browser,
-        page,
-        url: deployment.url,
-      });
-      // Automatic cleanup handled by afterEach hooks
-    });
-  }
+  testDev(`${name} (dev)`, testFn);
+  testDeploy(`${name} (deployment)`, testFn);
 }
 
 /**
  * Skip version of testDevAndDeploy
  */
 testDevAndDeploy.skip = (name: string, testFn?: any) => {
-  test.skip(`${name} (dev)`, testFn || (() => {}));
-  test.skip(`${name} (deployment)`, testFn || (() => {}));
+  test.skip(name, testFn || (() => {}));
 };
 
-/**
- * Only version of testDevAndDeploy
- */
 testDevAndDeploy.only = (
   name: string,
   testFn: (context: {
@@ -507,35 +654,8 @@ testDevAndDeploy.only = (
     url: string;
   }) => Promise<void>,
 ) => {
-  if (!SKIP_DEV_SERVER_TESTS) {
-    test.only(`${name} (dev)`, async () => {
-      const devServer = await createDevServer();
-      const browser = await createBrowser();
-      const page = await browser.newPage();
-
-      await testFn({
-        devServer,
-        browser,
-        page,
-        url: devServer.url,
-      });
-    });
-  }
-
-  if (!SKIP_DEPLOYMENT_TESTS) {
-    test.only(`${name} (deployment)`, async () => {
-      const deployment = await createDeployment();
-      const browser = await createBrowser();
-      const page = await browser.newPage();
-
-      await testFn({
-        deployment,
-        browser,
-        page,
-        url: deployment.url,
-      });
-    });
-  }
+  testDev.only(`${name} (dev)`, testFn);
+  testDeploy.only(`${name} (deployment)`, testFn);
 };
 
 /**

--- a/sdk/src/lib/e2e/testHarness.mts
+++ b/sdk/src/lib/e2e/testHarness.mts
@@ -34,6 +34,7 @@ interface DeploymentInstance {
   url: string;
   workerName: string;
   resourceUniqueKey: string;
+  projectDir: string;
 }
 
 // Environment variable flags for skipping tests
@@ -284,6 +285,7 @@ export async function createDeployment(): Promise<DeploymentInstance> {
     url: deployResult.url,
     workerName: deployResult.workerName,
     resourceUniqueKey,
+    projectDir: env.projectDir,
   };
 }
 


### PR DESCRIPTION
- **Automatic Retries**: Added a retry mechanism to handle transient network errors.
- **Reliable Worker Cleanup**: Replaced `wrangler delete` with a direct Cloudflare API call for worker cleanup.
- **Smarter Database Cleanup**: The D1 cleanup now checks `wrangler.jsonc` before attempting deletion.
- **Deployment Polling**: Added polling to wait for deployments to be live before running tests.
- **Increased Test Timeout**: Increased the polling timeout to 2 minutes.