### PR TITLE
feat: Set `__webpack_require__` + passing `requestInfo` context in `renderToStream`

### DIFF
--- a/sdk/src/runtime/render/renderToStream.tsx
+++ b/sdk/src/runtime/render/renderToStream.tsx
@@ -55,7 +55,7 @@ export const renderToStream = async (
 
   // context(gching, 2025-10-29): We wrap the following with context to the requestInfo
   // due to `ssrWebpackRequire` needing to reference the `requestInfo` in context.
-  // Therefore, we need to wrap + also pass in the requestInfo their independent
+  // Therefore, we need to wrap + also pass in the requestInfo in their independent
   // function calls
   return runWithRequestInfo(requestInfo, async () => {
     let rscStream = renderToRscStream({


### PR DESCRIPTION
ref #847 

* `renderToStream` being ran outside of `defineApp` would throw `__webpack_require__ is not defined`

## Changes
* Sets `globalThis.__webpack_require__` to `ssrWebpackRequire`
* Wraps implementation with `runWithRequireInfo` to set the requestInfo for calls

## Before Change
```tsx
// ServerComp.tsx
function ServerComp() {
  return <ClientComp/>
}

// ClientComp.tsx
'use client';
function ClientComp(){
  return <div/>
}


// Outside of defineApp()
const html = renderToString(<ServerComp/>, {...})
// Throws, '__webpack_require__' not defined
```
* Given that `__webpack_require__` isn't set, `renderToStream` will throw
## After Change

* `renderToStream` won't throw when used outside of `defineApp`