### PR TITLE
ci(release): use GITHUB_TOKEN instead of personal PAT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ on:
 permissions:
   id-token: write
   contents: write
+  actions: write
 
 env:
   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -47,10 +48,6 @@ jobs:
         with:
           # We need to fetch all history for semver to work correctly and to push changes.
           fetch-depth: 0
-          # This token should have write permissions to the repository.
-          # It's recommended to use a dedicated bot account's PAT.
-          # The secret should be named GH_TOKEN_FOR_RELEASES
-          token: ${{ secrets.GH_TOKEN_FOR_RELEASES }}
 
       - name: Set up Git user
         run: |
@@ -101,7 +98,7 @@ jobs:
       - name: Create GitHub Release
         if: success() && github.event.inputs.create_gh_release == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN_FOR_RELEASES }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           FLAGS="--generate-notes"
           VERSION_TYPE="${{ github.event.inputs.version_type }}"
@@ -124,6 +121,15 @@ jobs:
 
           echo "Creating GitHub release for tag ${{ env.TAG_NAME }} with flags: $FLAGS"
           gh release create ${{ env.TAG_NAME }} $FLAGS
+
+      - name: Dispatch release-artifacts workflow
+        if: success() && env.TAG_NAME != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Tag pushes made with GITHUB_TOKEN don't trigger other workflows,
+          # so we dispatch release-artifacts.yml explicitly.
+          gh workflow run release-artifacts.yml --ref "${{ env.TAG_NAME }}"
 
       - name: Prune node_modules for artifact upload
         if: failure() && steps.release_script.outputs.project-dir


### PR DESCRIPTION
## Problem

When v1.2.0 was released, the release didn't finish. The package reached npm, but no tag or GitHub Release was created (#1158).

The reason: the release workflow was using a personal token that belonged to one person. That token lost write access to the repo, so the final "push to GitHub" step was denied. npm had already been published by then.

## Solution

Stop using a personal token. Use the built-in token that GitHub hands every workflow run. It's tied to the workflow, not a person, so it can't expire with someone's account or lose access.

Three small changes to `release.yml`:

1. Remove the personal token from the checkout step and from the "Create GitHub Release" step. The built-in token takes over.
2. Give the workflow permission to start other workflows.
3. At the end, explicitly start the "release artifacts" workflow. The built-in token can't trigger other workflows automatically, so we do it by hand.

## Related change (already applied)

The `main` branch had a rule saying "pull requests required" but with 0 approvals. It wasn't really protecting anything, but it did block the release workflow from pushing directly — which is why the old setup relied on a personal token with admin powers to get around it. That rule has been removed. Force-push and branch-deletion blocks on `main` are unchanged.

## Cleanup after merge

The `GH_TOKEN_FOR_RELEASES` secret is no longer used by anything and can be deleted.

cc @justinvdm — heads-up on the unused secret and the branch-protection tweak.

## Test plan

- [ ] Run a test release and confirm: the tag pushes, the GitHub Release is created, and the release-artifacts workflow runs.
- [ ] Confirm no other workflow still references `GH_TOKEN_FOR_RELEASES` before deleting the secret.
- [ ] agent-ci was not run locally (needs Docker, not available here) — please run it in CI before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)