### PR TITLE
fix: Bring back DocumentProps and LayoutProps in rwsdk/router

### DIFF
--- a/sdk/src/runtime/entries/router.ts
+++ b/sdk/src/runtime/entries/router.ts
@@ -1,3 +1,4 @@
 import "./types/shared";
 export * from "../lib/links";
 export * from "../lib/router";
+export type { DocumentProps, LayoutProps } from "../lib/types";


### PR DESCRIPTION
We accidentally stopped exporting these types in https://github.com/redwoodjs/sdk/pull/815