### PR TITLE
fix: re-wire onNavigate callback dropped in navigate() extraction refactor

### DIFF
--- a/.docs/learnings/2026-04-09-onnavigate-callback-regression.md
+++ b/.docs/learnings/2026-04-09-onnavigate-callback-regression.md
@@ -1,0 +1,31 @@
+# onNavigate Callback Dropped During Function Extraction Refactor
+
+**Date:** 2026-04-09
+**Issue:** #1123
+**Commit that introduced regression:** `c543ef7` ("Programattic client side navigation. (#804)", 2025-10-02)
+
+## What Happened
+
+`initClientNavigation` originally wired `onNavigate` as the internal mechanism for both triggering the RSC fetch and providing a user callback hook (the default implementation called `__rsc_callServer`; user-provided implementations replaced the default). When `navigate()` was extracted as a standalone public function in c543ef7, the RSC fetch moved into `navigate()` directly — but neither the click handler nor the popstate handler was updated to pass `opts.onNavigate` through. The option continued to be accepted and typed, but had zero call sites in the function body.
+
+## Why TypeScript Didn't Catch It
+
+TypeScript does not warn about unused optional parameters. A function can accept `opts: { onNavigate?: () => void }` and simply never read `opts.onNavigate` — no compiler error, no lint warning. Structural typing means no tool surface that detects "this callback was declared but never invoked."
+
+## Why Tests Didn't Catch It
+
+The existing tests checked navigation behavior (redirects, error handling) but not callback invocation. Tests that validate the *side effect* of a callback (e.g., analytics were sent, a loading state was cleared) would have caught this immediately. Tests that only check what the navigation function returns miss callback regressions entirely.
+
+## The Fix Pattern
+
+When extracting a function that was previously responsible for calling a callback, explicitly carry the callback through via the new function's options interface. In this case:
+
+- Added `onNavigate?: () => Promise<void> | void` to `NavigateOptions`
+- Pass `opts.onNavigate` from the click handler into `navigate()` explicitly
+- Handle popstate inline since it doesn't go through `navigate()`
+
+## Lessons
+
+1. **After any function extraction refactor, grep for the original function's parameter names** in the caller — if any option names disappear from usage, they were likely dropped.
+2. **Callback options should always have a corresponding test** that asserts the callback was actually called, not just that the function completed.
+3. **Optional callback parameters with `async` return values** should be typed `() => Promise<void> | void`, not `() => void`, to correctly signal that async callbacks are supported.

--- a/.kindling/board/doing/2026-04-09-2232-fix-issue-1123-based-on-pr-1125-290d.md
+++ b/.kindling/board/doing/2026-04-09-2232-fix-issue-1123-based-on-pr-1125-290d.md
@@ -26,6 +26,8 @@ Fix issue 1123 based on PR 1125
 
 
 
+
+- [2026-04-09T20:50:42.149Z] [harness] (cycle progress)
 - [2026-04-09T20:49:00.689Z] [harness] (cycle progress)
 - [2026-04-09T20:48:59.601Z] [developer] Addressed review feedback:
 

--- a/.kindling/board/doing/2026-04-09-2232-fix-issue-1123-based-on-pr-1125-290d.md
+++ b/.kindling/board/doing/2026-04-09-2232-fix-issue-1123-based-on-pr-1125-290d.md
@@ -22,6 +22,8 @@ Fix issue 1123 based on PR 1125
 
 
 
+
+- [2026-04-09T20:43:35.035Z] [harness] (cycle progress)
 - [2026-04-09T20:39:50.625Z] [harness] (cycle progress)
 - [2026-04-09T20:34:47.825Z] [orchestrator] Starting fix task for issue #1123. Dispatching Analyst to investigate the issue and related PR #1125, reproduce the bug, and identify root causes. This is phase 1 of 5.
 - [2026-04-09T20:34:47.818Z] [harness] Plan ready: 5 phases, fix protocol. Task force: Analyst, Developer, Reviewer.

--- a/.kindling/board/doing/2026-04-09-2232-fix-issue-1123-based-on-pr-1125-290d.md
+++ b/.kindling/board/doing/2026-04-09-2232-fix-issue-1123-based-on-pr-1125-290d.md
@@ -23,6 +23,8 @@ Fix issue 1123 based on PR 1125
 
 
 
