### PR TITLE
fix(synced-state): mark capnweb as optional peer, defer imports

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -201,6 +201,11 @@
     "vite": "^6.2.6 || 7.x",
     "wrangler": "^4.77.0"
   },
+  "peerDependenciesMeta": {
+    "capnweb": {
+      "optional": true
+    }
+  },
   "packageManager": "pnpm@10.31.0",
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.31.0",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rwsdk",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Build fast, server-driven webapps on Cloudflare with SSR, RSC, and realtime",
   "type": "module",
   "bin": {

--- a/sdk/src/use-synced-state/SyncedStateServer.mts
+++ b/sdk/src/use-synced-state/SyncedStateServer.mts
@@ -1,6 +1,7 @@
-import { RpcStub, RpcTarget, newWorkersRpcResponse } from "capnweb";
+import type { RpcStub } from "capnweb";
 import { DurableObject } from "cloudflare:workers";
 import type { RequestInfo } from "../runtime/requestInfo/types";
+import { loadCapnweb } from "./capnweb-loader.mjs";
 
 export type SyncedStateValue = unknown;
 
@@ -30,6 +31,64 @@ type OnUnsubscribeHandler = (
   key: string,
   stub: DurableObjectStub<SyncedStateServer>,
 ) => void;
+
+type CoordinatorApiCtor = new (
+  coordinator: SyncedStateServer,
+  stub: DurableObjectStub<SyncedStateServer>,
+) => { _setStub(stub: DurableObjectStub<SyncedStateServer>): void };
+
+let CoordinatorApiClass: CoordinatorApiCtor | null = null;
+
+async function getCoordinatorApi(): Promise<{
+  CoordinatorApi: CoordinatorApiCtor;
+  newWorkersRpcResponse: typeof import("capnweb").newWorkersRpcResponse;
+}> {
+  const { RpcTarget, newWorkersRpcResponse } = await loadCapnweb();
+  if (!CoordinatorApiClass) {
+    CoordinatorApiClass = class CoordinatorApi extends RpcTarget {
+      #coordinator: SyncedStateServer;
+      #stub: DurableObjectStub<SyncedStateServer>;
+
+      constructor(
+        coordinator: SyncedStateServer,
+        stub: DurableObjectStub<SyncedStateServer>,
+      ) {
+        super();
+        this.#coordinator = coordinator;
+        this.#stub = stub;
+        coordinator.setStub(stub);
+      }
+
+      _setStub(stub: DurableObjectStub<SyncedStateServer>): void {
+        this.#stub = stub;
+        this.#coordinator.setStub(stub);
+      }
+
+      getState(key: string): SyncedStateValue {
+        return this.#coordinator.getState(key);
+      }
+
+      setState(value: SyncedStateValue, key: string): void {
+        this.#coordinator.setState(value, key);
+      }
+
+      subscribe(
+        key: string,
+        client: RpcStub<(value: SyncedStateValue) => void>,
+      ): void {
+        this.#coordinator.subscribe(key, client);
+      }
+
+      unsubscribe(
+        key: string,
+        client: RpcStub<(value: SyncedStateValue) => void>,
+      ): void {
+        this.#coordinator.unsubscribe(key, client);
+      }
+    } as unknown as CoordinatorApiCtor;
+  }
+  return { CoordinatorApi: CoordinatorApiClass, newWorkersRpcResponse };
+}
 
 /**
  * Durable Object that keeps shared state for multiple clients and notifies subscribers.
@@ -218,54 +277,13 @@ export class SyncedStateServer extends DurableObject {
   }
 
   async fetch(request: Request): Promise<Response> {
+    const { CoordinatorApi, newWorkersRpcResponse } =
+      await getCoordinatorApi();
     // Create a placeholder stub - it will be set by the worker via _setStub
     const api = new CoordinatorApi(
       this,
       this.#stub || ({} as DurableObjectStub<SyncedStateServer>),
     );
     return newWorkersRpcResponse(request, api);
-  }
-}
-
-class CoordinatorApi extends RpcTarget {
-  #coordinator: SyncedStateServer;
-  #stub: DurableObjectStub<SyncedStateServer>;
-
-  constructor(
-    coordinator: SyncedStateServer,
-    stub: DurableObjectStub<SyncedStateServer>,
-  ) {
-    super();
-    this.#coordinator = coordinator;
-    this.#stub = stub;
-    coordinator.setStub(stub);
-  }
-
-  // Internal method to set the stub - called from worker
-  _setStub(stub: DurableObjectStub<SyncedStateServer>): void {
-    this.#stub = stub;
-    this.#coordinator.setStub(stub);
-  }
-
-  getState(key: string): SyncedStateValue {
-    return this.#coordinator.getState(key);
-  }
-
-  setState(value: SyncedStateValue, key: string): void {
-    this.#coordinator.setState(value, key);
-  }
-
-  subscribe(
-    key: string,
-    client: RpcStub<(value: SyncedStateValue) => void>,
-  ): void {
-    this.#coordinator.subscribe(key, client);
-  }
-
-  unsubscribe(
-    key: string,
-    client: RpcStub<(value: SyncedStateValue) => void>,
-  ): void {
-    this.#coordinator.unsubscribe(key, client);
   }
 }

--- a/sdk/src/use-synced-state/__tests__/client-core.test.ts
+++ b/sdk/src/use-synced-state/__tests__/client-core.test.ts
@@ -45,6 +45,8 @@ import {
   __testing,
 } from "../client-core";
 
+const ENDPOINT = "wss://test.example.com/__synced-state";
+
 describe("client-core reconnection", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -68,15 +70,17 @@ describe("client-core reconnection", () => {
     vi.useRealTimers();
   });
 
-  it("registers onRpcBroken callback when creating a client", () => {
-    getSyncedStateClient("wss://test.example.com/__synced-state");
+  it("registers onRpcBroken callback when creating a client", async () => {
+    getSyncedStateClient(ENDPOINT);
+    await __testing.warmUp(ENDPOINT);
 
     expect(mockClients).toHaveLength(1);
     expect(mockClients[0].onRpcBroken).toHaveBeenCalledOnce();
   });
 
-  it("creates a new client after connection breaks", () => {
-    getSyncedStateClient("wss://test.example.com/__synced-state");
+  it("creates a new client after connection breaks", async () => {
+    getSyncedStateClient(ENDPOINT);
+    await __testing.warmUp(ENDPOINT);
     expect(mockClients).toHaveLength(1);
 
     // Simulate connection break
@@ -84,12 +88,14 @@ describe("client-core reconnection", () => {
 
     // Reconnect happens after backoff timer fires
     vi.runOnlyPendingTimers();
+    await __testing.warmUp(ENDPOINT);
 
     expect(mockClients).toHaveLength(2);
   });
 
-  it("does not reconnect immediately — waits for backoff", () => {
-    getSyncedStateClient("wss://test.example.com/__synced-state");
+  it("does not reconnect immediately — waits for backoff", async () => {
+    getSyncedStateClient(ENDPOINT);
+    await __testing.warmUp(ENDPOINT);
 
     mockClients[0].simulateBreak();
 
@@ -98,13 +104,12 @@ describe("client-core reconnection", () => {
 
     // After timer fires, reconnect happens
     vi.runOnlyPendingTimers();
+    await __testing.warmUp(ENDPOINT);
     expect(mockClients).toHaveLength(2);
   });
 
   it("re-subscribes active subscriptions after reconnect", async () => {
-    const client = getSyncedStateClient(
-      "wss://test.example.com/__synced-state",
-    );
+    const client = getSyncedStateClient(ENDPOINT);
     const handler = vi.fn();
 
     await client.subscribe("counter", handler);
@@ -112,6 +117,7 @@ describe("client-core reconnection", () => {
     // Simulate connection break
     mockClients[0].simulateBreak();
     vi.runOnlyPendingTimers();
+    await __testing.warmUp(ENDPOINT);
 
     // The new client should have subscribe called with the same key and handler
     const newClient = mockClients[1];
@@ -119,24 +125,21 @@ describe("client-core reconnection", () => {
   });
 
   it("fetches latest state for each subscription after reconnect", async () => {
-    const client = getSyncedStateClient(
-      "wss://test.example.com/__synced-state",
-    );
+    const client = getSyncedStateClient(ENDPOINT);
     const handler = vi.fn();
 
     await client.subscribe("counter", handler);
 
     mockClients[0].simulateBreak();
     vi.runOnlyPendingTimers();
+    await __testing.warmUp(ENDPOINT);
 
     const newClient = mockClients[1];
     expect(newClient.getState).toHaveBeenCalledWith("counter");
   });
 
   it("calls handler with fetched state when value is not undefined", async () => {
-    const client = getSyncedStateClient(
-      "wss://test.example.com/__synced-state",
-    );
+    const client = getSyncedStateClient(ENDPOINT);
     const handler = vi.fn();
 
     await client.subscribe("counter", handler);
@@ -150,6 +153,7 @@ describe("client-core reconnection", () => {
 
     mockClients[0].simulateBreak();
     vi.runOnlyPendingTimers();
+    await __testing.warmUp(ENDPOINT);
 
     // Allow the getState promise to resolve
     await vi.runAllTimersAsync();
@@ -158,9 +162,7 @@ describe("client-core reconnection", () => {
   });
 
   it("does not call handler when fetched state is undefined", async () => {
-    const client = getSyncedStateClient(
-      "wss://test.example.com/__synced-state",
-    );
+    const client = getSyncedStateClient(ENDPOINT);
     const handler = vi.fn();
 
     await client.subscribe("counter", handler);
@@ -168,6 +170,7 @@ describe("client-core reconnection", () => {
 
     mockClients[0].simulateBreak();
     vi.runOnlyPendingTimers();
+    await __testing.warmUp(ENDPOINT);
 
     // Default mock returns undefined for getState
     await vi.runAllTimersAsync();
@@ -176,9 +179,7 @@ describe("client-core reconnection", () => {
   });
 
   it("does not re-subscribe keys that were unsubscribed before reconnect", async () => {
-    const client = getSyncedStateClient(
-      "wss://test.example.com/__synced-state",
-    );
+    const client = getSyncedStateClient(ENDPOINT);
     const handler = vi.fn();
 
     await client.subscribe("counter", handler);
@@ -186,19 +187,22 @@ describe("client-core reconnection", () => {
 
     mockClients[0].simulateBreak();
     vi.runOnlyPendingTimers();
+    await __testing.warmUp(ENDPOINT);
 
     const newClient = mockClients[1];
     expect(newClient.subscribe).not.toHaveBeenCalled();
   });
 
-  it("does not schedule multiple reconnects for the same endpoint", () => {
-    getSyncedStateClient("wss://test.example.com/__synced-state");
+  it("does not schedule multiple reconnects for the same endpoint", async () => {
+    getSyncedStateClient(ENDPOINT);
+    await __testing.warmUp(ENDPOINT);
 
     // Fire broken twice rapidly
     mockClients[0].simulateBreak();
     mockClients[0].simulateBreak();
 
     vi.runOnlyPendingTimers();
+    await __testing.warmUp(ENDPOINT);
 
     // Should only have created one new session
     expect(mockClients).toHaveLength(2);
@@ -217,21 +221,16 @@ describe("client-core reconnection", () => {
     expect(inRange(__testing.getBackoffMs(10), 22500, 30000)).toBe(true); // still capped
   });
 
-  it("returns cached client on second call for same endpoint", () => {
-    const client1 = getSyncedStateClient(
-      "wss://test.example.com/__synced-state",
-    );
-    const client2 = getSyncedStateClient(
-      "wss://test.example.com/__synced-state",
-    );
+  it("returns cached client on second call for same endpoint", async () => {
+    const client1 = getSyncedStateClient(ENDPOINT);
+    const client2 = getSyncedStateClient(ENDPOINT);
     expect(client1).toBe(client2);
+    await __testing.warmUp(ENDPOINT);
     expect(mockClients).toHaveLength(1);
   });
 
   it("re-subscribes multiple subscriptions after reconnect", async () => {
-    const client = getSyncedStateClient(
-      "wss://test.example.com/__synced-state",
-    );
+    const client = getSyncedStateClient(ENDPOINT);
     const handler1 = vi.fn();
     const handler2 = vi.fn();
 
@@ -240,6 +239,7 @@ describe("client-core reconnection", () => {
 
     mockClients[0].simulateBreak();
     vi.runOnlyPendingTimers();
+    await __testing.warmUp(ENDPOINT);
 
     const newClient = mockClients[1];
     expect(newClient.subscribe).toHaveBeenCalledWith("counter", handler1);
@@ -249,10 +249,9 @@ describe("client-core reconnection", () => {
   });
 
   describe("onStatusChange", () => {
-    const ENDPOINT = "wss://test.example.com/__synced-state";
-
-    it("fires 'disconnected' immediately when connection breaks", () => {
+    it("fires 'disconnected' immediately when connection breaks", async () => {
       getSyncedStateClient(ENDPOINT);
+      await __testing.warmUp(ENDPOINT);
       const statusCb = vi.fn();
       onStatusChange(ENDPOINT, statusCb);
 
@@ -263,6 +262,7 @@ describe("client-core reconnection", () => {
 
     it("fires 'reconnecting' then 'connected' when reconnect completes", async () => {
       getSyncedStateClient(ENDPOINT);
+      await __testing.warmUp(ENDPOINT);
       const statusCb = vi.fn();
       onStatusChange(ENDPOINT, statusCb);
 
@@ -279,6 +279,7 @@ describe("client-core reconnection", () => {
 
     it("fires full lifecycle: disconnected → reconnecting → connected", async () => {
       getSyncedStateClient(ENDPOINT);
+      await __testing.warmUp(ENDPOINT);
       const statuses: string[] = [];
       onStatusChange(ENDPOINT, (s) => statuses.push(s));
 
@@ -289,8 +290,9 @@ describe("client-core reconnection", () => {
       expect(statuses).toEqual(["disconnected", "reconnecting", "connected"]);
     });
 
-    it("returns an unsubscribe function that stops notifications", () => {
+    it("returns an unsubscribe function that stops notifications", async () => {
       getSyncedStateClient(ENDPOINT);
+      await __testing.warmUp(ENDPOINT);
       const statusCb = vi.fn();
       const unsub = onStatusChange(ENDPOINT, statusCb);
 
@@ -300,8 +302,9 @@ describe("client-core reconnection", () => {
       expect(statusCb).not.toHaveBeenCalled();
     });
 
-    it("supports multiple listeners on the same endpoint", () => {
+    it("supports multiple listeners on the same endpoint", async () => {
       getSyncedStateClient(ENDPOINT);
+      await __testing.warmUp(ENDPOINT);
       const cb1 = vi.fn();
       const cb2 = vi.fn();
       onStatusChange(ENDPOINT, cb1);
@@ -318,7 +321,7 @@ describe("client-core reconnection", () => {
   // REPRODUCTIONS: Failing tests demonstrating Copilot-flagged bugs
   // ============================================================
   describe("REPRO: bug reproductions", () => {
-    it("BUG: status listener registered with relative URL never fires because reconnect uses the normalized absolute URL", () => {
+    it("BUG: status listener registered with relative URL never fires because reconnect uses the normalized absolute URL", async () => {
       // Stub window so relative URLs get normalized inside getSyncedStateClient
       vi.stubGlobal("window", {
         location: { protocol: "https:", host: "example.com" },
@@ -332,6 +335,7 @@ describe("client-core reconnection", () => {
       // the same (relative) string it passes to getSyncedStateClient.
       onStatusChange(RELATIVE, statusCb);
       getSyncedStateClient(RELATIVE);
+      await __testing.warmUp(RELATIVE);
 
       mockClients[0].simulateBreak();
       vi.runOnlyPendingTimers();
@@ -344,9 +348,9 @@ describe("client-core reconnection", () => {
       vi.unstubAllGlobals();
     });
 
-    it("BUG: unsubscribing one of two instances of the same callback removes it for all", () => {
-      const ENDPOINT = "wss://test.example.com/__synced-state";
+    it("BUG: unsubscribing one of two instances of the same callback removes it for all", async () => {
       getSyncedStateClient(ENDPOINT);
+      await __testing.warmUp(ENDPOINT);
 
       // Simulate two React components sharing the same onStatusChange
       // callback (the case when createSyncedStateHook({ onStatusChange })
@@ -369,7 +373,6 @@ describe("client-core reconnection", () => {
     });
 
     it("BUG: reconnect emits 'connected' and resets backoff even when subscribe() rejects", async () => {
-      const ENDPOINT = "wss://test.example.com/__synced-state";
       const client = getSyncedStateClient(ENDPOINT);
       const handler = vi.fn();
 

--- a/sdk/src/use-synced-state/capnweb-loader.mts
+++ b/sdk/src/use-synced-state/capnweb-loader.mts
@@ -1,0 +1,14 @@
+let capnwebPromise: Promise<typeof import("capnweb")> | null = null;
+
+export function loadCapnweb(): Promise<typeof import("capnweb")> {
+  if (!capnwebPromise) {
+    capnwebPromise = import("capnweb").catch(() => {
+      throw new Error(
+        'The "use-synced-state" feature requires the "capnweb" package, ' +
+          'which is not installed. Install it with your package manager ' +
+          '(e.g. `npm install capnweb` or `pnpm add capnweb`).',
+      );
+    });
+  }
+  return capnwebPromise;
+}

--- a/sdk/src/use-synced-state/client-core.ts
+++ b/sdk/src/use-synced-state/client-core.ts
@@ -1,4 +1,4 @@
-import { newWebSocketRpcSession } from "capnweb";
+import { loadCapnweb } from "./capnweb-loader.mjs";
 import { DEFAULT_SYNCED_STATE_PATH } from "./constants.mjs";
 
 export type SyncedStateStatus = "connected" | "disconnected" | "reconnecting";
@@ -24,6 +24,10 @@ function normalizeEndpoint(endpoint: string): string {
 
 // Map of endpoint URLs to their respective clients
 const clientCache = new Map<string, SyncedStateClient>();
+
+// Tracks the promise of the underlying capnweb session per endpoint, exposed
+// for tests so they can `await` the lazy load before making assertions.
+const baseClientPromiseByEndpoint = new Map<string, Promise<unknown>>();
 
 // Track active subscriptions per client for cleanup on page reload
 // and for re-subscribing after reconnection
@@ -172,8 +176,9 @@ function reconnect(endpoint: string, deadClient: SyncedStateClient) {
 
 /**
  * Returns a cached client for the provided endpoint, creating it when necessary.
- * The client is wrapped to track subscriptions for cleanup on page reload.
- * On connection failure, automatically reconnects and re-subscribes.
+ * The returned client is a proxy that loads `capnweb` lazily on first method
+ * call — consumers that never hit `use-synced-state` pay no import cost and
+ * don't need `capnweb` installed.
  * @param endpoint Endpoint to connect to.
  * @returns RPC client instance.
  */
@@ -189,14 +194,27 @@ export const getSyncedStateClient = (
     return existingClient;
   }
 
-  const baseClient = newWebSocketRpcSession(
-    endpoint,
-  ) as unknown as SyncedStateClient;
+  let baseClientPromise: Promise<any> | null = null;
+  let wrappedClient!: SyncedStateClient;
 
-  // Wrap the client using a Proxy to track subscriptions
-  // The RPC client uses dynamic property access, so we can't use .bind()
-  const wrappedClient = new Proxy(baseClient, {
-    get(target, prop) {
+  const getBaseClient = (): Promise<any> => {
+    if (!baseClientPromise) {
+      baseClientPromise = loadCapnweb().then((mod) => {
+        const session = mod.newWebSocketRpcSession(endpoint);
+        if (typeof (session as any).onRpcBroken === "function") {
+          (session as any).onRpcBroken(() => {
+            reconnect(endpoint, wrappedClient);
+          });
+        }
+        return session;
+      });
+      baseClientPromiseByEndpoint.set(endpoint, baseClientPromise);
+    }
+    return baseClientPromise;
+  };
+
+  wrappedClient = new Proxy({} as SyncedStateClient, {
+    get(_target, prop) {
       if (prop === "subscribe") {
         return async (key: string, handler: (value: unknown) => void) => {
           const subscription: Subscription = {
@@ -205,7 +223,8 @@ export const getSyncedStateClient = (
             client: wrappedClient,
           };
           activeSubscriptions.add(subscription);
-          return (target as any)[prop](key, handler);
+          const base = await getBaseClient();
+          return base[prop](key, handler);
         };
       }
       if (prop === "unsubscribe") {
@@ -221,23 +240,28 @@ export const getSyncedStateClient = (
               break;
             }
           }
-          return (target as any)[prop](key, handler);
+          const base = await getBaseClient();
+          return base[prop](key, handler);
         };
       }
       // Pass through all other properties/methods
-      return (target as any)[prop];
+      return async (...args: unknown[]) => {
+        const base = await getBaseClient();
+        return base[prop as string](...args);
+      };
     },
   }) as SyncedStateClient;
 
-  // Listen for connection failure and trigger reconnection
-  if (typeof (baseClient as any).onRpcBroken === "function") {
-    (baseClient as any).onRpcBroken(() => {
-      reconnect(endpoint, wrappedClient);
-    });
-  }
-
   // Cache the client for this endpoint
   clientCache.set(endpoint, wrappedClient);
+
+  // Eagerly kick off the capnweb load so the underlying session (and its
+  // onRpcBroken handler) is ready as soon as possible, and reconnect flows
+  // that don't call methods on the new client still create the replacement
+  // session. Errors are swallowed here to avoid unhandled rejections — they
+  // still surface through subsequent method calls because the rejected
+  // promise remains cached.
+  void getBaseClient().catch(() => {});
 
   return wrappedClient;
 };
@@ -272,6 +296,7 @@ export const setSyncedStateClientForTesting = (
   } else {
     clientCache.delete(endpoint);
   }
+  baseClientPromiseByEndpoint.delete(endpoint);
   activeSubscriptions.clear();
   statusListeners.clear();
   // Clear any pending reconnection timers
@@ -291,4 +316,15 @@ export const __testing = {
   statusListeners,
   reconnect,
   getBackoffMs,
+  // Awaits the eagerly-kicked-off capnweb load for a cached client. Tests
+  // should `await __testing.warmUp(endpoint)` after `getSyncedStateClient`
+  // (or after a reconnect) when they need the underlying session to exist
+  // before asserting on it.
+  async warmUp(endpoint: string = DEFAULT_SYNCED_STATE_PATH): Promise<void> {
+    const normalized = normalizeEndpoint(endpoint);
+    const promise = baseClientPromiseByEndpoint.get(normalized);
+    if (promise) {
+      await promise.catch(() => {});
+    }
+  },
 };

--- a/sdk/src/use-synced-state/worker.mts
+++ b/sdk/src/use-synced-state/worker.mts
@@ -1,8 +1,8 @@
-import { RpcTarget, newWorkersRpcResponse } from "capnweb";
 import { env } from "cloudflare:workers";
 import { route } from "../runtime/entries/router";
 import type { RequestInfo } from "../runtime/requestInfo/types";
 import { runWithRequestInfo } from "../runtime/requestInfo/worker";
+import { loadCapnweb } from "./capnweb-loader.mjs";
 import {
   SyncedStateServer,
   type SyncedStateValue,
@@ -18,114 +18,132 @@ export type SyncedStateRouteOptions = {
 
 const DEFAULT_SYNC_STATE_NAME = "syncedState";
 
-class SyncedStateProxy extends RpcTarget {
-  #stub: DurableObjectStub<SyncedStateServer>;
-  #keyHandler:
-    | ((
-        key: string,
-        stub: DurableObjectStub<SyncedStateServer>,
-      ) => Promise<string>)
-    | null;
-  #requestInfo: RequestInfo | null;
+type KeyHandler = (
+  key: string,
+  stub: DurableObjectStub<SyncedStateServer>,
+) => Promise<string>;
 
-  constructor(
-    stub: DurableObjectStub<SyncedStateServer>,
-    keyHandler:
-      | ((
+type SyncedStateProxyCtor = new (
+  stub: DurableObjectStub<SyncedStateServer>,
+  keyHandler: KeyHandler | null,
+  requestInfo: RequestInfo | null,
+) => unknown;
+
+let SyncedStateProxyClass: SyncedStateProxyCtor | null = null;
+
+async function getSyncedStateProxy(): Promise<{
+  SyncedStateProxy: SyncedStateProxyCtor;
+  newWorkersRpcResponse: typeof import("capnweb").newWorkersRpcResponse;
+}> {
+  const { RpcTarget, newWorkersRpcResponse } = await loadCapnweb();
+  if (!SyncedStateProxyClass) {
+    SyncedStateProxyClass = class SyncedStateProxy extends RpcTarget {
+      #stub: DurableObjectStub<SyncedStateServer>;
+      #keyHandler: KeyHandler | null;
+      #requestInfo: RequestInfo | null;
+
+      constructor(
+        stub: DurableObjectStub<SyncedStateServer>,
+        keyHandler: KeyHandler | null,
+        requestInfo: RequestInfo | null,
+      ) {
+        super();
+        this.#stub = stub;
+        this.#keyHandler = keyHandler;
+        this.#requestInfo = requestInfo;
+        // Set stub in DO instance so handlers can access it
+        if (stub && typeof (stub as any)._setStub === "function") {
+          void (stub as any)._setStub(stub);
+        }
+      }
+
+      /**
+       * Transforms a key using the keyHandler, preserving async context so requestInfo.ctx is available.
+       */
+      async #transformKey(key: string): Promise<string> {
+        if (!this.#keyHandler) {
+          return key;
+        }
+        if (this.#requestInfo) {
+          // Preserve async context when calling keyHandler so requestInfo.ctx is available
+          return await runWithRequestInfo(
+            this.#requestInfo,
+            async () => await this.#keyHandler!(key, this.#stub),
+          );
+        }
+        return await this.#keyHandler(key, this.#stub);
+      }
+
+      /**
+       * Calls a handler function, preserving async context so requestInfo.ctx is available.
+       */
+      #callHandler(
+        handler: (
           key: string,
           stub: DurableObjectStub<SyncedStateServer>,
-        ) => Promise<string>)
-      | null,
-    requestInfo: RequestInfo | null,
-  ) {
-    super();
-    this.#stub = stub;
-    this.#keyHandler = keyHandler;
-    this.#requestInfo = requestInfo;
-    // Set stub in DO instance so handlers can access it
-    if (stub && typeof (stub as any)._setStub === "function") {
-      void (stub as any)._setStub(stub);
-    }
+        ) => void,
+        key: string,
+        stub: DurableObjectStub<SyncedStateServer>,
+      ): void {
+        if (this.#requestInfo) {
+          // Preserve async context when calling handler so requestInfo.ctx is available
+          runWithRequestInfo(this.#requestInfo, () => {
+            handler(key, stub);
+          });
+        } else {
+          handler(key, stub);
+        }
+      }
+
+      async getState(key: string): Promise<SyncedStateValue> {
+        const transformedKey = await this.#transformKey(key);
+        return this.#stub.getState(transformedKey);
+      }
+
+      async setState(value: SyncedStateValue, key: string): Promise<void> {
+        const transformedKey = await this.#transformKey(key);
+        return this.#stub.setState(value, transformedKey);
+      }
+
+      async subscribe(key: string, client: any): Promise<void> {
+        const transformedKey = await this.#transformKey(key);
+
+        const subscribeHandler = SyncedStateServer.getSubscribeHandler();
+        if (subscribeHandler) {
+          this.#callHandler(subscribeHandler, transformedKey, this.#stub);
+        }
+
+        // dup the client if it is a function; otherwise, pass it as is;
+        // this is because the client is a WebSocketRpcSession, and we need to pass a new instance of the client to the DO;
+        const clientToPass =
+          typeof client.dup === "function" ? client.dup() : client;
+        return this.#stub.subscribe(transformedKey, clientToPass);
+      }
+
+      async unsubscribe(key: string, client: any): Promise<void> {
+        const transformedKey = await this.#transformKey(key);
+
+        // Call unsubscribe handler before unsubscribe, similar to subscribe handler
+        // This ensures the handler is called even if the unsubscribe doesn't find a match
+        // or if the RPC call fails
+        const unsubscribeHandler = SyncedStateServer.getUnsubscribeHandler();
+        if (unsubscribeHandler) {
+          this.#callHandler(unsubscribeHandler, transformedKey, this.#stub);
+        }
+
+        try {
+          await this.#stub.unsubscribe(transformedKey, client);
+        } catch (error) {
+          // Ignore errors during unsubscribe - handler has already been called
+          // This prevents RPC stub disposal errors from propagating
+        }
+      }
+    } as unknown as SyncedStateProxyCtor;
   }
-
-  /**
-   * Transforms a key using the keyHandler, preserving async context so requestInfo.ctx is available.
-   */
-  async #transformKey(key: string): Promise<string> {
-    if (!this.#keyHandler) {
-      return key;
-    }
-    if (this.#requestInfo) {
-      // Preserve async context when calling keyHandler so requestInfo.ctx is available
-      return await runWithRequestInfo(
-        this.#requestInfo,
-        async () => await this.#keyHandler!(key, this.#stub),
-      );
-    }
-    return await this.#keyHandler(key, this.#stub);
-  }
-
-  /**
-   * Calls a handler function, preserving async context so requestInfo.ctx is available.
-   */
-  #callHandler(
-    handler: (key: string, stub: DurableObjectStub<SyncedStateServer>) => void,
-    key: string,
-    stub: DurableObjectStub<SyncedStateServer>,
-  ): void {
-    if (this.#requestInfo) {
-      // Preserve async context when calling handler so requestInfo.ctx is available
-      runWithRequestInfo(this.#requestInfo, () => {
-        handler(key, stub);
-      });
-    } else {
-      handler(key, stub);
-    }
-  }
-
-  async getState(key: string): Promise<SyncedStateValue> {
-    const transformedKey = await this.#transformKey(key);
-    return this.#stub.getState(transformedKey);
-  }
-
-  async setState(value: SyncedStateValue, key: string): Promise<void> {
-    const transformedKey = await this.#transformKey(key);
-    return this.#stub.setState(value, transformedKey);
-  }
-
-  async subscribe(key: string, client: any): Promise<void> {
-    const transformedKey = await this.#transformKey(key);
-
-    const subscribeHandler = SyncedStateServer.getSubscribeHandler();
-    if (subscribeHandler) {
-      this.#callHandler(subscribeHandler, transformedKey, this.#stub);
-    }
-
-    // dup the client if it is a function; otherwise, pass it as is;
-    // this is because the client is a WebSocketRpcSession, and we need to pass a new instance of the client to the DO;
-    const clientToPass =
-      typeof client.dup === "function" ? client.dup() : client;
-    return this.#stub.subscribe(transformedKey, clientToPass);
-  }
-
-  async unsubscribe(key: string, client: any): Promise<void> {
-    const transformedKey = await this.#transformKey(key);
-
-    // Call unsubscribe handler before unsubscribe, similar to subscribe handler
-    // This ensures the handler is called even if the unsubscribe doesn't find a match
-    // or if the RPC call fails
-    const unsubscribeHandler = SyncedStateServer.getUnsubscribeHandler();
-    if (unsubscribeHandler) {
-      this.#callHandler(unsubscribeHandler, transformedKey, this.#stub);
-    }
-
-    try {
-      await this.#stub.unsubscribe(transformedKey, client);
-    } catch (error) {
-      // Ignore errors during unsubscribe - handler has already been called
-      // This prevents RPC stub disposal errors from propagating
-    }
-  }
+  return {
+    SyncedStateProxy: SyncedStateProxyClass,
+    newWorkersRpcResponse,
+  };
 }
 
 /**
@@ -173,6 +191,8 @@ export const syncedStateRoutes = (
 
     const id = namespace.idFromName(resolvedRoomName);
     const coordinator = namespace.get(id);
+    const { SyncedStateProxy, newWorkersRpcResponse } =
+      await getSyncedStateProxy();
     const proxy = new SyncedStateProxy(coordinator, keyHandler, requestInfo);
 
     return newWorkersRpcResponse(request, proxy);


### PR DESCRIPTION
## Summary

- Marks `capnweb` as an **optional peer dep** via `peerDependenciesMeta` so consumers who don't use `use-synced-state` no longer get an unmet-peer warning on install.
- Moves all `capnweb` imports in `use-synced-state/*` behind a dynamic loader, so projects that never use the feature don't need `capnweb` installed at all.
- If `capnweb` *is* missing when the feature is actually used (client `getSyncedStateClient`, `syncedStateRoutes`, or a routed `SyncedStateServer.fetch`), a clear error is thrown:

  > The "use-synced-state" feature requires the "capnweb" package, which is not installed. Install it with your package manager (e.g. `npm install capnweb` or `pnpm add capnweb`).

Fixes #1121.

## Implementation notes

- New `sdk/src/use-synced-state/capnweb-loader.mts`: single dynamic-import helper that caches the resolved module (or rejection) and wraps resolution failures in a friendly message.
- `SyncedStateServer.mts` and `worker.mts` used `RpcTarget` as a superclass at module top level — this is now deferred to a lazy class-factory called from the async `fetch` / `forwardRequest` paths, so importing the module no longer forces `capnweb` to resolve.
- `client-core.ts` `getSyncedStateClient` now returns a Proxy that eagerly kicks off the dynamic import and forwards async method calls to the underlying capnweb session once it's loaded. Semantics of subscription tracking, reconnect, and `onStatusChange` are unchanged.

## Test plan

- [x] `pnpm test` (516/516 pass)
- [x] `pnpm build` (clean tsc)
- [ ] Smoke: fresh `pnpm add rwsdk` in a project with no `capnweb` → no unmet-peer warning
- [ ] Smoke: consumer using `useSyncedState` without `capnweb` installed → friendly install-message error at first use

🤖 Generated with [Claude Code](https://claude.com/claude-code)