### PR TITLE
fix(router): export linkFor from client entry so client imports work

### DIFF
--- a/sdk/src/runtime/entries/routerClient.ts
+++ b/sdk/src/runtime/entries/routerClient.ts
@@ -1,1 +1,1 @@
-export { defineLinks } from "../lib/links.js";
+export { defineLinks, linkFor } from "../lib/links.js";


### PR DESCRIPTION
### fix(router): export linkFor from client entry so client imports work

### Summary
- Fixes missing `linkFor` export from the client router entry, which caused `import { linkFor } from "rwsdk/router"` to be undefined in the browser.

### What changed
- Export `linkFor` alongside `defineLinks` from the client entry.
  - Before: `export { defineLinks } from "../lib/links.js";`
  - After: `export { defineLinks, linkFor } from "../lib/links.js";`
- No changes to export map or build config.
- No manual `.d.ts` edits required (types are emitted and already include `linkFor` via `entries/router.d.ts`).

### Files
- `sdk/src/runtime/entries/routerClient.ts`

### Rationale
- `linkFor` existed in `runtime/lib/links` and in the server/worker path, but the client entry didn’t re-export it, breaking client-side imports.

### Impact
- No breaking changes. Server/worker behavior unchanged.
- Types already point to `entries/router.d.ts` which includes `linkFor`.

### Notes
- No test added