### PR TITLE
Fix: database-do.mdx Define Your Migrations example

### DIFF
--- a/docs/src/content/docs/core/database-do.mdx
+++ b/docs/src/content/docs/core/database-do.mdx
@@ -89,13 +89,15 @@ import { type Migrations } from "rwsdk/db";
 export const migrations = {
   "001_initial_schema": {
     async up(db) {
-      await db.schema
-        .createTable("todos")
-        .addColumn("id", "text", (col) => col.primaryKey())
-        .addColumn("text", "text", (col) => col.notNull())
-        .addColumn("completed", "integer", (col) => col.notNull().defaultTo(0))
-        .addColumn("createdAt", "text", (col) => col.notNull())
-        .execute();
+      return [
+        await db.schema
+          .createTable("todos")
+          .addColumn("id", "text", (col) => col.primaryKey())
+          .addColumn("text", "text", (col) => col.notNull())
+          .addColumn("completed", "integer", (col) => col.notNull().defaultTo(0))
+          .addColumn("createdAt", "text", (col) => col.notNull())
+          .execute()
+      ];
     },
 
     async down(db) {


### PR DESCRIPTION
Missing return statement on `up` method.

Mentioned in [discord](https://discord.com/channels/679514959968993311/1307974274145062912/1433215415978295306)