+
+- [2026-04-09T20:47:24.306Z] [harness] (cycle progress)
 - [2026-04-09T20:43:35.035Z] [harness] (cycle progress)
 - [2026-04-09T20:39:50.625Z] [harness] (cycle progress)
 - [2026-04-09T20:34:47.825Z] [orchestrator] Starting fix task for issue #1123. Dispatching Analyst to investigate the issue and related PR #1125, reproduce the bug, and identify root causes. This is phase 1 of 5.

--- a/.kindling/board/doing/2026-04-09-2232-fix-issue-1123-based-on-pr-1125-290d.md
+++ b/.kindling/board/doing/2026-04-09-2232-fix-issue-1123-based-on-pr-1125-290d.md
@@ -21,6 +21,8 @@ Fix issue 1123 based on PR 1125
 
 
 
+
+- [2026-04-09T20:39:50.625Z] [harness] (cycle progress)
 - [2026-04-09T20:34:47.825Z] [orchestrator] Starting fix task for issue #1123. Dispatching Analyst to investigate the issue and related PR #1125, reproduce the bug, and identify root causes. This is phase 1 of 5.
 - [2026-04-09T20:34:47.818Z] [harness] Plan ready: 5 phases, fix protocol. Task force: Analyst, Developer, Reviewer.
 - [2026-04-09T20:34:23.536Z] [harness] Planning approach -- reading your brief, selecting protocol, assembling task force...

--- a/.kindling/board/doing/2026-04-09-2232-fix-issue-1123-based-on-pr-1125-290d.md
+++ b/.kindling/board/doing/2026-04-09-2232-fix-issue-1123-based-on-pr-1125-290d.md
@@ -27,6 +27,8 @@ Fix issue 1123 based on PR 1125
 
 
 
+
+- [2026-04-09T20:52:55.660Z] [harness] (cycle progress)
 - [2026-04-09T20:50:42.149Z] [harness] (cycle progress)
 - [2026-04-09T20:49:00.689Z] [harness] (cycle progress)
 - [2026-04-09T20:48:59.601Z] [developer] Addressed review feedback:

--- a/.kindling/board/doing/2026-04-09-2232-fix-issue-1123-based-on-pr-1125-290d.md
+++ b/.kindling/board/doing/2026-04-09-2232-fix-issue-1123-based-on-pr-1125-290d.md
@@ -1,0 +1,27 @@
+---
+status: doing
+labels: []
+created: "2026-04-09T20:33:34.273Z"
+started: "2026-04-09T20:33:34.273Z"
+completed: null
+github-pr: null
+github-comments: true
+no-pr: false
+depends-on: []
+---
+
+## Brief
+
+Fix issue 1123 based on PR 1125
+
+## Checklist
+
+## Progress Log
+
+
+
+
+- [2026-04-09T20:34:47.825Z] [orchestrator] Starting fix task for issue #1123. Dispatching Analyst to investigate the issue and related PR #1125, reproduce the bug, and identify root causes. This is phase 1 of 5.
+- [2026-04-09T20:34:47.818Z] [harness] Plan ready: 5 phases, fix protocol. Task force: Analyst, Developer, Reviewer.
+- [2026-04-09T20:34:23.536Z] [harness] Planning approach -- reading your brief, selecting protocol, assembling task force...
+- [2026-04-09T20:33:35.465Z] [harness] Understanding your codebase so agents have architectural context...

--- a/.kindling/board/doing/2026-04-09-2232-fix-issue-1123-based-on-pr-1125-290d.md
+++ b/.kindling/board/doing/2026-04-09-2232-fix-issue-1123-based-on-pr-1125-290d.md
@@ -24,6 +24,20 @@ Fix issue 1123 based on PR 1125
 
 
 
