### PR TITLE
fix(vite): Prevent re-optimization by defining all framework dependencies

### DIFF
--- a/.notes/justin/worklogs/2025-09-24-vite-esbuild-yarn-resolution-issue.md
+++ b/.notes/justin/worklogs/2025-09-24-vite-esbuild-yarn-resolution-issue.md
@@ -136,62 +136,39 @@ The `sdk/package.json` file's `exports` map was used as the source of truth for 
 #### 1. `worker` Environment (Server-Side)
 
 *   **Goal:** Ensure all backend-related modules are pre-optimized.
-*   **Additions:**
-    *   `rwsdk/constants`: Provides fundamental constants used across server modules. Its omission was the cause of the initial error.
-    *   `rwsdk/debug`: A general-purpose debugging utility for server-side logging.
-    *   `rwsdk/llms`: Server-side utilities for Large Language Models.
+*   **Rationale:** This environment includes all server-side functionalities. `rwsdk/auth`, `rwsdk/db`, `rwsdk/llms`, and `rwsdk/router` are all exclusively used for backend logic and are therefore included.
 
 #### 2. `client` Environment (Browser)
 
 *   **Goal:** Pre-optimize all modules intended for browser execution.
-*   **Additions:**
-    *   `rwsdk/auth`: Manages client-side authentication state.
-    *   `rwsdk/router`: A core module for client-side navigation.
-    *   `rwsdk/turnstile`: Integrates the client-side Cloudflare Turnstile captcha service.
-    *   `rwsdk/constants` and `rwsdk/debug`: General utilities that are also used on the client.
-
-#### 3. `ssr` Environment (Server-Side Rendering)
-
-*   **Goal:** Pre-optimize modules needed to render client components on the server. Its dependencies should largely mirror the `client` environment.
-*   **Additions:**
-    *   `rwsdk/auth`, `rwsdk/router`, `rwsdk/realtime/client`: Required to successfully pre-render components that depend on authentication state, routing, or realtime data.
-    *   `rwsdk/constants` and `rwsdk/debug`: General utilities needed for rendering.
-
-### Implementation Details and Rationale
-
-The `sdk/package.json` file's `exports` map was used as the source of truth for all public framework entry points. Each entry point was categorized for its relevance to the `worker`, `client`, and `ssr` environments to create a comprehensive dependency list for each.
-
-#### 1. `worker` Environment (Server-Side)
-
-*   **Goal:** Ensure all backend-related modules are pre-optimized.
-*   **Modules Included:** `rwsdk/auth`, `rwsdk/llms`, and `rwsdk/router` are included as they are worker-only functionalities.
-
-#### 2. `client` Environment (Browser)
-
-*   **Goal:** Pre-optimize all modules intended for browser execution.
-*   **Modules Included:** `rwsdk/turnstile` (client-side captcha) and `rwsdk/realtime/client` are the primary client-specific modules. `rwsdk/auth` and `rwsdk/router` were removed as they are not used on the client.
+*   **Rationale:** This list includes only modules that are safe and necessary for the client. `rwsdk/turnstile` (client-side captcha) and `rwsdk/realtime/client` are the primary client-specific modules. `rwsdk/auth` and `rwsdk/router` are excluded as their functionality is worker-only.
 
 #### 3. `ssr` Environment (Server-Side Rendering)
 
 *   **Goal:** Pre-optimize modules needed to render client components on the server. Its dependencies mirror the `client` environment.
-*   **Modules Included:** As with the `client` environment, `rwsdk/auth` and `rwsdk/router` are not required.
+*   **Rationale:** Since this environment pre-renders client components, its dependencies should align with the client. As such, `rwsdk/auth` and `rwsdk/router` are not required.
 
 #### 4. All Environments
 
-*   **Modules Included:** `rwsdk/constants` and `rwsdk/debug` are platform-agnostic utilities and are therefore included in all environments.
+*   **Goal:** Include platform-agnostic utilities everywhere.
+*   **Rationale:** `rwsdk/constants` and `rwsdk/debug` are general-purpose utilities that can be used in any environment.
 
 ## PR Description
 
 ### fix(vite): Prevent re-optimization by defining all framework dependencies
 
-This change prevents Vite's dependency optimizer from re-running after the initial scan, which was causing unexpected full-page reloads in the dev server.
+This change prevents the dev server from crashing with a pre-bundling error by ensuring Vite's dependency optimizer has a complete map of all framework modules from the start.
 
 #### Problem
 
