### PR TITLE
fix(smoke-test): harden release test against Cloudflare propagation race

### DIFF
--- a/sdk/src/lib/e2e/testHarness.mts
+++ b/sdk/src/lib/e2e/testHarness.mts
@@ -395,11 +395,16 @@ export function createDeployment() {
             resourceUniqueKey,
           );
 
+          // A fresh *.workers.dev subdomain can return 200 with Cloudflare's
+          // "There is nothing here yet" placeholder before the worker code
+          // propagates globally. Wait until the response body contains the
+          // rwsdk-rendered marker so tests don't run against the placeholder.
           await poll(
             async () => {
               try {
                 const response = await fetch(deployResult.url);
-                return response.status > 0;
+                const body = await response.text();
+                return body.includes("__RWSDK_CONTEXT");
               } catch (e) {
                 return false;
               }

--- a/sdk/src/lib/smokeTests/codeUpdates.mts
+++ b/sdk/src/lib/smokeTests/codeUpdates.mts
@@ -94,9 +94,9 @@ export async function createSmokeTestStylesheets(targetDir: string) {
   log("Creating smokeTestUrlStyles.css at: %s", urlStylesPath);
   await fs.writeFile(urlStylesPath, smokeTestUrlStylesCssTemplate);
 
-  // Modify Document.tsx to include the URL stylesheet using CSS URL import
-  const documentPath = join(appDir, "Document.tsx");
-  log("Modifying Document.tsx to include URL stylesheet at: %s", documentPath);
+  // Modify document.tsx to include the URL stylesheet using CSS URL import
+  const documentPath = join(appDir, "document.tsx");
+  log("Modifying document.tsx to include URL stylesheet at: %s", documentPath);
   try {
     const documentContent = await fs.readFile(documentPath, "utf-8");
     const s = new MagicString(documentContent);
@@ -118,12 +118,12 @@ export async function createSmokeTestStylesheets(targetDir: string) {
         '      <link rel="stylesheet" href={smokeTestUrlStyles} />\n',
       );
       await fs.writeFile(documentPath, s.toString(), "utf-8");
-      log("Successfully modified Document.tsx with CSS URL import pattern");
+      log("Successfully modified document.tsx with CSS URL import pattern");
     } else {
-      log("Could not find </head> tag in Document.tsx");
+      log("Could not find </head> tag in document.tsx");
     }
   } catch (e) {
-    log("Could not modify Document.tsx: %s", e);
+    log("Could not modify document.tsx: %s", e);
   }
 
   log("Smoke test stylesheets created successfully");

--- a/sdk/src/lib/smokeTests/release.mts
+++ b/sdk/src/lib/smokeTests/release.mts
@@ -30,6 +30,55 @@ export async function runRelease(
   return runE2ERelease(cwd, projectDir, resourceUniqueKey);
 }
 
+async function waitForDeploymentContent(
+  baseUrl: string,
+  {
+    timeoutMs = 60_000,
+    intervalMs = 2_000,
+  }: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<void> {
+  const marker = "__RWSDK_CONTEXT";
+  const deadline = Date.now() + timeoutMs;
+  let attempt = 0;
+  let lastStatus: number | undefined;
+  let lastBytes = 0;
+  while (Date.now() < deadline) {
+    attempt += 1;
+    try {
+      const res = await fetch(baseUrl);
+      const body = await res.text();
+      lastStatus = res.status;
+      lastBytes = body.length;
+      if (body.includes(marker)) {
+        log(
+          "Deployment content verified at %s after %d attempt(s)",
+          baseUrl,
+          attempt,
+        );
+        console.log(
+          `✅ Deployment content ready at ${baseUrl} (attempt ${attempt})`,
+        );
+        return;
+      }
+      log(
+        "Attempt %d: %s returned %d (%d bytes), no app marker yet",
+        attempt,
+        baseUrl,
+        res.status,
+        body.length,
+      );
+    } catch (err) {
+      log("Attempt %d: fetch failed for %s: %O", attempt, baseUrl, err);
+    }
+    await setTimeout(intervalMs);
+  }
+  throw new Error(
+    `Deployment at ${baseUrl} did not serve app content within ${timeoutMs}ms ` +
+      `(last status ${lastStatus ?? "n/a"}, ${lastBytes} bytes). ` +
+      `Likely Cloudflare *.workers.dev propagation still in progress.`,
+  );
+}
+
 /**
  * Runs tests against the production deployment
  */
@@ -62,6 +111,13 @@ export async function runReleaseTest(
 
     // DRY: check both root and custom path
     await checkServerUp(url, "/");
+
+    // A fresh *.workers.dev subdomain can return 200 with Cloudflare's
+    // "There is nothing here yet" placeholder before the worker code is
+    // globally propagated. Poll the URL until the response body contains
+    // an rwsdk-rendered marker so we don't run the browser tests against
+    // the placeholder.
+    await waitForDeploymentContent(url);
 
     // Now run the tests with the custom path
     const testUrl = new URL("/__smoke_test", url).toString();


### PR DESCRIPTION
## Summary

- The production release smoke test has been flaking on `main` — two consecutive Release workflow failures today ([24390750381](https://github.com/redwoodjs/sdk/actions/runs/24390750381), [24389368095](https://github.com/redwoodjs/sdk/actions/runs/24389368095)) — with the same pair of errors:
  - `Smoke test status element not found in the page`
  - `The __rw API or upgradeToRealtime method is not available`
- Root cause: a freshly deployed `*.workers.dev` subdomain can return HTTP 200 with Cloudflare's *"There is nothing here yet"* placeholder for a window after `wrangler deploy` completes, before the worker code is globally propagated. The existing `checkServerUp` treats any 2xx as "up", so Puppeteer loads the placeholder and both errors follow — neither the app HTML (no `[data-testid="health-status"]`) nor the client bootstrap (no `window.__rw`) are present. The failing local reproduction's screenshot confirmed it: Cloudflare's "There is nothing here yet. If you expect something to be here, it may take some time. Please check back again later." page.

## Changes

1. **`release.mts`** — after the reachability check, poll the deployed URL until the response body contains `__RWSDK_CONTEXT` (emitted on every rwsdk-rendered page). The placeholder lacks this marker, so the poll only clears once the real worker response is being served. 60s timeout, 2s interval.
2. **`codeUpdates.mts`** — rename the smoke test's `Document.tsx` references to `document.tsx`. The starter was renamed in `20081aad` (2026-01-26) but the smoke test wasn't updated; on case-sensitive Linux CI this was silently swallowed and surfaced as `URL Styles / Client Module Styles: DID NOT RUN` warnings. Picked up from the existing fix on branch `pp-implement-1131-synced-state-reconnect`.

## Test plan

- [x] Local smoke test reproduced the original failure (`Smoke test status element not found in the page`).
- [x] Same smoke test with this fix passes end-to-end, dev + production (`Smoke tests passed for 'starter' with 'pnpm'`).
- [x] SDK build passes (`pnpm --filter rwsdk build`).
- [ ] Release workflow rerun on `main` after merge to confirm CI passes consistently.

Note: in local testing, propagation cleared on the first poll attempt (`Deployment content ready ... (attempt 1)`), so the retry path itself wasn't exercised end-to-end. The logic is small (fetch → substring check → sleep → retry) and low-risk, but we'll want to watch the next few release runs for any edge cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)