### PR TITLE
fix(deps): bump @cloudflare/vite-plugin to 1.31.0 and wrangler to 4.80.0

### DIFF
--- a/community/package.json
+++ b/community/package.json
@@ -35,7 +35,7 @@
     "react": ">=19.2.0-0 <19.3.0 || >=19.3.0-0 <20.0.0",
     "react-dom": ">=19.2.0-0 <19.3.0 || >=19.3.0-0 <20.0.0",
     "rwsdk": "workspace:*",
-    "wrangler": "^4.77.0"
+    "wrangler": "^4.80.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "~4.20260331.1",

--- a/community/playground/ark-ui-showcase/package.json
+++ b/community/playground/ark-ui-showcase/package.json
@@ -30,7 +30,7 @@
     "rwsdk": "workspace:*"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "25.3.5",
     "@types/react": "19.2.14",
@@ -38,7 +38,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
   }

--- a/community/playground/chakra-ui-showcase/package.json
+++ b/community/playground/chakra-ui-showcase/package.json
@@ -30,7 +30,7 @@
     "rwsdk": "workspace:*"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "25.3.5",
     "@types/react": "19.2.14",
@@ -38,7 +38,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
   }

--- a/community/playground/dark-mode/package.json
+++ b/community/playground/dark-mode/package.json
@@ -29,7 +29,7 @@
     "tailwindcss": "^4.2.1"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@tailwindcss/vite": "^4.2.1",
     "@types/node": "25.3.5",
@@ -38,7 +38,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
   }

--- a/community/playground/hello-world/package.json
+++ b/community/playground/hello-world/package.json
@@ -28,14 +28,14 @@
     "rwsdk": "workspace:*"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "25.3.5",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "typescript": "6.0.2",
     "vite": "~7.3.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
   }

--- a/community/playground/vitest-showcase/package.json
+++ b/community/playground/vitest-showcase/package.json
@@ -30,14 +30,14 @@
     "react-server-dom-webpack": "19.2.5"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "25.3.5",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "typescript": "6.0.2",
     "vite": "~7.3.2",
-    "wrangler": "4.79.0",
+    "wrangler": "4.80.0",
     "@cloudflare/vitest-pool-workers": "^0.12.20",
     "vitest": "4.1.2"
   }

--- a/docs/package.json
+++ b/docs/package.json
@@ -40,7 +40,7 @@
     "zod": "^4.1.11"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@tailwindcss/typography": "^0.5.18",
     "@tailwindcss/vite": "^4.1.6",
@@ -57,7 +57,7 @@
     "typescript": "6.0.2",
     "unist-util-visit": "^5.1.0",
     "vite": "~7.3.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {}
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "tsx": "^4.21.0",
     "typescript": "^6.0.2",
     "vitest": "^4.1.2",
-    "wrangler": "^4.77.0"
+    "wrangler": "^4.80.0"
   },
   "pnpm": {
     "overrides": {
@@ -79,9 +79,6 @@
       "webpack@5.97.1": "5.105.4",
       "yaml@1.10.2": "1.10.3",
       "yaml@2.8.2": "2.8.3",
-      "wrangler@4.77.0": "4.80.0",
-      "wrangler@4.79.0": "4.80.0",
-      "@cloudflare/vite-plugin@1.30.1": "1.31.0",
       "@cloudflare/workers-types@4.20260331.1": "4.20260405.1"
     },
     "onlyBuiltDependencies": [

--- a/playground/base-path/package.json
+++ b/playground/base-path/package.json
@@ -28,7 +28,7 @@
     "react-server-dom-webpack": "19.2.5"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "24.12.0",
     "@types/react": "19.2.14",
@@ -36,7 +36,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/playground/baseui/package.json
+++ b/playground/baseui/package.json
@@ -29,14 +29,14 @@
     "@base-ui-components/react": "^1.0.0-rc.0"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "24.12.0",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "typescript": "6.0.2",
     "vite": "~7.3.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "overrides": {
     "react": "19.2.5",

--- a/playground/chakra-ui/package.json
+++ b/playground/chakra-ui/package.json
@@ -31,7 +31,7 @@
     "rwsdk": "workspace:*"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "24.12.0",
     "@types/react": "19.2.14",
@@ -39,7 +39,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "overrides": {
     "react": "19.2.5",

--- a/playground/client-navigation/package.json
+++ b/playground/client-navigation/package.json
@@ -28,7 +28,7 @@
     "react-server-dom-webpack": "19.2.5"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "24.12.0",
     "@types/react": "19.2.14",
@@ -36,7 +36,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
   }

--- a/playground/community/todo-serverquery-and-actions/package.json
+++ b/playground/community/todo-serverquery-and-actions/package.json
@@ -30,14 +30,14 @@
     "tailwindcss": "^4.2.1"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "~24.12.0",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "typescript": "5.9.3",
     "vite": "~7.3.2",
-    "wrangler": "4.77.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/playground/content-collections/package.json
+++ b/playground/content-collections/package.json
@@ -35,7 +35,7 @@
     "@content-collections/core": "0.14.2"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "24.12.0",
     "@types/react": "19.2.14",
@@ -43,7 +43,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
   }

--- a/playground/css/package.json
+++ b/playground/css/package.json
@@ -28,7 +28,7 @@
     "rwsdk": "workspace:*"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "~24.12.0",
     "@types/react": "19.2.14",
@@ -36,7 +36,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
   }

