### PR TITLE
refactor: Make worker-run dev-only API more explicit

### DIFF
--- a/sdk/src/runtime/worker.tsx
+++ b/sdk/src/runtime/worker.tsx
@@ -62,6 +62,14 @@ export const defineApp = <
         import.meta.env.VITE_IS_DEV_SERVER &&
         new URL(request.url).pathname === "/__worker-run"
       ) {
+        const expectedToken = (import.meta.env as any)
+          .VITE_RWSDK_WORKER_RUN_TOKEN;
+        const requestToken = request.headers.get("x-rwsdk-worker-run-token");
+
+        if (!expectedToken || expectedToken !== requestToken) {
+          return new Response("Forbidden", { status: 403 });
+        }
+
         const url = new URL(request.url);
         const scriptPath = url.searchParams.get("script");
 

--- a/sdk/src/scripts/worker-run.mts
+++ b/sdk/src/scripts/worker-run.mts
@@ -1,3 +1,4 @@
+import crypto from "crypto";
 import dbg from "debug";
 import getPort from "get-port";
 import path from "path";
@@ -9,6 +10,9 @@ const debug = dbg("rwsdk:worker-run");
 
 const main = async () => {
   process.env.RWSDK_WORKER_RUN = "1";
+
+  const token = crypto.randomBytes(32).toString("hex");
+  process.env.VITE_RWSDK_WORKER_RUN_TOKEN = token;
 
   const relativeScriptPath = process.argv[2];
 
@@ -60,7 +64,11 @@ const main = async () => {
     )}`;
     debug("Fetching %s", url);
 
-    const response = await fetch(url);
+    const response = await fetch(url, {
+      headers: {
+        "x-rwsdk-worker-run-token": token,
+      },
+    });
     debug("Response from worker: %s", response);
 
     if (!response.ok) {


### PR DESCRIPTION
RedwoodSDK includes a `worker-run` command used for running seed scripts inside the development worker. It uses a small internal endpoint usable only in local development, and all execution remaining within the miniflare/workerd sandbox.

This PR reinforces that intent by ensuring the endpoint only responds to requests initiated by the local `worker-run` process