### PR TITLE
Switch to client side navigation by default

### DIFF
--- a/docs/src/content/docs/guides/frontend/client-side-nav.mdx
+++ b/docs/src/content/docs/guides/frontend/client-side-nav.mdx
@@ -9,7 +9,7 @@ import { Aside, Badge } from "@astrojs/starlight/components";
 
 Client-side navigation is a technique that allows users to move between pages without a full-page reload. Instead of the browser reloading the entire HTML document, the JavaScript runtime intercepts navigation events (like link clicks), fetches the next page's content (usually as JavaScript modules or RSC payload), and updates the current view.
 
-This approach is commonly referred to as a Single Page App (SPA). In RedwoodSDK, you get SPA-like navigation with server-fetched React Server Components (RSC), so it's fast and dynamic, but still uses the server for rendering.
+This approach is commonly referred to as a Single Page App (SPA). In RedwoodSDK, you get SPA-like navigation with server-fetched React Server Components (RSC), so it's fast and dynamic, but still uses the server for rendering. RedwoodSDK uses **RSC RPC** to emulate client-side navigation.
 
 ```tsx title="src/client.tsx" ins="initClientNavigation()"
 import { initClient, initClientNavigation } from "rwsdk/client";

--- a/playground/hello-world/src/client.tsx
+++ b/playground/hello-world/src/client.tsx
@@ -1,3 +1,6 @@
-import { initClient } from "rwsdk/client";
+import { initClient, initClientNavigation } from "rwsdk/client";
 
-initClient();
+// RedwoodSDK uses RSC RPC to emulate client side navigation.
+// https://docs.rwsdk.com/guides/frontend/client-side-nav/
+const { handleResponse, onHydrated } = initClientNavigation();
+initClient({ handleResponse, onHydrated });

--- a/sdk/src/runtime/client/client.tsx
+++ b/sdk/src/runtime/client/client.tsx
@@ -47,7 +47,7 @@ export const fetchTransport: Transport = (transportContext) => {
 
     if (isAction) {
       url.searchParams.set("__rsc_action_id", id);
-      
+
       // If args are provided and method is GET, serialize them into the query string
       if (args != null && method === "GET") {
         url.searchParams.set("args", JSON.stringify(args));
@@ -188,16 +188,12 @@ export const fetchTransport: Transport = (transportContext) => {
  *
  * @example
  * // Basic usage
- * import { initClient } from "rwsdk/client";
- *
- * initClient();
- *
- * @example
- * // With client-side navigation
  * import { initClient, initClientNavigation } from "rwsdk/client";
  *
- * const { handleResponse } = initClientNavigation();
- * initClient({ handleResponse });
+ * // RedwoodSDK uses RSC RPC to emulate client side navigation.
+ * // https://docs.rwsdk.com/guides/frontend/client-side-nav/
+ * const { handleResponse, onHydrated } = initClientNavigation();
+ * initClient({ handleResponse, onHydrated });
  *
  * @example
  * // With error handling
@@ -240,7 +236,7 @@ export const initClient = async ({
   onActionResponse?: (actionResponse: ActionResponseData) => boolean | void;
 } = {}) => {
   const transportContext: TransportContext = {
-    setRscPayload: () => {},
+    setRscPayload: () => { },
     handleResponse,
     onHydrated,
     onActionResponse,

--- a/starter/src/client.tsx
+++ b/starter/src/client.tsx
@@ -1,3 +1,6 @@
-import { initClient } from "rwsdk/client";
+import { initClient, initClientNavigation } from "rwsdk/client";
 
-initClient();
+// RedwoodSDK uses RSC RPC to emulate client side navigation.
+// https://docs.rwsdk.com/guides/frontend/client-side-nav/
+const { handleResponse, onHydrated } = initClientNavigation();
+initClient({ handleResponse, onHydrated });


### PR DESCRIPTION
Client side navigation is now stable and feels more performant than page-reload. For new users we're making this the default experience.