--- a/playground/database-do/package.json
+++ b/playground/database-do/package.json
@@ -30,7 +30,7 @@
     "react-server-dom-webpack": "19.2.5"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "24.12.0",
     "@types/react": "19.2.14",
@@ -38,7 +38,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
   }

--- a/playground/directives/package.json
+++ b/playground/directives/package.json
@@ -28,7 +28,7 @@
     "react-server-dom-webpack": "19.2.5"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "24.12.0",
     "@types/react": "19.2.14",
@@ -36,7 +36,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
   }

--- a/playground/drizzle-do/package.json
+++ b/playground/drizzle-do/package.json
@@ -30,7 +30,7 @@
     "rwsdk": "workspace:*"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "24.12.0",
     "@types/react": "19.2.14",
@@ -39,7 +39,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
   }

--- a/playground/entrypoint-from-node_modules/package.json
+++ b/playground/entrypoint-from-node_modules/package.json
@@ -29,7 +29,7 @@
     "react-server-dom-webpack": "19.2.5"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "24.12.0",
     "@types/react": "19.2.14",
@@ -37,7 +37,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
   }

--- a/playground/fontsource-css-imports/package.json
+++ b/playground/fontsource-css-imports/package.json
@@ -29,7 +29,7 @@
     "react-server-dom-webpack": "19.2.5"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "24.12.0",
     "@types/react": "19.2.14",
@@ -37,7 +37,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
   }

--- a/playground/hello-world/package.json
+++ b/playground/hello-world/package.json
@@ -28,7 +28,7 @@
     "rwsdk": "workspace:*"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "~24.12.0",
     "@types/react": "19.2.14",
@@ -36,7 +36,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
   }

--- a/playground/import-from-use-client/package.json
+++ b/playground/import-from-use-client/package.json
@@ -29,7 +29,7 @@
     "ui-lib": "file:./packages/ui-lib"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "24.12.0",
     "@types/react": "19.2.14",
@@ -37,7 +37,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
   }

--- a/playground/kitchen-sink/package.json
+++ b/playground/kitchen-sink/package.json
@@ -30,7 +30,7 @@
     "react-server-dom-webpack": "19.2.5"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "24.12.0",
     "@types/react": "19.2.14",
@@ -38,7 +38,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
   }

--- a/playground/mantine/package.json
+++ b/playground/mantine/package.json
@@ -30,7 +30,7 @@
     "@mantine/hooks": "^9.0.0"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "24.12.0",
     "@types/react": "19.2.14",
@@ -38,7 +38,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0",
+    "wrangler": "4.80.0",
     "postcss": "^8.5.8",
     "postcss-preset-mantine": "^1.18.0",
     "postcss-simple-vars": "^7.0.1"

--- a/playground/mdx/package.json
+++ b/playground/mdx/package.json
@@ -28,7 +28,7 @@
     "react-server-dom-webpack": "19.2.5"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@mdx-js/rollup": "^3.1.1",
     "@types/node": "24.12.0",
@@ -37,7 +37,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
   }

--- a/playground/meta-hoisting/package.json
+++ b/playground/meta-hoisting/package.json
@@ -28,7 +28,7 @@
     "react-server-dom-webpack": "19.2.5"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "24.12.0",
     "@types/react": "19.2.14",
@@ -36,7 +36,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
   }

--- a/playground/monorepo-top-level-deps/packages/project/package.json
+++ b/playground/monorepo-top-level-deps/packages/project/package.json
@@ -29,7 +29,7 @@
     "react-server-dom-webpack": "19.2.5"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "24.12.0",
     "@types/react": "19.2.14",
@@ -37,7 +37,7 @@
     "typescript": "5.9.3",
     "vite": "~7.3.2",
     "vitest": "^4.0.18",
-    "wrangler": "4.77.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
   }

--- a/playground/non-blocking-suspense/package.json
+++ b/playground/non-blocking-suspense/package.json
@@ -28,7 +28,7 @@
     "react-server-dom-webpack": "19.2.5"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "24.12.0",
     "@types/react": "19.2.14",
@@ -36,7 +36,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
   }

--- a/playground/render-apis/package.json
+++ b/playground/render-apis/package.json
@@ -28,7 +28,7 @@
     "react-server-dom-webpack": "19.2.5"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "24.12.0",
     "@types/react": "19.2.14",
@@ -36,7 +36,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
   }

--- a/playground/requestInfo/package.json
+++ b/playground/requestInfo/package.json
@@ -31,7 +31,7 @@
     "rwsdk": "workspace:*"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "24.12.0",
     "@types/react": "19.2.14",
