### PR TITLE
starter: fix FOUC and font flash on slow networks

### DIFF
--- a/starter/src/app/document.tsx
+++ b/starter/src/app/document.tsx
@@ -6,6 +6,17 @@ export const Document: React.FC<{ children: React.ReactNode }> = ({
       <meta charSet="utf-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
       <title>@redwoodjs/starter-minimal</title>
+      <link rel="preconnect" href="https://fonts.googleapis.com" />
+      <link
+        rel="preconnect"
+        href="https://fonts.gstatic.com"
+        crossOrigin=""
+      />
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,100..900;1,100..900&family=Playfair+Display:ital,wght@0,400..900;1,400..900&display=optional"
+        precedence="first"
+      />
       <link rel="modulepreload" href="/src/client.tsx" />
     </head>
     <body>

--- a/starter/src/app/pages/welcome.module.css
+++ b/starter/src/app/pages/welcome.module.css
@@ -4,8 +4,6 @@
 * _Feel free to delete this file_
 **/
 
-@import url("https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,100..900;1,100..900&family=Playfair+Display:ital,wght@0,400..900;1,400..900&display=swap");
-
 :root {
   --color-baige: #f4eedf;
   --color-orange: #f47238;


### PR DESCRIPTION
## Context

Follow-up to #1083. The production FOUC fix in the SDK itself is already released and working (the app stylesheet is emitted into the document head with `data-precedence="first"` and hoisted by React 19). However the starter's welcome page still had a visible flash on slow connections. Investigation showed the remaining issue was entirely in the starter's own authoring choices around how Google Fonts are loaded — not in the SDK.

**No changes to `rwsdk` itself in this PR — starter only.**

## Previous behaviour

- `welcome.module.css` started with `@import url("https://fonts.googleapis.com/...&display=swap")`.
- A nested `@import` inside a CSS file is a **sequential** load: the browser only discovers the Google Fonts URL after the app CSS has finished downloading and parsing. The font CSS then makes a second round-trip, and only after that the woff2 files are fetched.
- `display=swap` further instructs the browser to paint text immediately in a fallback font and *swap* to the web font when the woff2 arrives — FOUT by design.
- Net effect on slow (3G) connections: the page paints in a fallback font, then flashes to the web font as soon as the font files finally land.

## New behaviour

- The `@import` is removed from `welcome.module.css`.
- `Document.tsx` now declares the Google Fonts stylesheet directly in the `<head>`, alongside `<link rel="preconnect">` hints for `fonts.googleapis.com` and `fonts.gstatic.com`. The font request now starts at the very beginning of HTML parse, in parallel with the app CSS, over an already-warmed connection.
- The stylesheet link has `precedence="first"`, which opts it into React 19's stylesheet resource hoisting so it lands at the top of the `<head>` instead of being demoted below the `modulepreload` tags.
- The font-display strategy is switched from `swap` to `optional`. With `optional`, the browser gives the font a ~100ms block period, and if it hasn't arrived by then the fallback is committed for the rest of the page load — the browser will **not** swap later. This is the only `font-display` value whose swap period is zero, so it is the only one that fully eliminates the swap flash on slow networks.

## Trade-off

`display=optional` chooses "no flash, possibly wrong font" over "right font, visible swap":

- On a fast or cached connection the woff2 arrives within the 100ms block window and the web font is used on first paint — the intended design.
- On a slow (3G) connection on a first visit, the woff2 does not arrive in 100ms, so the fallback font sticks for the whole page load. The user sees a consistent, non-flashing page in the fallback font, and the web font is cached for subsequent navigations.

We consider this the better default for a starter: a predictable first paint without a visible flash is preferable to a correct-but-jarring swap. Projects that want the web font on first paint at the cost of a swap (or of self-hosting the woff2 files) can change the strategy locally.

## Verification

- [x] Fresh `create-rwsdk` project on `rwsdk@1.2.1`, rebuilt with these changes: `<head>` now contains both the app CSS and the Google Fonts stylesheet with `data-precedence="first"`, ordered before modulepreloads.
- [x] Verified on a throttled 3G profile that the swap flash no longer occurs.

<img width="1664" height="1080" alt="Cap 2026-04-20 at 09 08 20" src="https://github.com/user-attachments/assets/eb2d1e51-a43f-4c12-8289-af78be0e58cf" />
