### PR TITLE
fix: layout() no longer errors when child routes have extra params

### DIFF
--- a/sdk/src/runtime/lib/router.test.ts
+++ b/sdk/src/runtime/lib/router.test.ts
@@ -5,6 +5,7 @@ import type { RequestInfo } from "../requestInfo/types";
 import {
   defineRoutes,
   except,
+  index,
   layout,
   matchPath,
   prefix,
@@ -1025,6 +1026,68 @@ describe("defineRoutes - Request Handling Behavior", () => {
       });
 
       expect(await response.text()).toBe("Rendered with layouts");
+    });
+
+    it("should accept child routes whose params are a superset of the layout's params", async () => {
+      let capturedLayoutProps: any = null;
+      let capturedRouteParams: any = null;
+
+      // Layout only needs { orgId }
+      const AppLayout = (props: {
+        children?: React.ReactNode;
+        requestInfo?: RequestInfo<{ orgId: string }>;
+      }) => {
+        capturedLayoutProps = props;
+        return React.createElement("div", { className: "app-layout" }, props.children);
+      };
+
+      const OrgIndex = () => {
+        return React.createElement("div", {}, "Org Index");
+      };
+
+      // Schedule needs { orgId, date } — a superset
+      const Schedule = (requestInfo: RequestInfo<{ orgId: string; date: string }>) => {
+        capturedRouteParams = requestInfo.params;
+        return React.createElement(
+          "div",
+          {},
+          `${requestInfo.params.orgId} / ${requestInfo.params.date}`,
+        );
+      };
+
+      const routes = prefix("/:orgId", [
+        layout(AppLayout, [
+          index(OrgIndex),
+          prefix("/schedule", [
+            route("/:date", Schedule),
+          ]),
+        ]),
+      ]);
+
+      const router = defineRoutes([...routes]);
+
+      const deps = createMockDependencies();
+      deps.mockRequestInfo.request = new Request(
+        "http://localhost:3000/acme/schedule/2025-01-15/",
+      );
+
+      const request = new Request(
+        "http://localhost:3000/acme/schedule/2025-01-15/",
+      );
+      const response = await router.handle({
+        request,
+        renderPage: deps.mockRenderPage,
+        getRequestInfo: deps.getRequestInfo,
+        onError: deps.onError,
+        runWithRequestInfoOverrides: deps.mockRunWithRequestInfoOverrides,
+        rscActionHandler: deps.mockRscActionHandler,
+      });
+
+      expect(response.status).toBe(200);
+      expect(deps.mockRequestInfo.params).toEqual({
+        orgId: "acme",
+        date: "2025-01-15",
+      });
     });
   });
 

--- a/sdk/src/runtime/lib/router.ts
+++ b/sdk/src/runtime/lib/router.ts
@@ -981,9 +981,9 @@ export const wrapHandlerToThrowResponses = <
  * ])
  */
 export function layout<
-  T extends RequestInfo = RequestInfo,
-  Routes extends readonly Route<T>[] = readonly Route<T>[],
->(LayoutComponent: React.FC<LayoutProps<T>>, routes: Routes): Routes {
+  TLayout extends RequestInfo = RequestInfo,
+  Routes extends readonly Route<any>[] = readonly Route<any>[],
+>(LayoutComponent: React.FC<LayoutProps<TLayout>>, routes: Routes): Routes {
   return routes.map((route) => {
     if (typeof route === "function") {
       // Pass through middleware as-is
@@ -1000,13 +1000,13 @@ export function layout<
     }
     if (Array.isArray(route)) {
       // Recursively process nested route arrays
-      return layout(LayoutComponent, route) as Route<T>;
+      return layout(LayoutComponent, route);
     }
-    const routeDef = route as RouteDefinition<string, T>;
+    const routeDef = route as RouteDefinition<string, any>;
     return {
       ...routeDef,
       layouts: [LayoutComponent, ...(routeDef.layouts || [])],
-    } as Route<T>;
+    };
   }) as unknown as Routes;
 }
 


### PR DESCRIPTION
Closes #1129

## Problem

When you wrap routes with `layout()`, and one of those routes has **more** URL params than the layout needs, TypeScript gets angry.

For example: your layout only cares about `orgId`, but a child route also has a `date` param. That should be totally fine — the layout doesn't need `date`, it just ignores it. But TypeScript says no.

```tsx
prefix("/:orgId", [
  layout(AppLayout, [          // AppLayout only needs { orgId }
    index(OrgIndex),
    prefix("/schedule", [
      route("/:date", Schedule), // TS2322 💥 — Schedule needs { orgId, date }
    ]),
  ]),
])
```

**Why this happens:** `layout()` looks at the layout component to figure out the type `T`, then forces every child route to match that exact same `T`. But a route with `{ orgId, date }` doesn't match `{ orgId }` exactly — it has extra stuff. TypeScript's type variance rules on the internal `layouts` field make this fail.

## Solution

Stop forcing the layout's type and the routes' types to be the same thing. The layout has its own type (`TLayout`), and the routes keep whatever types they already had. They don't need to match.

This is safe because at runtime, the layout always receives the matched route's full params — which is a superset of what it needs. A layout that only reads `orgId` will work fine even when the route also has `date`.

## Test plan

- [x] Added test: layout with `{ orgId }` wrapping a child route with `{ orgId, date }` — compiles and params are extracted correctly at runtime
- [x] All 54 router tests pass
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)