### PR TITLE
Fix type hover for routers triggering wrong Markdown formatting

### DIFF
--- a/sdk/src/runtime/lib/router.ts
+++ b/sdk/src/runtime/lib/router.ts
@@ -453,7 +453,7 @@ export function defineRoutes<T extends RequestInfo = RequestInfo>(
  * Supports three types of path patterns:
  * - Static: /about, /contact
  * - Parameters: /users/:id, /posts/:postId/edit
- * - Wildcards: /files/*, /api/*\/download
+ * - Wildcards: /files/\*, /api/\*\/download
  *
  * @example
  * // Static route


### PR DESCRIPTION
The type hover signature in e.g. VS Code treats the text as markdown and thus the `*, /api/*` part is considered to be `<em>, api/</em>` unless the `*` is escaped.

I've verified these changes by tweaking the contents of `node_modules/rwsdk/dist/runtime/lib/router.d.ts` to incorporate these same changes.

This is basically me following up with what https://github.com/redwoodjs/sdk/pull/866 changes actually look like in the editor.

## Before

<img width="911" height="278" alt="SCR-20251121-mwby" src="https://github.com/user-attachments/assets/ffa78bbc-4479-4570-a602-97071467c69f" />

## After

<img width="911" height="278" alt="SCR-20251121-mvzr" src="https://github.com/user-attachments/assets/66262f99-7ee1-403a-b67c-63a9de4c4bbc" />
