### PR TITLE
allow user to override kysely plugins in SqliteDurableObject

### DIFF
--- a/sdk/src/runtime/lib/db/SqliteDurableObject.ts
+++ b/sdk/src/runtime/lib/db/SqliteDurableObject.ts
@@ -4,6 +4,7 @@ import { DODialect } from "kysely-do";
 import {
   CompiledQuery,
   Kysely,
+  KyselyPlugin,
   ParseJSONResultsPlugin,
   QueryResult,
 } from "kysely";
@@ -24,6 +25,7 @@ export class SqliteDurableObject<T = any> extends DurableObject {
     env: any,
     migrations: Record<string, any>,
     migrationTableName = "__migrations",
+    plugins: KyselyPlugin[] = [new ParseJSONResultsPlugin()],
   ) {
     super(ctx, env);
     this.migrations = migrations;
@@ -31,7 +33,7 @@ export class SqliteDurableObject<T = any> extends DurableObject {
 
     this.kysely = new Kysely<T>({
       dialect: new DODialect({ ctx }),
-      plugins: [new ParseJSONResultsPlugin()],
+      plugins: plugins,
     });
   }
 


### PR DESCRIPTION
[Context from Discord](https://discord.com/channels/679514959968993311/1307974274145062912/1436932741777064036)

I was having trouble creating a Better Auth adapter for DurableObject SQLite. It turned out that was because `SqliteDurableObject` from rwsdk automatically uses `ParseJSONResultsPlugin`. This PR allows the list of Kysely plugins to be set in the `SqliteDurableObject` constructor. 

I figured this was more scalable then just having a boolean flag to control the JSON parsing, but I'm happy to just use the boolean flag if that is preferable. 

cc: @peterp @justinvdm 