@@ -39,7 +39,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
   }

--- a/playground/resend/package.json
+++ b/playground/resend/package.json
@@ -31,7 +31,7 @@
     "react-server-dom-webpack": "19.2.5"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "24.12.0",
     "@types/react": "19.2.14",
@@ -39,7 +39,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
   }

--- a/playground/rsc-kitchen-sink/package.json
+++ b/playground/rsc-kitchen-sink/package.json
@@ -28,14 +28,14 @@
     "react-server-dom-webpack": "19.2.5"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "24.12.0",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "typescript": "6.0.2",
     "vite": "~7.3.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
   }

--- a/playground/server-decorators/package.json
+++ b/playground/server-decorators/package.json
@@ -29,7 +29,7 @@
     "rwsdk": "workspace:*"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "~24.10.0",
     "@types/react": "19.2.14",
@@ -37,7 +37,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {}
 }

--- a/playground/server-functions/package.json
+++ b/playground/server-functions/package.json
@@ -30,7 +30,7 @@
     "react-server-dom-webpack": "19.2.5"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "24.12.0",
     "@types/react": "19.2.14",
@@ -38,7 +38,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
   }

--- a/playground/shadcn/package.json
+++ b/playground/shadcn/package.json
@@ -76,7 +76,7 @@
     "@tailwindcss/vite": "^4.2.1",
     "shadcn": "^4.1.2",
     "tw-animate-css": "^1.4.0",
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "24.12.0",
     "@types/react": "19.2.14",
@@ -84,7 +84,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "overrides": {
     "react": "19.2.5",

--- a/playground/storybook/package.json
+++ b/playground/storybook/package.json
@@ -30,7 +30,7 @@
     "react-server-dom-webpack": "19.2.5"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "~24.12.0",
     "@types/react": "19.2.14",
@@ -48,7 +48,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
   }

--- a/playground/typed-routes/package.json
+++ b/playground/typed-routes/package.json
@@ -28,7 +28,7 @@
     "react-server-dom-webpack": "19.2.5"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "24.12.0",
     "@types/react": "19.2.14",
@@ -36,7 +36,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
   }

--- a/playground/use-synced-state/package.json
+++ b/playground/use-synced-state/package.json
@@ -29,7 +29,7 @@
     "capnweb": "^0.5.0"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "24.12.0",
     "@types/react": "19.2.14",
@@ -37,7 +37,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
   }

--- a/playground/useid-test/package.json
+++ b/playground/useid-test/package.json
@@ -28,7 +28,7 @@
     "react-server-dom-webpack": "19.2.5"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "24.12.0",
     "@types/react": "19.2.14",
@@ -36,7 +36,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
   }

--- a/playground/workers-og/package.json
+++ b/playground/workers-og/package.json
@@ -29,7 +29,7 @@
     "workers-og": "^0.0.27"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.30.1",
+    "@cloudflare/vite-plugin": "1.31.0",
     "@cloudflare/workers-types": "4.20260331.1",
     "@types/node": "24.12.0",
     "@types/react": "19.2.14",
@@ -37,7 +37,7 @@
     "typescript": "6.0.2",
     "vite": "~7.3.2",
     "vitest": "^4.1.2",
-    "wrangler": "4.79.0"
+    "wrangler": "4.80.0"
   },
   "pnpm": {
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,9 +45,6 @@ overrides:
   webpack@5.97.1: 5.105.4
   yaml@1.10.2: 1.10.3
   yaml@2.8.2: 2.8.3
-  wrangler@4.77.0: 4.80.0
-  wrangler@4.79.0: 4.80.0
-  '@cloudflare/vite-plugin@1.30.1': 1.31.0
   '@cloudflare/workers-types@4.20260331.1': 4.20260405.1
 
 importers:
@@ -91,7 +88,7 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2(@types/node@25.5.0)(msw@2.11.3(@types/node@25.5.0)(typescript@6.0.2))(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.8))(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       wrangler:
-        specifier: 4.80.0
+        specifier: ^4.80.0
         version: 4.80.0(@cloudflare/workers-types@4.20260405.1)
 
   addons/passkey:
@@ -128,7 +125,7 @@ importers:
         specifier: workspace:*
         version: link:../sdk
       wrangler:
-        specifier: 4.80.0
+        specifier: ^4.80.0
         version: 4.80.0(@cloudflare/workers-types@4.20260405.1)
     devDependencies:
       '@cloudflare/workers-types':


### PR DESCRIPTION
## Summary
- Bumps `@cloudflare/vite-plugin` from 1.30.1 to 1.31.0 across all packages
- Bumps `wrangler` from 4.77.0/4.79.0 to 4.80.0 across all packages
- Removes now-unnecessary pnpm overrides for these packages

## Test plan
- [ ] `pnpm install` succeeds
- [ ] Playground apps build and run correctly
- [ ] E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)