### PR TITLE
Update wildcard route pattern in documentation

### DIFF
--- a/sdk/src/runtime/lib/router.ts
+++ b/sdk/src/runtime/lib/router.ts
@@ -396,7 +396,7 @@ export function defineRoutes<T extends RequestInfo = RequestInfo>(
  * Supports three types of path patterns:
  * - Static: /about, /contact
  * - Parameters: /users/:id, /posts/:postId/edit
- * - Wildcards: /files/*, /api/*/download
+ * - Wildcards: /files/*, /api/*\/download
  *
  * @example
  * // Static route


### PR DESCRIPTION
The example for wildcards should've probably used `*` character here.

Noticed this one when looking at the diff from #860