### PR TITLE
Avoid rendering current docs hover color with background color

### DIFF
--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -11,8 +11,8 @@
   color: #0f172a !important;
 }
 
-.sidebar-content a:hover,
-.sidebar-content a:focus-visible {
+.sidebar-content a:not([aria-current="page"]):hover,
+.sidebar-content a:not([aria-current="page"]):focus-visible {
   color: #ff7a00 !important;
 }
 


### PR DESCRIPTION
Otherwise hovering or focusing on the current docs page will turn the text color to be the same color as the background color is — essentially making the text disappear.

Here's screenshots from Firefox:

## Baseline (no hover or focus visible)

<img width="314" height="182" alt="image" src="https://github.com/user-attachments/assets/752f2849-a484-4458-b5ad-1b166b925d66" />

## Before

### Hover

<img width="314" height="182" alt="image" src="https://github.com/user-attachments/assets/30c9e7fe-560c-4e42-88d9-7dbef0d9304a" />

### Focus visible

<img width="314" height="182" alt="image" src="https://github.com/user-attachments/assets/32bac7ce-5b45-4ad3-b55a-efffafb1ddab" />

## After

### Hover

<img width="314" height="182" alt="image" src="https://github.com/user-attachments/assets/1f84c091-a1c1-4c94-841a-f14157df5536" />


### Focus visible

<img width="314" height="182" alt="image" src="https://github.com/user-attachments/assets/84ffb404-805b-4174-b361-d8e9f3a53317" />

Essentially nothing changes. This matches the Starlight CSS https://starlight.astro.build/getting-started/ as they also don't change the text color or background color of the active page on hover or focus visible.