### PR TITLE
feat: Respect Vite `base` for linking asset placeholders

### DIFF
--- a/sdk/src/vite/linkerPlugin.test.mts
+++ b/sdk/src/vite/linkerPlugin.test.mts
@@ -35,6 +35,26 @@ describe("linkWorkerBundle", () => {
     expect(result.code).toContain(`const logo = "/assets/logo.abc.svg";`);
   });
 
+  it("should replace asset placeholder with a base + hashed paths from the manifest if base is provided", () => {
+    const code = `
+      const stylesheet = "rwsdk_asset:/src/styles.css";
+      const logo = "rwsdk_asset:/src/logo.svg";
+    `;
+
+    const base = "/base/";
+
+    const result = linkWorkerBundle({
+      code,
+      manifestContent,
+      projectRootDir,
+      base,
+    });
+    expect(result.code).toContain(
+      `const stylesheet = "/base/assets/styles.123.css";`,
+    );
+    expect(result.code).toContain(`const logo = "/base/assets/logo.abc.svg";`);
+  });
+
   it("should deprefix remaining asset placeholders not in the manifest", () => {
     const code = `const publicImg = "rwsdk_asset:/images/photo.jpg";`;
     const result = linkWorkerBundle({


### PR DESCRIPTION
Ref #837 

This PR adds in support for the Vite `base` for the linker for asset placeholders. This is needed since in the current second workers linker build, we are statically replacing asset placeholders to final paths that don't respect this `base` setting

> Not a main contributor, so this might be the wrong spot. Let me know if this logic should be elsewhere

## Changes
* Store reference to config
* Pass in `base` to `linkWorkerBundle` to prepend if it exists
* Simple tests

## Before change
With Vite `base` = `https://example.com/`
```js
// Before linking
const stylesheet = "rwsdk_asset:/src/styles.css";
const logo = "rwsdk_asset:/src/logo.svg";

// After linking
// Note not including the base
const stylesheet = "/assets/styles.123.css"
const logo = "/assets/logo.abc.svg"
```

##  After change
With Vite `base` = `https://example.com`
```js
// Before linking
const stylesheet = "rwsdk_asset:/src/styles.css";
const logo = "rwsdk_asset:/src/logo.svg";

// After linking
// Note not including the base
const stylesheet = "https://example.com/assets/styles.123.css"
const logo = "https://example.com/assets/logo.abc.svg"
```