### PR TITLE
tests: Add automatic client-side error checking to e2e tests

### DIFF
--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
+if [[ "$1" == "--" ]]; then
+  shift
+fi
+
 cd "$(dirname "$0")/.."
 
 (cd sdk && pnpm build)


### PR DESCRIPTION
This change introduces automatic client-side error checking to the end-to-end test harness. Previously, tests would only fail based on their explicit assertions, potentially missing uncaught JavaScript errors that could indicate a broken user experience.

The test harness now monitors for page errors (including console errors and uncaught exceptions) during test execution. If any such errors are detected, the test will fail, providing immediate feedback on runtime issues.

A new option, `checkForPageErrors`, has been added to the test runners (`testDev`, `testDeploy`, `testDevAndDeploy`). This allows specific tests to opt-out of this behavior if client-side errors are expected. By default, error checking is enabled.

### Testing