### PR TITLE
Bump transitive deps for MCP SDK + Hono JWT advisories

### DIFF
--- a/.notes/justin/worklogs/2026-01-14-security-deps.md
+++ b/.notes/justin/worklogs/2026-01-14-security-deps.md
@@ -1,0 +1,37 @@
+# 2026-01-14 security deps
+
+## Problem
+
+GitHub alerts report:
+
+- @modelcontextprotocol/sdk - ReDoS
+- hono - JWT algorithm confusion (jwt + jwk middleware)
+
+Goal: bump SDK direct deps in `sdk/`, and for transitive-only deps apply a monorepo-root override, then update the lockfile.
+
+## Plan
+
+- Find the affected versions currently in `pnpm-lock.yaml` and which workspace pulls them in.
+- Find the patched versions from advisories.
+- Apply bumps/overrides, regenerate `pnpm-lock.yaml`, and confirm with `pnpm why`.
+
+## Findings
+
+`pnpm-lock.yaml` shows:
+
+- `playground/shadcn` depends on `shadcn` (CLI)
+- `shadcn` depends on `@modelcontextprotocol/sdk@1.25.1` and `hono@4.11.3`
+
+Root `package.json` already had an override pinning `@modelcontextprotocol/sdk`, but it pinned to `1.25.1`, which still appears to be in the affected range for the ReDoS advisory.
+
+Attempted `pnpm -w install --ignore-scripts` after updating overrides, but pnpm rejected it due to a lockfile/config mismatch (frozen install). Next step is to run with `--no-frozen-lockfile` so the lock can update.
+
+After updating overrides and running install, `@modelcontextprotocol/sdk` moved to `1.25.2`, but `hono` stayed at `4.11.3` even though the registry shows `4.11.4` exists and is tagged `latest`. Next step is to try a more specific override selector (`hono@4.11.3` -> `4.11.4`) to force the lock to move.
+
+The override selector showed up in the lockfile config, but the resolved `hono` package stayed at `4.11.3`. It seems like this is coming from peer auto-install rather than a normal dependency edge, so I added `hono@4.11.4` as a devDependency of `playground/shadcn` to satisfy the peer at a known patched version.
+
+After re-installing, the lockfile now resolves:
+
+- `@modelcontextprotocol/sdk` at `1.25.2`
+- `hono` at `4.11.4`
+

--- a/package.json
+++ b/package.json
@@ -37,11 +37,12 @@
   },
   "pnpm": {
     "overrides": {
-      "@modelcontextprotocol/sdk@1.19.1": "1.25.1",
+      "@modelcontextprotocol/sdk": "1.25.2",
       "body-parser@2.2.0": "2.2.1",
       "esbuild@0.18.20": "0.27.2",
       "esbuild@0.19.12": "0.27.2",
       "glob@10.4.5": "13.0.0",
+      "hono@4.11.3": "4.11.4",
       "js-yaml@4.1.0": "4.1.1",
       "mdast-util-to-hast@13.2.0": "13.2.1",
       "qs@6.14.0": "6.14.1",

--- a/playground/shadcn/package.json
+++ b/playground/shadcn/package.json
@@ -74,6 +74,7 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.6",
+    "hono": "4.11.4",
     "shadcn": "^3.3.1",
     "tw-animate-css": "^1.3.8",
     "@cloudflare/vite-plugin": "1.20.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,11 +5,12 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@modelcontextprotocol/sdk@1.19.1': 1.25.1
+  '@modelcontextprotocol/sdk': 1.25.2
   body-parser@2.2.0: 2.2.1
   esbuild@0.18.20: 0.27.2
   esbuild@0.19.12: 0.27.2
   glob@10.4.5: 13.0.0
+  hono@4.11.3: 4.11.4
   js-yaml@4.1.0: 4.1.1
   mdast-util-to-hast@13.2.0: 13.2.1
   qs@6.14.0: 6.14.1
@@ -1325,9 +1326,12 @@ importers:
       '@types/react-dom':
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.7)
+      hono:
+        specifier: 4.11.4
+        version: 4.11.4
       shadcn:
         specifier: ^3.3.1
-        version: 3.4.0(@types/node@24.10.4)(babel-plugin-macros@3.1.0)(hono@4.11.3)(typescript@5.9.3)
+        version: 3.4.0(@types/node@24.10.4)(babel-plugin-macros@3.1.0)(hono@4.11.4)(typescript@5.9.3)
       tw-animate-css:
         specifier: ^1.3.8
         version: 1.4.0
@@ -3160,7 +3164,7 @@ packages:
     resolution: {integrity: sha512-vUcD0uauS7EU2caukW8z5lJKtoGMokxNbJtBiwHgpqxEXokaHCBkQUmCHhjFB1VUTWdqj25QoMkMKzgjq+uhrw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: 4.11.4
 
   '@hookform/resolvers@5.2.2':
     resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
@@ -3544,8 +3548,8 @@ packages:
     peerDependencies:
       rollup: '>=2'
 
-  '@modelcontextprotocol/sdk@1.25.1':
-    resolution: {integrity: sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ==}
+  '@modelcontextprotocol/sdk@1.25.2':
+    resolution: {integrity: sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -7871,8 +7875,8 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
-  hono@4.11.3:
-    resolution: {integrity: sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w==}
+  hono@4.11.4:
+    resolution: {integrity: sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==}
     engines: {node: '>=16.9.0'}
 
   html-entities@2.6.0:
@@ -12423,9 +12427,9 @@ snapshots:
 
   '@hexagon/base64@1.1.28': {}
 
-  '@hono/node-server@1.19.7(hono@4.11.3)':
+  '@hono/node-server@1.19.7(hono@4.11.4)':
     dependencies:
-      hono: 4.11.3
+      hono: 4.11.4
 
   '@hookform/resolvers@5.2.2(react-hook-form@7.64.0(react@19.3.0-canary-d6cae440-20260106))':
     dependencies:
@@ -12819,9 +12823,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.25.1(hono@4.11.3)(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.25.2(hono@4.11.4)(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.7(hono@4.11.3)
+      '@hono/node-server': 1.19.7(hono@4.11.4)
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)
       content-type: 1.0.5
@@ -17922,7 +17926,7 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  hono@4.11.3: {}
+  hono@4.11.4: {}
 
   html-entities@2.6.0: {}
 
@@ -20301,7 +20305,7 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  shadcn@3.4.0(@types/node@24.10.4)(babel-plugin-macros@3.1.0)(hono@4.11.3)(typescript@5.9.3):
+  shadcn@3.4.0(@types/node@24.10.4)(babel-plugin-macros@3.1.0)(hono@4.11.4)(typescript@5.9.3):
     dependencies:
       '@antfu/ni': 25.0.0
       '@babel/core': 7.28.4
@@ -20309,7 +20313,7 @@ snapshots:
       '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.4)
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.4)
       '@dotenvx/dotenvx': 1.51.0
-      '@modelcontextprotocol/sdk': 1.25.1(hono@4.11.3)(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.25.2(hono@4.11.4)(zod@3.25.76)
       browserslist: 4.26.3
       commander: 14.0.1
       cosmiconfig: 9.0.0(typescript@5.9.3)


### PR DESCRIPTION
#### Changes
- **Override MCP SDK**: force `@modelcontextprotocol/sdk` to `1.25.2` at the monorepo root.
- **Pin Hono**: add `hono@4.11.4` to `playground/shadcn` devDependencies to satisfy the `shadcn` peer at a patched version.
- **Lockfile**: updated `pnpm-lock.yaml` to resolve the patched versions.