### PR TITLE
fix(docs): use canonical "RedwoodSDK" branding consistently

### DIFF
--- a/docs/src/content/docs/core/routing.mdx
+++ b/docs/src/content/docs/core/routing.mdx
@@ -476,7 +476,7 @@ export function AboutPageLayout() {
 }
 ```
 
-After each client navigation, Redwood scans `link[rel="x-prefetch"][href]` elements
+After each client navigation, RedwoodSDK scans `link[rel="x-prefetch"][href]` elements
 and issues background `GET` requests for those route-like URLs with the `__rsc`
 query parameter set and an `x-prefetch: true` header. Successful responses are stored in a generation-based `Cache`
 using `cache.put`, following the semantics described in the MDN Cache

--- a/docs/src/content/docs/experimental/realtime.mdx
+++ b/docs/src/content/docs/experimental/realtime.mdx
@@ -19,7 +19,7 @@ RedwoodSDK provides built-in support for real-time applications through shared s
 ## Why would you use it?
 
 - **Realtime**: Updates are instant for all users on the page.
-- **Native**: It's built into Redwood SDK.
+- **Native**: It's built into RedwoodSDK.
 - **Cloudflare**: It leverages Cloudflare Durable Objects for coordination.
 
 ## Where would you use it?

--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -122,6 +122,6 @@ The first time you run the command it might fail and ask you to create a workers
 
 <LinkCard
   title="What's next?"
-  description="Learn everything you need to know to build webapps with Redwood!"
+  description="Learn everything you need to know to build webapps with RedwoodSDK!"
   href="/core/overview"
 />

--- a/docs/src/content/docs/guides/frontend/ark-ui.mdx
+++ b/docs/src/content/docs/guides/frontend/ark-ui.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ark UI
-description: A step-by-step guide for installing and configuring Ark UI headless components in Redwood SDK projects, with styling examples using Tailwind CSS.
+description: A step-by-step guide for installing and configuring Ark UI headless components in RedwoodSDK projects, with styling examples using Tailwind CSS.
 ---
 
 import { Aside } from "@astrojs/starlight/components";

--- a/docs/src/content/docs/guides/frontend/chakra-ui.mdx
+++ b/docs/src/content/docs/guides/frontend/chakra-ui.mdx
@@ -1,6 +1,6 @@
 ---
 title: Chakra UI
-description: A step-by-step guide for installing and configuring Chakra UI v3 in Redwood SDK projects, including customization options and theming techniques.
+description: A step-by-step guide for installing and configuring Chakra UI v3 in RedwoodSDK projects, including customization options and theming techniques.
 ---
 
 import { Aside } from "@astrojs/starlight/components";
@@ -10,7 +10,7 @@ import { PackageManagers } from "starlight-package-managers";
 
 ## Installing Chakra UI
 
-Since the Redwood SDK is based on React and Vite, we can work through the ["Using Vite" documentation](https://chakra-ui.com/docs/get-started/frameworks/vite) from Chakra UI.
+Since RedwoodSDK is based on React and Vite, we can work through the ["Using Vite" documentation](https://chakra-ui.com/docs/get-started/frameworks/vite) from Chakra UI.
 
 <Aside type="note" title="Version Requirements">
   The minimum Node version required is Node.20.x. Chakra UI v3 represents a major rewrite with significant changes from v2, including new dependencies, component structures, and theming approaches.
@@ -90,7 +90,7 @@ Since the Redwood SDK is based on React and Vite, we can work through the ["Usin
 
 6. Set Up the Provider
 
-   The Chakra UI provider needs to wrap your application. In Redwood SDK, you'll want to add this to your root component or layout.
+   The Chakra UI provider needs to wrap your application. In RedwoodSDK, you'll want to add this to your root component or layout.
 
    First, create a provider component if the snippet didn't generate one:
 

--- a/docs/src/content/docs/guides/frontend/documents.mdx
+++ b/docs/src/content/docs/guides/frontend/documents.mdx
@@ -1,12 +1,12 @@
 ---
 title: Documents
-description: How to create custom HTML documents for different routes in your Redwood SDK project
+description: How to create custom HTML documents for different routes in your RedwoodSDK project
 ---
 
 import { Aside, Steps } from '@astrojs/starlight/components';
 import { FileTree } from '@astrojs/starlight/components';
 
-In RedwoodSDK, Document components give you complete control over the HTML structure of each route. Unlike many frameworks that use a fixed HTML document structure, Redwood lets you define custom documents per route, controlling everything from the doctype to scripts and hydration strategy.
+In RedwoodSDK, Document components give you complete control over the HTML structure of each route. Unlike many frameworks that use a fixed HTML document structure, RedwoodSDK lets you define custom documents per route, controlling everything from the doctype to scripts and hydration strategy.
 
 ## A Basic Document
 

--- a/docs/src/content/docs/guides/frontend/metadata.mdx
+++ b/docs/src/content/docs/guides/frontend/metadata.mdx
@@ -1,6 +1,6 @@
 ---
 title: Meta Data
-description: How to add meta tags and SEO elements to your Redwood SDK project using React 19 conventions
+description: How to add meta tags and SEO elements to your RedwoodSDK project using React 19 conventions
 ---
 
 import { Aside, Steps } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/guides/frontend/shadcn.mdx
+++ b/docs/src/content/docs/guides/frontend/shadcn.mdx
@@ -104,7 +104,7 @@ export function MainLayout({ children }: { children: React.ReactNode }) {
 
 
 <Aside type="caution" title="React Server Components">
-By default, all pages and components within Redwood are server components. However, most of the ShadCN components require reactivity. Therefore, you may need to add `use client` to the top of your component file.
+By default, all pages and components within RedwoodSDK are server components. However, most of the ShadCN components require reactivity. Therefore, you may need to add `use client` to the top of your component file.
 </Aside>
 
 ## Further reading

--- a/docs/src/content/docs/guides/frontend/storybook.mdx
+++ b/docs/src/content/docs/guides/frontend/storybook.mdx
@@ -1,6 +1,6 @@
 ---
 title: Storybook
-description: A step-by-step guide for installing and configuring Storybook in Redwood SDK projects.
+description: A step-by-step guide for installing and configuring Storybook in RedwoodSDK projects.
 ---
 
 import { Aside, Steps } from '@astrojs/starlight/components';
@@ -435,7 +435,7 @@ database via Prisma.
 
 You did it! 🚀 We now have a fully functioning Storybook project, and have started to explore the benefits of developing UI in isolation.
 
-We're also well on our way to having a robust, well-documented, and well-tested UI component library for our Redwood SDK project.
+We're also well on our way to having a robust, well-documented, and well-tested UI component library for our RedwoodSDK project.
 
 Some great resources for next steps are:
 - [Testing UIs with Storybook](https://storybook.js.org/docs/writing-tests/)

--- a/docs/src/content/docs/guides/frontend/tailwind.mdx
+++ b/docs/src/content/docs/guides/frontend/tailwind.mdx
@@ -1,6 +1,6 @@
 ---
 title: Tailwind CSS
-description: A step-by-step guide for installing and configuring Tailwind CSS v4 in Redwood SDK projects, including customization options and font integration techniques.
+description: A step-by-step guide for installing and configuring Tailwind CSS v4 in RedwoodSDK projects, including customization options and font integration techniques.
 ---
 
 import { Aside } from "@astrojs/starlight/components";

--- a/docs/src/content/docs/guides/optimize/react-compiler.mdx
+++ b/docs/src/content/docs/guides/optimize/react-compiler.mdx
@@ -32,7 +32,7 @@ pnpm add -D babel-plugin-react-compiler@latest @vitejs/plugin-react@latest
 
 ## Configure Vite
 
-Enable the compiler by adding the React plugin with the compiler Babel plugin. Place it before the Cloudflare and Redwood plugins.
+Enable the compiler by adding the React plugin with the compiler Babel plugin. Place it before the Cloudflare and RedwoodSDK plugins.
 
 ```ts ins="import react from "@vitejs/plugin-react";'" ins="tailwindcss()," {4, 12} ins={8-12} title="vite.config.mts"
 


### PR DESCRIPTION
## Summary
- Replaces 10 instances of "Redwood SDK" (with space) with "RedwoodSDK"
- Replaces 5 instances of standalone "Redwood" (referring to the SDK) with "RedwoodSDK"
- Fixes across 11 doc files (frontmatter descriptions, body text)
- Per the style guide in `docs/README.md`: *Always refer to 'RedwoodSDK' as 'RedwoodSDK,' not 'Redwood,' 'RedwoodJS' or 'Redwood SDK.'*