+
+
+- [2026-04-09T20:49:00.689Z] [harness] (cycle progress)
+- [2026-04-09T20:48:59.601Z] [developer] Addressed review feedback:
+
+> ❌ REVISE REQUIRED: Missed Type Update in `entries/types/client.ts`
+
+Updated the duplicate `ClientNavigationOptions` interface in the public type declarations file to use `() => Promise<void> | void`, matching the corrected definition in `navigation.ts`. This was a missed instance of the same type fix — now both definitions are in sync.
+
+---
+
+> Minor: Unused Import in Test File
+
+Removed the unused `navigate` import from the test file's import statement. All three regression tests invoke the function indirectly through captured event handlers, so the direct import was unnecessary.
 - [2026-04-09T20:47:24.306Z] [harness] (cycle progress)
 - [2026-04-09T20:43:35.035Z] [harness] (cycle progress)
 - [2026-04-09T20:39:50.625Z] [harness] (cycle progress)

--- a/sdk/src/runtime/client/navigation.test.ts
+++ b/sdk/src/runtime/client/navigation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { validateClickEvent, initClientNavigation } from "./navigation";
+import { validateClickEvent, initClientNavigation, navigate } from "./navigation";
 
 // Mocking browser globals
 vi.stubGlobal("window", {
@@ -100,6 +100,131 @@ describe("clientNavigation", () => {
         }),
       } as unknown as HTMLElement),
     ).toBe(true);
+  });
+});
+
+// Regression tests for issue #1123: onNavigate callback was never called
+// Root cause: commit c543ef7 extracted navigate() but dropped onNavigate wiring
+describe("onNavigate callback (issue #1123 regression)", () => {
+  let capturedClickHandler: ((event: MouseEvent) => void) | null = null;
+  let capturedPopstateHandler: (() => void) | null = null;
+
+  beforeEach(() => {
+    capturedClickHandler = null;
+    capturedPopstateHandler = null;
+    vi.clearAllMocks();
+
+    // Capture registered event listeners so we can invoke them manually
+    vi.stubGlobal("document", {
+      addEventListener: vi.fn((event: string, handler: any) => {
+        if (event === "click") capturedClickHandler = handler;
+      }),
+    });
+    vi.stubGlobal("window", {
+      location: { href: "http://localhost/" },
+      addEventListener: vi.fn((event: string, handler: any) => {
+        if (event === "popstate") capturedPopstateHandler = handler;
+      }),
+      history: {
+        scrollRestoration: "auto",
+        pushState: vi.fn(),
+        replaceState: vi.fn(),
+        state: {},
+      },
+      scrollTo: vi.fn(),
+    });
+    vi.stubGlobal("history", {
+      scrollRestoration: "auto",
+      pushState: vi.fn(),
+      replaceState: vi.fn(),
+      state: {},
+    });
+    vi.stubGlobal("URL", class {
+      href: string;
+      constructor(path: string, base: string) {
+        this.href = base.replace(/\/$/, "") + path;
+      }
+    });
+    // Assign directly to globalThis without replacing it (avoids breaking Vitest internals)
+    (globalThis as any).__rsc_callServer = vi.fn().mockResolvedValue(undefined);
+  });
+
+  it("onNavigate is called during link click navigation", async () => {
+    const onNavigate = vi.fn();
+
+    initClientNavigation({ onNavigate });
+
+    expect(capturedClickHandler).not.toBeNull();
+
+    const fakeAnchor = {
+      getAttribute: (attr: string) => (attr === "href" ? "/about" : null),
+      hasAttribute: () => false,
+      target: "",
+      closest: (sel: string) => (sel === "a" ? fakeAnchor : null),
+    };
+    const fakeTarget = {
+      closest: (sel: string) => (sel === "a" ? fakeAnchor : null),
+    };
+    const fakeClickEvent = {
+      button: 0,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      altKey: false,
+      target: fakeTarget,
+      preventDefault: vi.fn(),
+    } as unknown as MouseEvent;
+
+    await capturedClickHandler!(fakeClickEvent);
+
+    expect(onNavigate).toHaveBeenCalled();
+  });
+
+  it("onNavigate is called during popstate navigation", async () => {
+    const onNavigate = vi.fn();
+
+    initClientNavigation({ onNavigate });
+
+    expect(capturedPopstateHandler).not.toBeNull();
+
+    await capturedPopstateHandler!();
+
+    expect(onNavigate).toHaveBeenCalled();
+  });
+
+  it("onNavigate fires after pushState but before RSC fetch", async () => {
+    const callOrder: string[] = [];
+    const onNavigate = vi.fn(() => { callOrder.push("onNavigate"); });
+    (globalThis as any).__rsc_callServer = vi.fn(() => {
+      callOrder.push("rscCallServer");
+      return Promise.resolve();
+    });
+
+    initClientNavigation({ onNavigate });
+
+    const fakeAnchor = {
+      getAttribute: (attr: string) => (attr === "href" ? "/about" : null),
+      hasAttribute: () => false,
+      target: "",
+      closest: (sel: string) => (sel === "a" ? fakeAnchor : null),
+    };
+    const fakeTarget = {
+      closest: (sel: string) => (sel === "a" ? fakeAnchor : null),
+    };
+    const fakeClickEvent = {
+      button: 0,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      altKey: false,
+      target: fakeTarget,
+      preventDefault: vi.fn(),
+    } as unknown as MouseEvent;
+
+    await capturedClickHandler!(fakeClickEvent);
+
+    expect(callOrder).toEqual(["onNavigate", "rscCallServer"]);
+    expect(window.history.pushState).toHaveBeenCalled();
   });
 });
 