-In certain monorepo configurations, a previous fix (PR #775) enabled Vite's optimizer to correctly resolve `rwsdk` modules for the first time. However, this revealed a limitation in Vite's static analysis, which could not always discover the entire internal dependency graph of the framework.
+The dev server would crash with the error `Internal server error: There is a new version of the pre-bundle...` during development.
 
-When an application requested a framework module that Vite had missed during its initial scan (e.g., `rwsdk/constants`), Vite would identify it as a "new" dependency. This triggered a re-optimization of all dependencies and a forced page reload, which disrupts the framework's internal state management.
+This was a side effect of a fix in PR #775. To support 'use client' and 'use server' directives in third-party packages, our build process transforms code in `node_modules`, which can inject imports to `rwsdk` modules. In a monorepo, a transformed dependency can be hoisted to the root, while the `rwsdk` package itself is located in a nested project's `node_modules`.
+
+To handle this inverted resolution path, we introduced custom resolution logic in a vite plugin in RedwoodSDK. While this fixed the resolution failure, it revealed a limitation in Vite's dependency scanner. Once Vite could find an initial `rwsdk` module, its static analysis could not always discover the framework's entire internal dependency graph.
+
+When a module missed during the initial scan (e.g., `rwsdk/constants`) was requested at runtime, Vite would trigger a re-optimization to create a new dependency bundle. This caused the running server code, which still referenced the old bundle, to become inconsistent with Vite's module map, leading to the crash.
 
 #### Solution
 
-This is addressed by explicitly defining all public `rwsdk` entry points in each environment's `optimizeDeps.include` list (`worker`, `client`, and `ssr`). This provides Vite with a complete and accurate dependency map upfront, ensuring that all framework modules are pre-bundled from the start. This prevents any runtime discoveries that would lead to re-optimization.
+This is addressed by explicitly defining all public `rwsdk` entry points in each environment's `optimizeDeps.include` list (`worker`, `client`, and `ssr`). This provides Vite with a complete and accurate dependency map upfront, ensuring that all framework modules are pre-bundled from the start. This prevents any runtime discoveries that would lead to the re-optimization and subsequent server error.

--- a/sdk/src/vite/configPlugin.mts
+++ b/sdk/src/vite/configPlugin.mts
@@ -51,13 +51,16 @@ export const configPlugin = ({
       optimizeDeps: {
         noDiscovery: false,
         include: [
-          "rwsdk/worker",
-          "rwsdk/router",
-          "rwsdk/auth",
-          "rwsdk/db",
           "rwsdk/__ssr_bridge",
-          "rwsdk/realtime/worker",
+          "rwsdk/auth",
+          "rwsdk/constants",
+          "rwsdk/db",
+          "rwsdk/debug",
+          "rwsdk/llms",
           "rwsdk/realtime/durableObject",
+          "rwsdk/realtime/worker",
+          "rwsdk/router",
+          "rwsdk/worker",
         ],
         exclude: [],
         entries: [workerEntryPathname],
@@ -106,7 +109,13 @@ export const configPlugin = ({
           },
           optimizeDeps: {
             noDiscovery: false,
-            include: ["rwsdk/client", "rwsdk/realtime/client"],
+            include: [
+              "rwsdk/client",
+              "rwsdk/constants",
+              "rwsdk/debug",
+              "rwsdk/realtime/client",
+              "rwsdk/turnstile",
+            ],
             entries: [],
             esbuildOptions: {
               jsx: "automatic",
@@ -133,7 +142,14 @@ export const configPlugin = ({
             noDiscovery: false,
             entries: [workerEntryPathname],
             exclude: externalModules,
-            include: ["rwsdk/__ssr", "rwsdk/__ssr_bridge", "rwsdk/client"],
+            include: [
+              "rwsdk/__ssr",
+              "rwsdk/__ssr_bridge",
+              "rwsdk/client",
+              "rwsdk/constants",
+              "rwsdk/debug",
+              "rwsdk/realtime/client",
+            ],
             esbuildOptions: {
               jsx: "automatic",
               jsxImportSource: "react",

--- a/sdk/src/vite/knownDepsResolverPlugin.mts
+++ b/sdk/src/vite/knownDepsResolverPlugin.mts
@@ -1,5 +1,4 @@
 import { Plugin } from "vite";
-import fs from "fs/promises";
 import debug from "debug";
 import { ROOT_DIR } from "../lib/constants.mjs";
 import enhancedResolve from "enhanced-resolve";


### PR DESCRIPTION
#### Problem

The dev server would crash with the error `Internal server error: There is a new version of the pre-bundle...` during development.

This was a side effect of a fix in PR #775. To support 'use client' and 'use server' directives in third-party packages, our build process transforms code in `node_modules`, which requires injecting imports to `rwsdk` modules. In a monorepo, a transformed dependency can be hoisted to the root, while the `rwsdk` package itself is located in a nested project's `node_modules`.

To handle this inverted resolution path, we introduced custom resolution logic in a vite plugin in RedwoodSDK. While this fixed the resolution failure, it revealed a limitation in Vite's dependency scanner. Once Vite could find an initial `rwsdk` module, its static analysis could not always discover the framework's entire internal dependency graph.

When a module missed during the initial scan (e.g., `rwsdk/constants`) was requested at runtime, Vite would trigger a re-optimization to create a new dependency bundle. This caused the running server code, which still referenced the old bundle, to become inconsistent with Vite's module map, leading to the crash.

#### Solution

This is addressed by explicitly defining all public `rwsdk` entry points in each environment's `optimizeDeps.include` list (`worker`, `client`, and `ssr`). This provides Vite with a complete and accurate dependency map upfront, ensuring that all framework modules are pre-bundled from the start. This prevents any runtime discoveries that would lead to the re-optimization and subsequent server error.