### PR TITLE
fix(worker): allow registerServerFunctionWrap to be called more than once

### DIFF
--- a/sdk/src/runtime/server.test.ts
+++ b/sdk/src/runtime/server.test.ts
@@ -120,12 +120,20 @@ describe("registerServerFunctionWrap", () => {
     expect(result).toBeInstanceOf(Response);
   });
 
-  it("throws if called more than once", () => {
-    registerServerFunctionWrap(async (fn, args) => fn(...args));
+  it("replaces the wrapper if called more than once", async () => {
+    const first = vi.fn((fn, args, _type) => fn(...args));
+    const second = vi.fn((fn, args, _type) => fn(...args));
 
-    expect(() => {
-      registerServerFunctionWrap(async (fn, args) => fn(...args));
-    }).toThrow("registerServerFunctionWrap() has already been called");
+    registerServerFunctionWrap(first);
+    registerServerFunctionWrap(second);
+
+    const action = serverAction(async function run() {
+      return "ok";
+    });
+    await action();
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledOnce();
   });
 
   it("without registration, handlers work normally", async () => {

--- a/sdk/src/runtime/server.ts
+++ b/sdk/src/runtime/server.ts
@@ -33,7 +33,7 @@ let globalWrap: ServerFunctionWrap | undefined;
  * handler function, its arguments, and the type ("action" or "query").
  * Interruptors run *outside* the wrapper.
  *
- * Throws if called more than once.
+ * Only one wrapper is active at a time; the most recent call wins.
  *
  * @example
  * ```ts
@@ -49,12 +49,6 @@ let globalWrap: ServerFunctionWrap | undefined;
  * ```
  */
 export function registerServerFunctionWrap(wrap: ServerFunctionWrap) {
-  if (globalWrap) {
-    throw new Error(
-      "registerServerFunctionWrap() has already been called. " +
-        "Only one wrapper can be registered.",
-    );
-  }
   globalWrap = wrap;
 }
 


### PR DESCRIPTION
## Problem

A user reported that after adding `registerServerFunctionWrap` to their project for better instrumentation, their app would break during development any time the dev server hot-reloaded. The error was:

> registerServerFunctionWrap() has already been called. Only one wrapper can be registered.

The app would stop loading until a full restart. This happens because hot-reload re-runs the module that registers the wrapper, and the framework was treating that second call as a programming mistake.

## Solution

Drop the one-call-only check. The most recent call now simply replaces the previous wrapper. This is safe: there is still only one active wrapper at a time, and normal dev hot-reloading no longer breaks the app.

## Test plan

- [x] Registering a wrapper twice no longer throws; the second wrapper is the one that runs.
- [x] Hot-reloading a worker entry that calls `registerServerFunctionWrap` no longer surfaces the error in the dev server log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)