### PR TITLE
improve RouteHandler

### DIFF
--- a/sdk/src/runtime/lib/router.ts
+++ b/sdk/src/runtime/lib/router.ts
@@ -20,7 +20,7 @@ type RouteComponent<T extends RequestInfo = RequestInfo> = (
 type RouteHandler<T extends RequestInfo = RequestInfo> =
   | RouteFunction<T>
   | RouteComponent<T>
-  | [...RouteMiddleware<T>[], RouteFunction<T> | RouteComponent<T>];
+  | readonly [...RouteMiddleware<T>[], RouteFunction<T> | RouteComponent<T>];
 
 const METHOD_VERBS = ["delete", "get", "head", "patch", "post", "put"] as const;
 


### PR DESCRIPTION
I have this code

api.ts
```ts
export default [
  requireAuth,
  handler
] as const
```

index.ts
```ts
export default [route('/api', apiHandler)]
```

and it failed to typecheck with this error

```
Argument of type 'readonly [({ request }: RequestInfo<any, DefaultAppContext>) => Promise<Response | undefined>, ({ request, params }: RequestInfo<Params, DefaultAppContext>) => Promise<...>]' is not assignable to parameter of type 'RouteHandler<RequestInfo<Params, DefaultAppContext>> | MethodHandlers<RequestInfo<Params, DefaultAppContext>>'.
  The type 'readonly [({ request }: RequestInfo<any, DefaultAppContext>) => Promise<Response | undefined>, ({ request, params }: RequestInfo<Params, DefaultAppContext>) => Promise<...>]' is 'readonly' and cannot be assigned to the mutable type '[...RouteMiddleware<RequestInfo<Params, DefaultAppContext>>[], RouteFunction<RequestInfo<Params, DefaultAppContext>> | RouteComponent<...>]'.ts(2345)
```

this PR should fixes it

note `as const` is needed so the array is inferred as `[A, B]` instead of `(A|B)[]` which is not accepted by routes as it requires middlewares (A) before the route handler (B)

meanwhile, I am using workaround

```ts
const tuple = <T extends unknown[]>(...args: T) => args

export default tuple(requireAuth, handler)
```