### PR TITLE
fix(use-synced-state): surface clear error when capnweb version is incompatible

### DIFF
--- a/sdk/src/use-synced-state/capnweb-loader.mts
+++ b/sdk/src/use-synced-state/capnweb-loader.mts
@@ -2,13 +2,28 @@ let capnwebPromise: Promise<typeof import("capnweb")> | null = null;
 
 export function loadCapnweb(): Promise<typeof import("capnweb")> {
   if (!capnwebPromise) {
-    capnwebPromise = import("capnweb").catch(() => {
-      throw new Error(
-        'The "use-synced-state" feature requires the "capnweb" package, ' +
-          'which is not installed. Install it with your package manager ' +
-          '(e.g. `npm install capnweb` or `pnpm add capnweb`).',
-      );
-    });
+    capnwebPromise = import("capnweb")
+      .catch(() => {
+        throw new Error(
+          'The "use-synced-state" feature requires the "capnweb" package, ' +
+            "which is not installed. Install it with your package manager " +
+            "(e.g. `npm install capnweb` or `pnpm add capnweb`).",
+        );
+      })
+      .then((mod) => {
+        if (
+          typeof (mod as Record<string, unknown>).newWebSocketRpcSession !==
+          "function"
+        ) {
+          throw new Error(
+            'The installed "capnweb" version is incompatible with rwsdk ' +
+              'use-synced-state: it does not export "newWebSocketRpcSession". ' +
+              'Ensure "capnweb" matches rwsdk\'s peer-dependency range ' +
+              "(see rwsdk's package.json > peerDependencies.capnweb).",
+          );
+        }
+        return mod;
+      });
   }
   return capnwebPromise;
 }


### PR DESCRIPTION
## Summary

`loadCapnweb` in `use-synced-state/capnweb-loader.mts` currently handles the "capnweb not installed at all" case with a clear, actionable error. It does **not** handle the "capnweb is installed but at an incompatible version" case — when that happens, the error surfaces as a cryptic runtime failure deep in user code, e.g.:

```
TypeError: d.newWebSocketRpcSession is not a function
  at <consumer component using useSyncedState>
```

This PR adds a shape check on the resolved module: if `newWebSocketRpcSession` (the symbol use-synced-state actually calls) isn't a function on the loaded module, we throw an actionable error directing the user to rwsdk's `peerDependencies.capnweb` range.

## Motivation

Hit this in production after upgrading rwsdk from 1.1.0 → 1.2.3 in a pnpm monorepo. capnweb is an optional peer dep, so pnpm didn't auto-install it, and an orphaned older capnweb from a prior install was still present in the pnpm store and resolvable at runtime. All `useSyncedState` flows (notifications, realtime sync, etc.) broke at once with the "not a function" error above. Took ~30 minutes to trace the minified runtime error back to the actual root cause: capnweb version mismatch against rwsdk's peer-dep range (`~0.5.0`).

For reference, this is the consumer-side fix we shipped on our end (adding `capnweb` as an explicit dep at the peer-dep version): **[goprzm/przm#1312](https://github.com/goprzm/przm/pull/1312)** — that PR's description has the full debugging trail. This upstream PR is the complementary fix: making the failure mode obvious to the next consumer who hits it, so they don't go through the same 30-minute debug session.

This check turns that into a ~30-second diagnosis: the user sees the clear error message, checks rwsdk's `peerDependencies.capnweb`, bumps their install, done.

## Changes

- `sdk/src/use-synced-state/capnweb-loader.mts` — chain `.then(...)` after the existing `.catch(...)`; if the resolved module lacks `newWebSocketRpcSession`, throw a clear version-mismatch error. Untouched happy path for compatible versions; untouched error text for the not-installed case.

## Alternatives considered

- **Checking more symbols**: I limited the check to `newWebSocketRpcSession` — the one symbol `client-core.ts` actually calls. Broader checks would risk false positives if capnweb legitimately rearranges internal exports between compatible versions.
- **Making capnweb a required dep**: would burden every rwsdk consumer (including those not using `use-synced-state`) with a dependency they'll never import. The optional-peer design is the right choice; only the error surface needed improvement.

## Test plan

- [x] `pnpm --filter rwsdk build` — clean, no tsc errors.

I didn't add a unit test for the new branch because the loader is cached in module scope (`capnwebPromise` is a module-level `let`), which makes isolated unit testing awkward without a reset helper that feels out of scope for this tiny fix. Happy to add one if you'd prefer — can add an `__resetCapnwebPromiseForTesting` helper and a small vitest spec that mocks `capnweb` to return an empty module and asserts the new error is thrown.