--- a/sdk/src/runtime/client/navigation.test.ts
+++ b/sdk/src/runtime/client/navigation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { validateClickEvent, initClientNavigation, navigate } from "./navigation";
+import { validateClickEvent, initClientNavigation } from "./navigation";
 
 // Mocking browser globals
 vi.stubGlobal("window", {

--- a/sdk/src/runtime/client/navigation.ts
+++ b/sdk/src/runtime/client/navigation.ts
@@ -8,7 +8,7 @@ import {
 export type { NavigationCache, NavigationCacheStorage };
 
 export interface ClientNavigationOptions {
-  onNavigate?: () => void;
+  onNavigate?: () => Promise<void> | void;
   scrollToTop?: boolean;
   scrollBehavior?: "auto" | "smooth" | "instant";
   cacheStorage?: NavigationCacheStorage;
@@ -60,6 +60,7 @@ let IS_CLIENT_NAVIGATION = false;
 
 export interface NavigateOptions {
   history?: "push" | "replace";
+  onNavigate?: () => Promise<void> | void;
   info?: {
     scrollToTop?: boolean;
     scrollBehavior?: "auto" | "smooth" | "instant";
@@ -84,6 +85,8 @@ export async function navigate(
   } else {
     window.history.replaceState({ path: href }, "", url);
   }
+
+  await options.onNavigate?.();
 
   await globalThis.__rsc_callServer(null, null, "navigation");
 
@@ -170,12 +173,13 @@ export function initClientNavigation(opts: ClientNavigationOptions = {}) {
       const a = el.closest("a");
       const href = a?.getAttribute("href") as string;
 
-      await navigate(href);
+      await navigate(href, { history: "push", onNavigate: opts.onNavigate });
     },
     true,
   );
 
   window.addEventListener("popstate", async function handlePopState() {
+    await opts.onNavigate?.();
     await globalThis.__rsc_callServer(null, null, "navigation");
   });
 

--- a/sdk/src/runtime/entries/types/client.ts
+++ b/sdk/src/runtime/entries/types/client.ts
@@ -1,7 +1,7 @@
 import "./shared";
 
 export interface ClientNavigationOptions {
-  onNavigate?: () => void;
+  onNavigate?: () => Promise<void> | void;
   scrollToTop?: boolean;
   scrollBehavior?: "auto" | "smooth" | "instant";
 }


### PR DESCRIPTION
## Problem

A regression was introduced in the client-side navigation layer that caused the navigation callback to behave incorrectly under certain conditions, as reported in issue #1123. The root cause traced back to how the navigation handler was wired up in the client entry types, where a subtle mismatch in the expected signature or invocation timing broke the callback contract. This went undetected because the existing test suite lacked coverage for the specific navigation scenarios that triggered the failure. The related work in PR #1125 provided useful context for understanding how the navigation system was intended to function.

## Solution

The fix corrects the navigation callback handling in the client runtime by aligning its behavior with the originally intended contract, drawing on the architectural context established in PR #1125. A targeted adjustment was made to the navigation module and its associated type definition to ensure the callback is invoked correctly in all navigation scenarios. A dedicated test suite was added to cover the affected code paths, providing a regression safety net for this behavior going forward. Documentation of the root cause and fix has been captured in the session knowledge files to preserve the investigation findings.