### PR TITLE
bugfix: handleMiddlewareResult fails for cross-realm Response.json()

### DIFF
--- a/sdk/src/runtime/lib/router.test.ts
+++ b/sdk/src/runtime/lib/router.test.ts
@@ -1435,6 +1435,181 @@ describe("defineRoutes - Request Handling Behavior", () => {
     });
   });
 
+  describe("Cross-realm Response.json() handling", () => {
+    // In Cloudflare's vite dev mode, Response.json() constructs from a
+    // different realm's prototype, so `instanceof Response` fails.
+    // handleMiddlewareResult must recognize these as valid Responses.
+    //
+    // We simulate this by calling Response.json() and then stripping the
+    // prototype, which is exactly what a cross-realm boundary does: the
+    // object is a real Response but its [[Prototype]] comes from a different
+    // global, so `instanceof` against the local `Response` returns false.
+
+    function crossRealmResponseJson(data: unknown, init?: ResponseInit) {
+      // In workerd/vite dev mode, Response.json() constructs from a different
+      // realm's Response. The resulting object has constructor.name === "Response"
+      // but fails instanceof against the local Response global.
+      //
+      // We can't just swap the prototype in Node because V8's brand checks on
+      // Response internal slots would throw. Instead, wrap a real Response.json()
+      // result in a Proxy that fakes a foreign prototype chain — matching exactly
+      // what workerd produces: instanceof false, constructor.name "Response",
+      // all properties/methods functional.
+      const real = Response.json(data, init);
+      const foreignProto = { constructor: { name: "Response" } };
+      const proxy = new Proxy(real, {
+        get(target, prop, _receiver) {
+          if (prop === "constructor") return foreignProto.constructor;
+          const val = Reflect.get(target, prop, target);
+          if (typeof val === "function") return val.bind(target);
+          return val;
+        },
+        getPrototypeOf() {
+          return foreignProto;
+        },
+      });
+      // Sanity: must match the real workerd behavior
+      if (proxy instanceof Response) {
+        throw new Error("Test setup broken: cross-realm response should not pass instanceof");
+      }
+      // TS narrows proxy to `never` after the instanceof check above (it
+      // assumes non-Response means no constructor), but the whole point is
+      // that this object IS a Response from a foreign realm.
+      if ((proxy as any).constructor?.name !== "Response") {
+        throw new Error("Test setup broken: constructor.name should be 'Response'");
+      }
+      return proxy;
+    }
+
+    it("should return cross-realm Response.json() from a POST route handler", async () => {
+      const router = defineRoutes([
+        route("/api/users/", {
+          post: () => crossRealmResponseJson({ created: true }, { status: 201 }),
+        }),
+      ]);
+
+      const deps = createMockDependencies();
+      const request = new Request("http://localhost:3000/api/users/", {
+        method: "POST",
+      });
+      deps.mockRequestInfo.request = request;
+
+      const response = await router.handle({
+        request,
+        renderPage: deps.mockRenderPage,
+        getRequestInfo: deps.getRequestInfo,
+        onError: deps.onError,
+        runWithRequestInfoOverrides: deps.mockRunWithRequestInfoOverrides,
+        rscActionHandler: deps.mockRscActionHandler,
+      });
+
+      expect(response.status).toBe(201);
+      expect(await response.json()).toEqual({ created: true });
+    });
+
+    it("should short-circuit global middleware returning cross-realm Response.json()", async () => {
+      const executionOrder: string[] = [];
+
+      const authMiddleware = () => {
+        executionOrder.push("authMiddleware");
+        return crossRealmResponseJson({ error: "forbidden" }, { status: 403 });
+      };
+
+      const PageComponent = () => {
+        executionOrder.push("PageComponent");
+        return React.createElement("div", {}, "Page");
+      };
+
+      const router = defineRoutes([
+        authMiddleware,
+        route("/test/", PageComponent),
+      ]);
+
+      const deps = createMockDependencies();
+      const request = new Request("http://localhost:3000/test/");
+      deps.mockRequestInfo.request = request;
+
+      const response = await router.handle({
+        request,
+        renderPage: deps.mockRenderPage,
+        getRequestInfo: deps.getRequestInfo,
+        onError: deps.onError,
+        runWithRequestInfoOverrides: deps.mockRunWithRequestInfoOverrides,
+        rscActionHandler: deps.mockRscActionHandler,
+      });
+
+      expect(executionOrder).toEqual(["authMiddleware"]);
+      expect(response.status).toBe(403);
+      expect(await response.json()).toEqual({ error: "forbidden" });
+    });
+
+    it("should short-circuit route-specific middleware returning cross-realm Response.json()", async () => {
+      const executionOrder: string[] = [];
+
+      const checkRole = () => {
+        executionOrder.push("checkRole");
+        return crossRealmResponseJson({ error: "unauthorized" }, { status: 401 });
+      };
+
+      const PageComponent = () => {
+        executionOrder.push("PageComponent");
+        return React.createElement("div", {}, "Page");
+      };
+
+      const router = defineRoutes([
+        route("/admin/", [checkRole, PageComponent]),
+      ]);
+
+      const deps = createMockDependencies();
+      const request = new Request("http://localhost:3000/admin/");
+      deps.mockRequestInfo.request = request;
+
+      const response = await router.handle({
+        request,
+        renderPage: deps.mockRenderPage,
+        getRequestInfo: deps.getRequestInfo,
+        onError: deps.onError,
+        runWithRequestInfoOverrides: deps.mockRunWithRequestInfoOverrides,
+        rscActionHandler: deps.mockRscActionHandler,
+      });
+
+      expect(executionOrder).toEqual(["checkRole"]);
+      expect(response.status).toBe(401);
+      expect(await response.json()).toEqual({ error: "unauthorized" });
+    });
+
+    it("should handle cross-realm Response.json() from an except handler", async () => {
+      const errorHandler = except(() => {
+        return crossRealmResponseJson({ error: "internal" }, { status: 500 });
+      });
+
+      const PageComponent = () => {
+        throw new Error("boom");
+      };
+
+      const router = defineRoutes([
+        errorHandler,
+        route("/test/", PageComponent),
+      ]);
+
+      const deps = createMockDependencies();
+      const request = new Request("http://localhost:3000/test/");
+      deps.mockRequestInfo.request = request;
+
+      const response = await router.handle({
+        request,
+        renderPage: deps.mockRenderPage,
+        getRequestInfo: deps.getRequestInfo,
+        onError: deps.onError,
+        runWithRequestInfoOverrides: deps.mockRunWithRequestInfoOverrides,
+        rscActionHandler: deps.mockRscActionHandler,
+      });
+
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({ error: "internal" });
+    });
+  });
+
   describe("Edge Cases", () => {
     it("should handle middleware-only apps with RSC actions", async () => {
       const executionOrder: string[] = [];

--- a/sdk/src/runtime/lib/router.ts
+++ b/sdk/src/runtime/lib/router.ts
@@ -408,8 +408,11 @@ export function defineRoutes<T extends RequestInfo = RequestInfo>(
       async function handleMiddlewareResult(
         result: Response | React.JSX.Element | void,
       ): Promise<Response | undefined> {
-        if (result instanceof Response) {
-          return result;
+        // NOTE: instanceof fails for cross-realm Responses (e.g. Response.json()
+        // in Cloudflare's vite dev mode constructs from a different realm's
+        // prototype). Fall back to constructor.name check.
+        if (result instanceof Response || result?.constructor?.name === 'Response') {
+          return result as Response;
         }
         if (result && React.isValidElement(result)) {
           return await renderElement(result);


### PR DESCRIPTION
hey team 👋 ran into this in dev mode — `Response.json()` returns a Response constructed from a different realm in workerd/vite, so `instanceof Response` returns `false`. this causes `handleMiddlewareResult` to miss valid Responses and fall through to the "did not return a Response" error.

## what's fixed

`handleMiddlewareResult` in `router.ts` now falls back to `result?.constructor?.name === 'Response'` when `instanceof` fails. diagnostic confirmed that `constructor.name` is `"Response"` for both `Response.json()` and `new Response()` in workerd, but only `new Response()` passes `instanceof`.

## test plan

- 4 new tests simulating cross-realm `Response.json()` via Proxy (can't just swap prototypes in Node because V8 brand checks on Response internal slots throw)
- covers: route handler, global middleware, route-specific middleware, except handler
- all 58 router tests pass
- all 824 SDK tests pass
- typecheck clean