### PR TITLE
docs: add Vite 8 migration guide

### DIFF
--- a/docs/src/app/sidebar.ts
+++ b/docs/src/app/sidebar.ts
@@ -11,7 +11,8 @@ export const pageTree: PageTree.Root = {
   children: [
     { type: "separator", name: "Get Started" },
     p("Quick Start", "getting-started/quick-start"),
-    p("Migrating to 1.x", "migrating"),
+    p("Migrating to 1.x", "migrating-to-v1"),
+    p("Migrating to Vite 8", "migrating-to-vite-8"),
 
     { type: "separator", name: "Core" },
     p("Overview", "core/overview"),

--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -42,7 +42,7 @@ RedwoodSDK is just a plugin for Vite, so you can use the same commands to run th
 />
 
 ```bash
-VITE v6.2.0  ready in 500 ms
+VITE v8.0.10  ready in 500 ms
 
 ➜  Local:   http://localhost:5173/
 ➜  Network: use --host to expose

--- a/docs/src/content/docs/guides/frontend/chakra-ui.mdx
+++ b/docs/src/content/docs/guides/frontend/chakra-ui.mdx
@@ -59,34 +59,26 @@ Since RedwoodSDK is based on React and Vite, we can work through the ["Using Vit
 
    For JavaScript projects, create a `jsconfig.json` file with the same configuration.
 
-4. Install Vite TypeScript Paths Plugin
-
-   To sync your TypeScript paths with Vite, install the `vite-tsconfig-paths` plugin:
-
-   <PackageManagers type="exec" args="install -D vite-tsconfig-paths" />
-
-5. Configure the Vite Plugin
+4. Configure the Vite Plugin
 
    ```ts title="vite.config.mts"
    import { defineConfig } from "vite";
    import react from "@vitejs/plugin-react";
-   import tsconfigPaths from "vite-tsconfig-paths"; // [!code ++]
    import { redwood } from "rwsdk/vite";
    import { cloudflare } from "@cloudflare/vite-plugin";
 
    export default defineConfig({
-     plugins: [ // [!code ++]
+     plugins: [
        cloudflare({
          viteEnvironment: { name: "worker" },
        }),
        redwood(),
        react(),
-       tsconfigPaths(),
      ],
    });
    ```
 
-6. Set Up the Provider
+5. Set Up the Provider
 
    The Chakra UI provider needs to wrap your application. In RedwoodSDK, you'll want to add this to your root component or layout.
 
@@ -130,7 +122,7 @@ Since RedwoodSDK is based on React and Vite, we can work through the ["Using Vit
    ]);
    ```
 
-7. Test Your Installation
+6. Test Your Installation
 
    Try using some Chakra UI components in your app to verify everything is working:
 
@@ -150,7 +142,7 @@ Since RedwoodSDK is based on React and Vite, we can work through the ["Using Vit
    }
    ```
 
-8. Run Development Server
+7. Run Development Server
 
    <PackageManagers type="run" args="dev" />
 

--- a/docs/src/content/docs/migrating-to-v1.mdx
+++ b/docs/src/content/docs/migrating-to-v1.mdx
@@ -1,7 +1,13 @@
 ---
 title: Migrating from 0.x to 1.x
-description: A guide for upgrading your RedwoodSDK project.
+description: A guide for upgrading your RedwoodSDK project from 0.x to 1.x.
 ---
+
+import { Aside } from "@/app/components/mdx";
+
+<Aside type="note">
+  Looking to upgrade from Vite 7 to Vite 8? See the [Vite 8 migration guide](/migrating-to-vite-8).
+</Aside>
 
 This guide is for users who have an existing RedwoodSDK project and wish to upgrade from a `0.x` version to `1.x`.
 

--- a/docs/src/content/docs/migrating-to-vite-8.mdx
+++ b/docs/src/content/docs/migrating-to-vite-8.mdx
@@ -1,0 +1,145 @@
+---
+title: Migrating to Vite 8
+description: Upgrade your RedwoodSDK project from Vite 7 to Vite 8.
+---
+
+import { Aside } from "@/app/components/mdx";
+
+This guide is for users who have an existing RedwoodSDK project on Vite 7 and wish to upgrade to Vite 8.
+
+## Overview
+
+RedwoodSDK now supports Vite 8, which uses Rolldown (a Rust-based bundler) for dependency pre-bundling. This upgrade brings significant performance improvements — most notably, the Vite 8 + Rolldown combination eliminates the per-module AST retention that could cause out-of-memory issues during builds of large projects.
+
+This guide covers the minimal changes needed to upgrade an existing project.
+
+## Required Changes
+
+### 1. Upgrade rwsdk
+
+First, upgrade to the latest version of rwsdk:
+
+```sh
+pnpm add rwsdk@latest
+```
+
+### 2. Upgrade Vite
+
+Upgrade Vite to version 8:
+
+```sh
+pnpm add -D vite@latest
+```
+
+Your `package.json` should now resolve to `vite@^8.0.0` or later.
+
+### 3. Upgrade @vitejs/plugin-react (if used)
+
+If your project uses `@vitejs/plugin-react`, upgrade to a version that supports Vite 8:
+
+```sh
+pnpm add -D @vitejs/plugin-react@latest
+```
+
+**Breaking change in v6:** The `babel` option was removed from `@vitejs/plugin-react`. If you were using the React Compiler via the `babel` option:
+
+```ts
+// BEFORE (v5)
+react({
+  babel: {
+    plugins: ['babel-plugin-react-compiler']
+  }
+})
+```
+
+You now need to add `@rolldown/plugin-babel` separately:
+
+```ts
+// AFTER (v6)
+import react, { reactCompilerPreset } from '@vitejs/plugin-react'
+import babel from '@rolldown/plugin-babel'
+
+// In your plugins array:
+react(),
+babel({ presets: [reactCompilerPreset()] })
+```
+
+Install the babel plugin:
+
+```sh
+pnpm add -D @rolldown/plugin-babel
+```
+
+If you prefer to stay on v5 for now, version `5.2.0` adds Vite 8 support without the API break:
+
+```sh
+pnpm add -D @vitejs/plugin-react@^5.2.0
+```
+
+### 4. Remove vite-tsconfig-paths (optional)
+
+Vite 8 has native TypeScript path resolution. If you were using `vite-tsconfig-paths`, you can remove it:
+
+```sh
+pnpm remove vite-tsconfig-paths
+```
+
+No config changes are needed — rwsdk enables `resolve.tsconfigPaths: true` automatically.
+
+### 5. Upgrade @tailwindcss/vite (if used)
+
+If you use Tailwind CSS with Vite:
+
+```sh
+pnpm add -D @tailwindcss/vite@latest
+```
+
+Version `4.2.4` and later support Vite 8.
+
+## What Changed Under the Hood
+
+Vite 8 switches from esbuild to Rolldown for `optimizeDeps` (dependency pre-bundling in development). This is transparent for most projects, but the change eliminates a major source of memory pressure:
+
+- **esbuild** retains the full AST for every module in the optimizer
+- **Rolldown** uses a Rust arena allocator that frees ASTs after transformation
+
+For large projects, this can mean the difference between builds completing normally and hitting Node's heap limit.
+
+## Verifying Your Migration
+
+After upgrading, verify everything works:
+
+```sh
+# Development server
+pnpm dev
+
+# Production build
+pnpm build
+
+# Run your test suite
+pnpm test
+```
+
+## Rollback
+
+If you encounter issues, you can temporarily pin Vite 7 while keeping the latest rwsdk:
+
+```sh
+pnpm add -D vite@~7.3.2
+```
+
+rwsdk continues to support Vite 7 for production builds.
+
+## Troubleshooting
+
+### Peer dependency warnings
+
+You may see warnings from packages that haven't updated their peer ranges yet. These are usually harmless. Check that the package has a version that supports Vite 8, and upgrade if needed.
+
+### __webpack_require__ errors in development
+
+If you see `ReferenceError: __webpack_require__ is not defined` in the browser console during development, make sure you are on the latest rwsdk version. This was fixed in the Vite 8 compatibility release.
+
+### CSS not loading in development
+
+If styles fail to load during `pnpm dev`, verify you are on the latest rwsdk. A CSS discovery fix for Rolldown was included in the Vite 8 release.

--- a/docs/src/content/docs/migrating-to-vite-8.mdx
+++ b/docs/src/content/docs/migrating-to-vite-8.mdx
@@ -17,10 +17,10 @@ This guide covers the minimal changes needed to upgrade an existing project.
 
 ### 1. Upgrade rwsdk
 
-First, upgrade to the latest version of rwsdk:
+First, install the canary release of rwsdk that supports Vite 8:
 
 ```sh
-pnpm add rwsdk@latest
+pnpm add rwsdk@canary
 ```
 
 ### 2. Upgrade Vite

--- a/docs/src/content/docs/migrating-to-vite-8.mdx
+++ b/docs/src/content/docs/migrating-to-vite-8.mdx
@@ -17,10 +17,10 @@ This guide covers the minimal changes needed to upgrade an existing project.
 
 ### 1. Upgrade rwsdk
 
-First, install the canary release of rwsdk that supports Vite 8:
+First, upgrade to the latest version of rwsdk:
 
 ```sh
-pnpm add rwsdk@canary
+pnpm add rwsdk@latest
 ```
 
 ### 2. Upgrade Vite


### PR DESCRIPTION
Adds a migration guide for upgrading from Vite 7 to Vite 8.

- New `migrating-to-vite-8.mdx` with upgrade steps, config changes, and troubleshooting
- Rename `migrating.mdx` → `migrating-to-v1.mdx` and add cross-link
- Update `quick-start.mdx` example output to VITE v8.0.10
- Remove `vite-tsconfig-paths` from `chakra-ui.mdx` (native in Vite 8)
- Update sidebar with both migration entries