### PR TITLE
fix: use native path module for Windows compatibility

### DIFF
--- a/sdk/src/lib/normalizeModulePath.mts
+++ b/sdk/src/lib/normalizeModulePath.mts
@@ -1,5 +1,12 @@
 import path from "node:path";
-import { normalizePath as normalizePathSeparators } from "vite";
+import { normalizePath } from "vite";
+
+const windowsDriveAbsoluteRE = /^[A-Za-z]:\//;
+
+// Vite's normalizePath only converts backslashes on Windows. This wrapper
+// ensures forward slashes regardless of platform, which matters when win32
+// path functions are injected for testing on Linux.
+const normalizePathSeparators = (p: string) => normalizePath(p.replace(/\\/g, "/"));
 
 /**
  * Find the number of common ancestor segments between two absolute paths.
@@ -49,9 +56,10 @@ export function normalizeModulePath(
   modulePath: string,
   projectRootDir: string,
   options: { absolute?: boolean; isViteStyle?: boolean } = {},
+  _path = path,
 ): string {
   modulePath = normalizePathSeparators(modulePath);
-  projectRootDir = normalizePathSeparators(path.resolve(projectRootDir));
+  projectRootDir = normalizePathSeparators(_path.resolve(projectRootDir));
 
   // Handle empty string or current directory
   if (modulePath === "" || modulePath === ".") {
@@ -60,7 +68,7 @@ export function normalizeModulePath(
 
   // For relative paths, resolve them first
   let resolved: string;
-  if (path.isAbsolute(modulePath)) {
+  if (_path.isAbsolute(modulePath)) {
     if (
       modulePath.startsWith(projectRootDir + "/") ||
       modulePath === projectRootDir
@@ -72,7 +80,7 @@ export function normalizeModulePath(
       if (options.isViteStyle !== undefined) {
         // User explicitly specified whether this should be treated as Vite-style
         if (options.isViteStyle) {
-          resolved = path.resolve(projectRootDir, modulePath.slice(1));
+          resolved = _path.resolve(projectRootDir, modulePath.slice(1));
         } else {
           resolved = modulePath;
         }
@@ -80,17 +88,18 @@ export function normalizeModulePath(
         // Fall back to heuristics using common ancestor depth
         const commonDepth = findCommonAncestorDepth(modulePath, projectRootDir);
 
-        if (commonDepth > 0) {
-          // Paths share meaningful common ancestor - treat as real absolute path
+        if (commonDepth > 0 || windowsDriveAbsoluteRE.test(modulePath)) {
+          // Paths share meaningful common ancestor, or this is a Windows absolute
+          // path on a different drive — treat as a real external absolute path
           resolved = modulePath;
         } else {
           // No meaningful common ancestor - assume Vite-style path within project
-          resolved = path.resolve(projectRootDir, modulePath.slice(1));
+          resolved = _path.resolve(projectRootDir, modulePath.slice(1));
         }
       }
     }
   } else {
-    resolved = path.resolve(projectRootDir, modulePath);
+    resolved = _path.resolve(projectRootDir, modulePath);
   }
 
   resolved = normalizePathSeparators(resolved);
@@ -101,11 +110,11 @@ export function normalizeModulePath(
   }
 
   // Check if the resolved path is within the project root
-  const relative = path.relative(projectRootDir, resolved);
+  const relative = _path.relative(projectRootDir, resolved);
 
   // If the path goes outside the project root (starts with ..) or is on a
   // different drive (Windows: path.relative returns an absolute path), return absolute
-  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+  if (relative.startsWith("..") || _path.isAbsolute(relative)) {
     return resolved;
   }
 

--- a/sdk/src/lib/normalizeModulePath.mts
+++ b/sdk/src/lib/normalizeModulePath.mts
@@ -1,4 +1,4 @@
-import { posix as path } from "node:path";
+import path from "node:path";
 import { normalizePath as normalizePathSeparators } from "vite";
 
 /**

--- a/sdk/src/lib/normalizeModulePath.mts
+++ b/sdk/src/lib/normalizeModulePath.mts
@@ -103,8 +103,9 @@ export function normalizeModulePath(
   // Check if the resolved path is within the project root
   const relative = path.relative(projectRootDir, resolved);
 
-  // If the path goes outside the project root (starts with ..), return absolute
-  if (relative.startsWith("..")) {
+  // If the path goes outside the project root (starts with ..) or is on a
+  // different drive (Windows: path.relative returns an absolute path), return absolute
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
     return resolved;
   }
 

--- a/sdk/src/lib/normalizeModulePath.test.mts
+++ b/sdk/src/lib/normalizeModulePath.test.mts
@@ -1,3 +1,4 @@
+import { win32 as windowsPath } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   findCommonAncestorDepth,
@@ -370,5 +371,44 @@ describe("normalizeModulePath", () => {
         ).toBe("/Users/name/code/my-app/opt/tools/logger.ts");
       });
     });
+  });
+});
+
+describe("Windows paths (path.win32)", () => {
+  const root = "C:/Projects/app";
+
+  it("Windows absolute path inside project", () => {
+    expect(
+      normalizeModulePath("C:/Projects/app/src/page.tsx", root, {}, windowsPath),
+    ).toBe("/src/page.tsx");
+  });
+
+  it("Windows absolute path outside project (same drive)", () => {
+    expect(
+      normalizeModulePath("C:/other/utils.ts", root, {}, windowsPath),
+    ).toBe("C:/other/utils.ts");
+  });
+
+  it("Cross-drive path is treated as external", () => {
+    expect(
+      normalizeModulePath("D:/other/utils.ts", root, {}, windowsPath),
+    ).toBe("D:/other/utils.ts");
+  });
+
+  it("Relative path resolves correctly", () => {
+    expect(
+      normalizeModulePath("src/page.tsx", root, {}, windowsPath),
+    ).toBe("/src/page.tsx");
+  });
+
+  it("Windows absolute path inside project with absolute option", () => {
+    expect(
+      normalizeModulePath(
+        "C:/Projects/app/src/page.tsx",
+        root,
+        { absolute: true },
+        windowsPath,
+      ),
+    ).toBe("C:/Projects/app/src/page.tsx");
   });
 });

--- a/sdk/src/vite/redwoodPlugin.mts
+++ b/sdk/src/vite/redwoodPlugin.mts
@@ -1,6 +1,6 @@
 import { cloudflare } from "@cloudflare/vite-plugin";
-import { resolve } from "node:path/posix";
-import { InlineConfig, Plugin } from "vite";
+import { resolve } from "node:path";
+import { InlineConfig, normalizePath, Plugin } from "vite";
 import { unstable_readConfig } from "wrangler";
 
 import { devServerConstantPlugin } from "./devServerConstant.mjs";
@@ -62,12 +62,12 @@ export const determineWorkerEntryPathname = async ({
   readConfig?: typeof unstable_readConfig;
 }) => {
   if (options.entry?.worker) {
-    return resolve(projectRootDir, options.entry.worker);
+    return normalizePath(resolve(projectRootDir, options.entry.worker));
   }
 
   const workerConfig = readConfig({ config: workerConfigPath });
 
-  return resolve(projectRootDir, workerConfig.main ?? "src/worker.tsx");
+  return normalizePath(resolve(projectRootDir, workerConfig.main ?? "src/worker.tsx"));
 };
 
 const clientFiles = new Set<string>();


### PR DESCRIPTION
Fixes #1080

## Problem

`npm run dev` fails on Windows with a directive scan error. The esbuild output shows the path being multiplied on every resolution step:
```
error: The entry point "C:\Users\...\project\C:\Users\...\project\C:\Users\...\project\src\worker.tsx"
```

## Root Cause

Two files import from `node:path/posix` where they shouldn't. On Windows, after Vite normalises backslashes to forward slashes, absolute paths look like `C:/Projects/app/...`. `posix.isAbsolute` only recognises paths starting with `/`, so it treats Windows drive-letter paths as relative and `posix.resolve` prepends the CWD each time the path is resolved — tripling it by the time it reaches esbuild.

- `redwoodPlugin.mts` — `posix.resolve(projectRootDir, "src/worker.tsx")` doesn't recognise `C:/...` as absolute, doubles the path
- `normalizeModulePath.mts` — same issue with `posix.isAbsolute`, re-resolves the already-doubled path against the root, tripling it

## Fix

Switch both files to native `node:path`. On Linux/Mac, native `path` is identical to `path.posix` so there's no behaviour change for existing users. Also wrapped `determineWorkerEntryPathname`'s return value with Vite's `normalizePath` to guarantee forward slashes out regardless of platform.

`normalizeModulePath` also gets a small hardening pass:
- Added a `normalizePathSeparators` helper that unconditionally converts backslashes (Vite's `normalizePath` only does this on Windows)
- Added a `windowsDriveAbsoluteRE` guard so cross-drive paths (e.g. `D:/other` with root on `C:`) are treated as external rather than being mistaken for Vite-style paths
- Added `_path.isAbsolute(relative)` check to the external-path return, covering the case where `path.relative` returns an absolute path on cross-drive Windows comparisons

## Verification

- Tested manually on Windows — `npm run dev` starts successfully
- Existing unit tests pass on Linux CI
- Windows path behaviour is covered by a new test suite in `normalizeModulePath.test.mts` using `path.win32` injection, so it runs correctly on Linux CI too