### PR TITLE
feat(docs): add search to sidebar

### DIFF
--- a/docs/src/app/components/SidebarSearch.tsx
+++ b/docs/src/app/components/SidebarSearch.tsx
@@ -1,7 +1,0 @@
-"use client";
-
-import { SearchCommand } from "@/app/components/SearchDialog";
-
-export function SidebarSearch() {
-  return <SearchCommand enableShortcut />;
-}

--- a/docs/src/app/layouts/DocsLayoutWrapper.tsx
+++ b/docs/src/app/layouts/DocsLayoutWrapper.tsx
@@ -4,7 +4,7 @@ import { RootProvider } from "fumadocs-ui/provider/base";
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import { MobileNav } from "@/app/components/Sidebar";
 import { ThemeToggle } from "@/app/components/ThemeToggle";
-import { SidebarSearch } from "@/app/components/SidebarSearch";
+import { SearchCommand } from "@/app/components/SearchDialog";
 import { pageTree } from "@/app/sidebar";
 
 const DiscordIcon = () => (
@@ -24,7 +24,7 @@ export function DocsLayoutWrapper({ children, requestInfo }: LayoutProps) {
         <DocsLayout
           tree={pageTree}
           sidebar={{
-            banner: <SidebarSearch />,
+            banner: <SearchCommand enableShortcut />,
           }}
           nav={{
             enabled: false,


### PR DESCRIPTION
## Summary
- Adds a `SidebarSearch` component that wraps `SearchCommand` with `enableShortcut` enabled
- Embeds it as a banner in the docs sidebar via fumadocs' `sidebar.banner` slot
- This also gives users Cmd+K / Ctrl+K search access from any docs page


<img width="1512" height="772" alt="image" src="https://github.com/user-attachments/assets/87085766-8d77-4552-94ac-d316db35d4c5" />
