### PR TITLE
chore(deps): Widen peer dependency ranges for better compatibility

### DIFF
--- a/.notes/justin/worklogs/2025-10-15-widen-react-peer-dependency-range.md
+++ b/.notes/justin/worklogs/2025-10-15-widen-react-peer-dependency-range.md
@@ -1,0 +1,45 @@
+# Widen React peer dependency range
+
+## Problem
+
+The current `peerDependency` range for React in `sdk/package.json` is too restrictive. It uses a specific canary version (`>=19.3.0-canary-4fdf7cf2-20251003`), which causes problems with `npm`. `npm` seems to have difficulty resolving newer canary versions against this range, preventing users from using them.
+
+## Plan
+
+1.  Update the `peerDependencies` for `react`, `react-dom`, and `react-server-dom-webpack` in `sdk/package.json` to `>19.3.0-0 <20.0.0`. This range will include all pre-releases of React 19.3.0 and later, up to version 20.
+2.  Validate this change by creating a temporary playground project.
+3.  This playground will use a newer React canary version to confirm that `pnpm install` works as expected with the updated `peerDependency` range.
+4.  Run the tests for the playground to ensure everything is functional.
+5.  Remove the temporary playground once validation is complete.
+
+## Renovate Configuration
+
+The `renovate.json` configuration was updated to prevent automatic updates of `peerDependencies` in `sdk/package.json`.
+
+### Reasoning
+
+Bumping the minimum version of a `peerDependency` in the SDK is a breaking change for users on an older version of that dependency. When they update the SDK, they would be forced to upgrade their other tools, which is not the desired behavior for a minor SDK update.
+
+To maintain a wide and stable compatibility range, Renovate has been configured to ignore `peerDependencies` for both React and other tools (like `wrangler` and `vite`) within `sdk/package.json`.
+
+Renovate will continue to update the dependencies in the starter and playground projects to the latest versions, which is useful for continuous integration and testing against the latest releases.
+
+---
+
+## PR Description
+
+### Problem
+
+The SDK's `peerDependencies` for React were previously being updated to specific canary versions by our automated dependency management. When users updated the SDK, this would cause `unmet peer` warnings if their project used an older, but still compatible, version of React. This effectively forced them to upgrade React to resolve the warnings, which is not ideal for a library update.
+
+This happens because automated updates for `peerDependencies` in a library can inadvertently create breaking changes for its users by narrowing the compatibility range.
+
+### Solution
+
+This change introduces a more stable peer dependency management strategy for the SDK.
+
+1.  **Widen React Peer Dependency Range**: The `peerDependencies` for `react`, `react-dom`, and `react-server-dom-webpack` in `sdk/package.json` have been changed to `>19.3.0-0 <20.0.0`. This broad range accepts any React 19 canary or minor release, preventing issues with `npm`'s handling of pre-release versions and giving users more flexibility.
+
+2.  **Update Renovate Configuration**: The Renovate configuration (`renovate.json`) has been updated to disable automatic updates for *all* `peerDependencies` within `sdk/package.json`. This ensures that the compatibility range for tools like React, Vite, and Wrangler remains wide and is only changed manually and intentionally. Renovate will continue to update dependencies in the `starter` and `playground` projects for internal testing purposes.
+
+This approach aligns with common library best practices, prioritizing user project stability and maximizing compatibility.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -582,6 +582,49 @@ importers:
         specifier: 4.42.0
         version: 4.42.0(@cloudflare/workers-types@4.20251004.0)
 
