### PR TITLE
Run greenkeeping for Redwood SDK

### DIFF
--- a/.kindling/board/doing/2026-04-15-1613-run-greenkeeping-for-redwood-sdk-ced3.md
+++ b/.kindling/board/doing/2026-04-15-1613-run-greenkeeping-for-redwood-sdk-ced3.md
@@ -1,0 +1,27 @@
+---
+status: doing
+labels: []
+created: "2026-04-15T14:13:46.776Z"
+started: "2026-04-15T14:13:46.776Z"
+completed: null
+github-pr: null
+github-comments: true
+no-pr: false
+depends-on: []
+---
+
+## Brief
+
+Run greenkeeping for Redwood SDK
+
+## Checklist
+
+## Progress Log
+
+
+
+
+- [2026-04-15T14:15:54.292Z] [harness] Starting greenkeeping cycle for the Redwood SDK monorepo. Today is the 3rd week of April, so Tier 1 (critical) and Tier 2 (SDK/Starter) dependencies are in scope. Dispatching GreenKeeper for the dependency audit phase — this will run pnpm outdated and pnpm audit across all workspaces to classify available updates and advisories before any changes are made. Phase 1 of 5.
+- [2026-04-15T14:15:54.284Z] [harness] Plan ready: 5 phases, greenkeeping protocol. Task force: GreenKeeper, Reviewer, Verifier.
+- [2026-04-15T14:14:59.411Z] [harness] Planning approach -- reading your brief, selecting protocol, assembling task force...
+- [2026-04-15T14:13:48.125Z] [harness] Understanding your codebase so agents have architectural context...


### PR DESCRIPTION
> **Note:** This description will be replaced when the task completes.

## Context

Dependency maintenance pass: audit Redwood SDK monorepo workspace packages and apply updates to Tier 1 (critical) and Tier 2 (SDK/Starter) dependencies per greenkeeping schedule. Verification includes pnpm install, audit checks, SDK unit tests, and security advisory remediation via package.json and pnpm overrides.