### PR TITLE
feat: Decouple rendering from async context 

### DIFF
--- a/sdk/src/runtime/entries/worker.ts
+++ b/sdk/src/runtime/entries/worker.ts
@@ -6,6 +6,7 @@ export * from "../register/worker";
 export * from "../render/renderToStream";
 export * from "../render/renderToString";
 export * from "../requestInfo/types";
+export * from "../requestInfo/utils";
 export * from "../requestInfo/worker";
 export * from "../script";
 export * from "../worker";

--- a/sdk/src/runtime/render/renderToStream.tsx
+++ b/sdk/src/runtime/render/renderToStream.tsx
@@ -1,7 +1,9 @@
 import { FC, ReactElement } from "react";
 import { injectRSCPayload } from "rsc-html-stream/server";
 import { DocumentProps } from "../lib/types.js";
-import { requestInfo } from "../requestInfo/worker";
+import { type PartialRequestInfo } from "../requestInfo/types";
+import { constructWithDefaultRequestInfo } from "../requestInfo/utils";
+import { getRequestInfo } from "../requestInfo/worker";
 import { renderDocumentHtmlStream } from "./renderDocumentHtmlStream";
 import { renderToRscStream } from "./renderToRscStream";
 
@@ -10,6 +12,7 @@ export interface RenderToStreamOptions {
   ssr?: boolean;
   injectRSCPayload?: boolean;
   onError?: (error: unknown) => void;
+  requestInfo?: PartialRequestInfo;
 }
 
 export const IdentityDocument: FC<DocumentProps> = ({ children }) => (
@@ -22,9 +25,29 @@ export const renderToStream = async (
     ssr: shouldSSR = true,
     Document = IdentityDocument,
     injectRSCPayload: shouldInjectRSCPayload = true,
+    requestInfo: givenRequestInfo,
     onError = () => {},
   }: RenderToStreamOptions = {},
 ): Promise<ReadableStream> => {
+  // Try to get the context requestInfo from the async store.
+  let contextRequestInfo;
+  try {
+    contextRequestInfo = getRequestInfo();
+  } catch (e) {
+    // No requestInfo detected from store.
+  }
+
+  // Construct requestInfo with defaults where overrides take precedence.
+  // If provided, `givenRequestInfo` will override values from context requestInfo if it exists
+  const requestInfo = constructWithDefaultRequestInfo({
+    ...contextRequestInfo,
+    ...givenRequestInfo,
+    rw: {
+      ...contextRequestInfo?.rw,
+      ...givenRequestInfo?.rw,
+    },
+  });
+
   let rscStream = renderToRscStream({
     input: {
       node: element,

--- a/sdk/src/runtime/render/renderToString.tsx
+++ b/sdk/src/runtime/render/renderToString.tsx
@@ -1,10 +1,12 @@
 import { FC, ReactElement } from "react";
 import { DocumentProps } from "../lib/types.js";
+import { type PartialRequestInfo } from "../requestInfo/types";
 import { renderToStream } from "./renderToStream";
 
 export interface RenderToStringOptions {
   Document?: FC<DocumentProps>;
   injectRSCPayload?: boolean;
+  requestInfo?: PartialRequestInfo;
 }
 
 export const renderToString = async (

--- a/sdk/src/runtime/requestInfo/types.ts
+++ b/sdk/src/runtime/requestInfo/types.ts
@@ -16,3 +16,10 @@ export interface RequestInfo<Params = any, AppContext = DefaultAppContext> {
   response: ResponseInit & { headers: Headers };
   isAction: boolean;
 }
+
+export type PartialRequestInfo<
+  Params = any,
+  AppContext = DefaultAppContext,
+> = Omit<Partial<RequestInfo<Params, AppContext>>, "rw"> & {
+  rw?: Partial<RwContext>;
+};

--- a/sdk/src/runtime/requestInfo/utils.tsx
+++ b/sdk/src/runtime/requestInfo/utils.tsx
@@ -1,0 +1,54 @@
+import { FC } from "react";
+import { type DocumentProps } from "../lib/types";
+import { generateNonce } from "../lib/utils";
+import { type PartialRequestInfo, type RequestInfo } from "./types";
+
+export const DefaultRequestInfoDocument: FC<DocumentProps> = ({ children }) => (
+  <>{children}</>
+);
+
+/**
+ * Constructs a generic requestInfo that can be used as defaults.
+ * Allows for passing in overrides to initialize with defaults.
+ */
+export const constructWithDefaultRequestInfo = (
+  overrides: PartialRequestInfo = {},
+): RequestInfo => {
+  const { rw: rwOverrides, ...otherRequestInfoOverrides } = overrides;
+
+  const defaultRequestInfo: RequestInfo = {
+    request: new Request("http://localhost/"),
+    params: {},
+    ctx: {},
+    cf: {
+      waitUntil: () => {},
+      passThroughOnException: () => {},
+      props: {},
+    },
+    response: {
+      status: 200,
+      headers: new Headers(),
+    },
+    isAction: false,
+    rw: {
+      Document: DefaultRequestInfoDocument,
+      nonce: generateNonce(),
+      rscPayload: true,
+      ssr: true,
+      databases: new Map(),
+      scriptsToBeLoaded: new Set(),
+      entryScripts: new Set(),
+      inlineScripts: new Set(),
+      pageRouteResolved: undefined,
+    },
+  };
+
+  return {
+    ...defaultRequestInfo,
+    ...otherRequestInfoOverrides,
+    rw: {
+      ...defaultRequestInfo.rw,
+      ...rwOverrides,
+    },
+  };
+};


### PR DESCRIPTION
Ref #840

The current rendering functions (`renderToStream`, `renderToString`) are tightly coupled to the **`requestInfo`** object provided by async local storage. This makes it difficult to use our rendering engine in environments outside `defineApp`.

This PR decouples the rendering logic from this implicit context.

## Changes

*   **`constructWithDefaultRequestInfo`**: Introduced and exposes a new utility function in entry from `sdk/src/runtime/requestInfo/utils.tsx`. This function creates a default `RequestInfo` object and merging with user-provided overrides.
*   **Refactored Rendering Functions**: `renderToStream` and `renderToString` were updated to accept an optional `requestInfo` parameter

### Before Change

* `renderToStream` implicitly depended on the `requestInfo` from the async local storage context
* To call these render methods, you had to import the internal `runWithRequestInfo` function and manually construct a complete `RequestInfo` object.

```typescript
  // Would error, since no requestInfo context.
  const html = await renderToString(<Welcome />);


  const requestInfo = {
    // Need to know internals and understand defaults
    // ...
  }

  await runWithRequestInfo(requestInfo, async () => {
    return renderToString(<Welcome />);
  });
```

## After Change

* Rendering functions now accept an optional `requestInfo` object
* Rendering functions automatically build up a default `requestInfo` and overrides it given the context `requestInfo` (backwards compatible) if it exists and user provided `requestInfo` overrides
* Exposes `constructWithDefaultRequestInfo` to be used to construct a `requestInfo` if needed (ie. we can use this in `defineApp` potentially)

```ts
  // Calling it without context won't error, and has defaults
  const html = await renderToString(<Welcome />);

  // Support simple overrides, ie. nonce
  const html = await renderToString(<Welcome />, {requestInfo: {nonce: 'hi-gavin-this-is-random'});

  // Can construct outside if needed in case we need a full requestInfo
  const requestInfo = {
    //...
  }
  // or
  const requestInfo = constructWithDefaultRequestInfo({...})

  // Supports passing requestInfo in it's entirety or utilize context in the past
  const html = await renderToString(<Welcome />, {requestInfo});

  await runWithRequestInfo(requestInfo, async () => {
    return renderToString(<Welcome />);
  });
  
```