### PR TITLE
Fix useSyncedState exports

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -105,13 +105,17 @@
       "types": "./dist/runtime/lib/realtime/durableObject.d.ts",
       "default": "./dist/runtime/lib/realtime/durableObject.js"
     },
+    "./use-sync-state": {
+      "types": "./dist/use-synced-state/useSyncedState.d.ts",
+      "default": "./dist/use-synced-state/useSyncedState.js"
+    },
     "./use-synced-state/client": {
       "types": "./dist/use-synced-state/client.d.ts",
       "default": "./dist/use-synced-state/client.js"
     },
     "./use-synced-state/worker": {
-      "types": "./dist/use-synced-state/worker.d.ts",
-      "default": "./dist/use-synced-state/worker.js"
+      "types": "./dist/use-synced-state/worker.d.mts",
+      "default": "./dist/use-synced-state/worker.mjs"
     }
   },
   "keywords": [


### PR DESCRIPTION
This should allow use of the hook introduce in #871. 

I wasn't able to import the synced state hook or DO like shown in [the docs](https://docs.rwsdk.com/core/usesyncedstate/). After doing a little digging it seems like the exports were messed up in package.json. The hook wasn't being exported at all and the DO was referencing nonexistant files. I built locally and think this should be fine. 

cc: @peterp 