### PR TITLE
bugfix: use explicit export block in SSR bridge to fix Rolldown/Vite+ builds

### DIFF
--- a/sdk/src/vite/ssrBridgeWrapPlugin.mts
+++ b/sdk/src/vite/ssrBridgeWrapPlugin.mts
@@ -71,8 +71,8 @@ export const ssrBridgeWrapPlugin = (): Plugin => {
           if (exportStart !== -1) break;
         }
 
-        const banner = `export const { renderHtmlStream, ssrLoadModule, ssrWebpackRequire, ssrGetModuleExport, createThenableFromReadableStream } = (function() {`;
-        const footer = `return { renderHtmlStream, ssrLoadModule, ssrWebpackRequire, ssrGetModuleExport, createThenableFromReadableStream };\n})();`;
+        const banner = `const { renderHtmlStream, ssrLoadModule, ssrWebpackRequire, ssrGetModuleExport, createThenableFromReadableStream } = (function() {`;
+        const footer = `return { renderHtmlStream, ssrLoadModule, ssrWebpackRequire, ssrGetModuleExport, createThenableFromReadableStream };\n})();\nexport { renderHtmlStream, ssrLoadModule, ssrWebpackRequire, ssrGetModuleExport, createThenableFromReadableStream };`;
 
         // Insert banner after the last import (or at the beginning if no imports)
         const insertIndex = lastImportEnd === -1 ? 0 : lastImportEnd;


### PR DESCRIPTION
## Summary

Fixes #1097

- The `ssrBridgeWrapPlugin` wraps the SSR bridge output in an IIFE during Rollup's `renderChunk` hook. After this, Vite's esbuild minification mangles the destructured binding names (`renderHtmlStream: e`, `ssrLoadModule: t`, etc.), so the actual ES module exports become single-letter variables
- Rolldown's (used by Vite+) strict static analysis reports `MISSING_EXPORT` errors. Rollup seems to be more lenient, and doesn't throw errors for this.
- Changed from `export const { renderHtmlStream, ... } = (function() { ... })()` to local destructuring + a separate `export { ... }` block, which minifiers always preserve

## Test plan

- [x] Verified `vp build` fails **without** the fix (`MISSING_EXPORT` x3)
- [x] Verified `vp build` passes **with** the fix
- [x] Verified regular `vite build` still passes (hello-world playground)