### PR TITLE
Fix link to Vitest showcase

### DIFF
--- a/docs/src/content/docs/guides/vitest.mdx
+++ b/docs/src/content/docs/guides/vitest.mdx
@@ -50,7 +50,7 @@ export default defineWorkersConfig({
 
 Expose a `/_test` route in your `src/worker.tsx` to handle incoming test requests using `rwsdk-community`.
 
-You can find a complete working example in our [Vitest Playground](https://github.com/redwoodjs/redwood/tree/main/packages/sdk/playground/community/vitest-showcase).
+You can find a complete working example in our [Vitest Playground](https://github.com/redwoodjs/sdk/tree/main/community/playground/vitest-showcase).
 
 ```tsx
 // src/worker.tsx


### PR DESCRIPTION
I think this link is out of date. Following it leads to missing page?