+  playground/react-canary-test:
+    dependencies:
+      react:
+        specifier: 19.3.0-canary-5f2b5718-20251014
+        version: 19.3.0-canary-5f2b5718-20251014
+      react-dom:
+        specifier: 19.3.0-canary-5f2b5718-20251014
+        version: 19.3.0-canary-5f2b5718-20251014(react@19.3.0-canary-5f2b5718-20251014)
+      react-server-dom-webpack:
+        specifier: 19.3.0-canary-5f2b5718-20251014
+        version: 19.3.0-canary-5f2b5718-20251014(react-dom@19.3.0-canary-5f2b5718-20251014(react@19.3.0-canary-5f2b5718-20251014))(react@19.3.0-canary-5f2b5718-20251014)(webpack@5.97.1)
+      rwsdk:
+        specifier: workspace:*
+        version: link:../../sdk
+    devDependencies:
+      '@cloudflare/vite-plugin':
+        specifier: 1.13.10
+        version: 1.13.10(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(workerd@1.20251001.0)(wrangler@4.42.0(@cloudflare/workers-types@4.20251004.0))
+      '@cloudflare/workers-types':
+        specifier: 4.20251004.0
+        version: 4.20251004.0
+      '@types/node':
+        specifier: 22.18.8
+        version: 22.18.8
+      '@types/react':
+        specifier: 19.1.2
+        version: 19.1.2
+      '@types/react-dom':
+        specifier: 19.1.2
+        version: 19.1.2(@types/react@19.1.2)
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vite:
+        specifier: 7.1.9
+        version: 7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.1)(msw@2.11.3(@types/node@22.18.8)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+      wrangler:
+        specifier: 4.42.0
+        version: 4.42.0(@cloudflare/workers-types@4.20251004.0)
+
   playground/render-apis:
     dependencies:
       react:
@@ -1040,17 +1083,17 @@ importers:
         specifier: ~24.22.0
         version: 24.22.3
       react:
-        specifier: '>=19.3.0-canary-4fdf7cf2-20251003 <20.0.0'
-        version: 19.3.0-canary-4fdf7cf2-20251003
+        specifier: '>=19.3.0-0 <20.0.0'
+        version: 19.3.0-canary-5f2b5718-20251014
       react-dom:
-        specifier: '>=19.3.0-canary-4fdf7cf2-20251003 <20.0.0'
-        version: 19.3.0-canary-4fdf7cf2-20251003(react@19.3.0-canary-4fdf7cf2-20251003)
+        specifier: '>=19.3.0-0 <20.0.0'
+        version: 19.3.0-canary-5f2b5718-20251014(react@19.3.0-canary-5f2b5718-20251014)
       react-is:
         specifier: ~19.1.0
         version: 19.1.1
       react-server-dom-webpack:
-        specifier: '>=19.3.0-canary-4fdf7cf2-20251003 <20.0.0'
-        version: 19.3.0-canary-4fdf7cf2-20251003(react-dom@19.3.0-canary-4fdf7cf2-20251003(react@19.3.0-canary-4fdf7cf2-20251003))(react@19.3.0-canary-4fdf7cf2-20251003)(webpack@5.97.1)
+        specifier: '>=19.3.0-0 <20.0.0'
+        version: 19.3.0-canary-5f2b5718-20251014(react-dom@19.3.0-canary-5f2b5718-20251014(react@19.3.0-canary-5f2b5718-20251014))(react@19.3.0-canary-5f2b5718-20251014)(webpack@5.97.1)
       rsc-html-stream:
         specifier: ~0.0.6
         version: 0.0.6
@@ -7270,6 +7313,11 @@ packages:
     peerDependencies:
       react: 19.3.0-canary-4fdf7cf2-20251003
 
+  react-dom@19.3.0-canary-5f2b5718-20251014:
+    resolution: {integrity: sha512-+tuYDL8NPvRDGh5NYcMby8pD2fS5QwMpR4/2Xbk7UJ5OF42KvKfio9E5+0yXOCtAQMQTqcAbMRrUt5y6GRsfRQ==}
+    peerDependencies:
+      react: 19.3.0-canary-5f2b5718-20251014
+
   react-hook-form@7.64.0:
     resolution: {integrity: sha512-fnN+vvTiMLnRqKNTVhDysdrUay0kUUAymQnFIznmgDvapjveUWOOPqMNzPg+A+0yf9DuE2h6xzBjN1s+Qx8wcg==}
     engines: {node: '>=18.0.0'}
@@ -7335,6 +7383,14 @@ packages:
       react-dom: 19.3.0-canary-4fdf7cf2-20251003
       webpack: ^5.59.0
 
+  react-server-dom-webpack@19.3.0-canary-5f2b5718-20251014:
+    resolution: {integrity: sha512-55nyr8D9rJK+FC2cB0o0q1slyGHlYfzcODF1P7c8stRgn2j0/s9E6NHe3JroWibGlhcpyZ61CXqniutjcztf5Q==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: 19.3.0-canary-5f2b5718-20251014
+      react-dom: 19.3.0-canary-5f2b5718-20251014
+      webpack: ^5.59.0
+
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
@@ -7347,6 +7403,10 @@ packages:
 
   react@19.3.0-canary-4fdf7cf2-20251003:
     resolution: {integrity: sha512-nqpqaCNw7ngpux+uWJ8UsrKevE++WN/R5r8DWKNip+2Vn9w0afKd7pxz+1R2+X350cBHkVkITzsxk5pFOxdWQw==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.3.0-canary-5f2b5718-20251014:
+    resolution: {integrity: sha512-ZmlTKlGXFGDp+CpoX4zI+u4ZkTsumB31Wq7i+Nsv5VV0orV7GNPgHir1jlPPyW21VODO03nKpMbtcyHYcUSdDQ==}
     engines: {node: '>=0.10.0'}
 
   readable-stream@2.3.8:
@@ -7566,6 +7626,9 @@ packages:
 
   scheduler@0.28.0-canary-4fdf7cf2-20251003:
     resolution: {integrity: sha512-1QhlHp6pLVs2txWGGz5L+ZF3swBXVhGoJgMiFCq747VLg6JcJRoHQFpQ5ot5AwQI4aGtmJDDuB3HFsHh9M4/PQ==}
+
+  scheduler@0.28.0-canary-5f2b5718-20251014:
+    resolution: {integrity: sha512-UVh2j97GoUX4h1GvJnjZW6Ok51nhc4LyEDcHQf04OsBf2dEstrDUiJUq3ulbh2MzHPh/T6rt1ehgMwqR7jQD2w==}
 
   schema-utils@3.3.0:
     resolution: {integrity: sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==}
@@ -11704,7 +11767,7 @@ snapshots:
 
   '@types/fontkit@2.0.8':
     dependencies:
-      '@types/node': 24.7.2
+      '@types/node': 22.18.8
 
   '@types/fs-extra@11.0.4':
     dependencies:
@@ -11767,6 +11830,7 @@ snapshots:
   '@types/node@24.7.2':
     dependencies:
       undici-types: 7.14.0
+    optional: true
 
   '@types/parse-json@4.0.2': {}
 
@@ -16102,6 +16166,11 @@ snapshots:
       react: 19.3.0-canary-4fdf7cf2-20251003
       scheduler: 0.28.0-canary-4fdf7cf2-20251003
 
+  react-dom@19.3.0-canary-5f2b5718-20251014(react@19.3.0-canary-5f2b5718-20251014):
+    dependencies:
+      react: 19.3.0-canary-5f2b5718-20251014
+      scheduler: 0.28.0-canary-5f2b5718-20251014
+
   react-hook-form@7.64.0(react@19.3.0-canary-4fdf7cf2-20251003):
     dependencies:
       react: 19.3.0-canary-4fdf7cf2-20251003
@@ -16158,6 +16227,15 @@ snapshots:
       webpack: 5.97.1
       webpack-sources: 3.3.3
 
+  react-server-dom-webpack@19.3.0-canary-5f2b5718-20251014(react-dom@19.3.0-canary-5f2b5718-20251014(react@19.3.0-canary-5f2b5718-20251014))(react@19.3.0-canary-5f2b5718-20251014)(webpack@5.97.1):
+    dependencies:
+      acorn-loose: 8.4.0
+      neo-async: 2.6.2
+      react: 19.3.0-canary-5f2b5718-20251014
+      react-dom: 19.3.0-canary-5f2b5718-20251014(react@19.3.0-canary-5f2b5718-20251014)
+      webpack: 5.97.1
+      webpack-sources: 3.3.3
+
   react-style-singleton@2.2.3(@types/react@19.1.2)(react@19.3.0-canary-4fdf7cf2-20251003):
     dependencies:
       get-nonce: 1.0.1
@@ -16167,6 +16245,8 @@ snapshots:
       '@types/react': 19.1.2
 
   react@19.3.0-canary-4fdf7cf2-20251003: {}
+
+  react@19.3.0-canary-5f2b5718-20251014: {}
 
   readable-stream@2.3.8:
     dependencies:
@@ -16501,6 +16581,8 @@ snapshots:
   sax@1.4.1: {}
 
   scheduler@0.28.0-canary-4fdf7cf2-20251003: {}
+
+  scheduler@0.28.0-canary-5f2b5718-20251014: {}
 
   schema-utils@3.3.0:
     dependencies:
@@ -17155,7 +17237,8 @@ snapshots:
 
   undici-types@7.12.0: {}
 
-  undici-types@7.14.0: {}
+  undici-types@7.14.0:
+    optional: true
 
   undici@7.14.0: {}
 

--- a/renovate.json
+++ b/renovate.json
@@ -42,7 +42,6 @@
     {
       "description": "Update non-React SDK peer dependencies in starter, playground, and addon projects as soon as they are available.",
       "matchFileNames": [
-        "sdk/package.json",
         "starter/package.json",
         "playground/**/package.json",
         "addons/**/package.json"
@@ -58,9 +57,20 @@
       "prPriority": 1
     },
     {
-      "description": "Update React peer dependencies in starter, playground, and addon projects, tracking the 'next' tag.",
+      "description": "Ignore non-React peerDependencies in the SDK to maintain a wide compatibility range.",
+      "matchFileNames": ["sdk/package.json"],
+      "matchPackageNames": [
+        "@cloudflare/vite-plugin",
+        "@cloudflare/workers-types",
+        "wrangler",
+        "vite"
+      ],
+      "matchDepTypes": ["peerDependencies"],
+      "enabled": false
+    },
+    {
+      "description": "Update React dependencies in starter, playground, and addon projects, tracking the 'next' tag.",
       "matchFileNames": [
-        "sdk/package.json",
         "starter/package.json",
         "playground/**/package.json",
         "addons/**/package.json"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -173,9 +173,9 @@
   },
   "peerDependencies": {
     "@cloudflare/vite-plugin": "^1.13.10",
-    "react": ">=19.3.0-canary-4fdf7cf2-20251003 <20.0.0",
-    "react-dom": ">=19.3.0-canary-4fdf7cf2-20251003 <20.0.0",
-    "react-server-dom-webpack": ">=19.3.0-canary-4fdf7cf2-20251003 <20.0.0",
+    "react": ">=19.3.0-0 <20.0.0",
+    "react-dom": ">=19.3.0-0 <20.0.0",
+    "react-server-dom-webpack": ">=19.3.0-0 <20.0.0",
     "vite": "^6.2.6 || 7.x",
     "wrangler": "^4.35.0"
   },


### PR DESCRIPTION
### Problem

The SDK's `peerDependencies` for React were previously being updated to specific canary versions by our automated dependency management. When users updated the SDK, this would cause `unmet peer` warnings if their project used an older, but still compatible, version of React. This effectively forced them to upgrade React to resolve the warnings, which is not ideal for a library update.

This happens because automated updates for `peerDependencies` in a library can inadvertently create breaking changes for its users by narrowing the compatibility range.

### Solution

This change introduces a more stable peer dependency management strategy for the SDK.

1.  **Widen React Peer Dependency Range**: The `peerDependencies` for `react`, `react-dom`, and `react-server-dom-webpack` in `sdk/package.json` have been changed to `>19.3.0-0 <20.0.0`. This broad range accepts any React 19 canary or minor release, preventing issues with `npm`'s handling of pre-release versions and giving users more flexibility.

2.  **Update Renovate Configuration**: The Renovate configuration (`renovate.json`) has been updated to disable automatic updates for *all* `peerDependencies` within `sdk/package.json`. This ensures that the compatibility range for tools like React, Vite, and Wrangler remains wide and is only changed manually and intentionally. Renovate will continue to update dependencies in the `starter` and `playground` projects for internal testing purposes.