### PR TITLE
fix(vite): restore Vite 8 Rolldown optimizeDeps plugins

### DIFF
--- a/sdk/src/runtime/render/assembleDocument.tsx
+++ b/sdk/src/runtime/render/assembleDocument.tsx
@@ -34,7 +34,7 @@ export const assembleDocument = ({
         dangerouslySetInnerHTML={{
           __html: `globalThis.__RWSDK_CONTEXT = ${JSON.stringify(
             clientContext,
-          )}`,
+          )};if(!globalThis.__webpack_require__){globalThis.__webpack_require__=function(id){throw new Error("rwsdk: __webpack_require__ called before client init for: "+id)};globalThis.__webpack_require__.u=function(){}}`,
         }}
       />
       <Stylesheets requestInfo={requestInfo} />

--- a/sdk/src/runtime/render/renderDocumentHtmlStream.tsx
+++ b/sdk/src/runtime/render/renderDocumentHtmlStream.tsx
@@ -48,7 +48,7 @@ export const renderDocumentHtmlStream = async ({
         dangerouslySetInnerHTML={{
           __html: `globalThis.__RWSDK_CONTEXT = ${JSON.stringify(
             clientContext,
-          )}`,
+          )};if(!globalThis.__webpack_require__){globalThis.__webpack_require__=function(id){throw new Error("rwsdk: __webpack_require__ called before client init for: "+id)};globalThis.__webpack_require__.u=function(){}}`,
         }}
       />
       <Stylesheets requestInfo={requestInfo} />

--- a/sdk/src/runtime/render/stylesheets.tsx
+++ b/sdk/src/runtime/render/stylesheets.tsx
@@ -10,7 +10,15 @@ const toManifestKey = (id: string) => (id.startsWith("/") ? id.slice(1) : id);
 
 const findCssForModule = (
   scriptId: string,
-  manifest: Record<string, { file: string; css?: string[] }>,
+  manifest: Record<
+    string,
+    {
+      file: string;
+      css?: string[];
+      imports?: string[];
+      dynamicImports?: string[];
+    }
+  >,
 ) => {
   const css = new Set<string>();
   const visited = new Set<string>();
@@ -29,6 +37,21 @@ const findCssForModule = (
     if (entry.css) {
       for (const href of entry.css) {
         css.add(href);
+      }
+    }
+
+    // context(justinvdm, 2026-04-23): Rolldown associates CSS with the
+    // chunk that imports the CSS file, which may be a dynamic import target
+    // rather than the entry chunk. Walk both static and dynamic imports to
+    // find CSS from transitive dependencies.
+    if (entry.imports) {
+      for (const importId of entry.imports) {
+        inner(importId);
+      }
+    }
+    if (entry.dynamicImports) {
+      for (const importId of entry.dynamicImports) {
+        inner(importId);
       }
     }
   };
@@ -52,6 +75,18 @@ export const Stylesheets = async ({
     const css = findCssForModule(scriptId, manifest);
     for (const entry of css) {
       allStylesheets.add(toAbsoluteHref(entry));
+    }
+  }
+
+  for (const [, entry] of Object.entries(manifest)) {
+    if ((entry as { isEntry?: boolean }).isEntry) {
+      const css = findCssForModule(
+        (entry as { src?: string }).src ?? "",
+        manifest,
+      );
+      for (const href of css) {
+        allStylesheets.add(toAbsoluteHref(href));
+      }
     }
   }
 

--- a/sdk/src/vite/addOptimizeDepsPlugin.mts
+++ b/sdk/src/vite/addOptimizeDepsPlugin.mts
@@ -1,0 +1,21 @@
+import type { EnvironmentOptions } from "vite";
+
+interface OptimizeDepsPlugin {
+  name: string;
+  resolveId?: (
+    id: string,
+    importer: string | undefined,
+    opts: { kind: string },
+  ) => any;
+  load?: (id: string) => any;
+}
+
+export function addOptimizeDepsPlugin(
+  config: EnvironmentOptions,
+  plugin: OptimizeDepsPlugin,
+): void {
+  config.optimizeDeps ??= {};
+  config.optimizeDeps.rolldownOptions ??= {};
+  (config.optimizeDeps.rolldownOptions as any).plugins ??= [];
+  ((config.optimizeDeps.rolldownOptions as any).plugins as any[]).push(plugin);
+}

--- a/sdk/src/vite/configPlugin.mts
+++ b/sdk/src/vite/configPlugin.mts
@@ -67,11 +67,13 @@ export const configPlugin = ({
         ],
         exclude: [],
         entries: [workerEntryPathname],
-        esbuildOptions: {
-          jsx: "automatic",
-          jsxImportSource: "react",
-          define: {
-            "process.env.NODE_ENV": JSON.stringify(mode),
+        rolldownOptions: {
+          transform: {
+            jsx: "react-jsx",
+            define: {
+              "process.env.NODE_ENV": JSON.stringify(mode),
+              "__webpack_require__": "globalThis.__webpack_require__",
+            },
           },
         },
       },
@@ -125,12 +127,13 @@ export const configPlugin = ({
               "rwsdk/turnstile",
             ],
             entries: [],
-            esbuildOptions: {
-              jsx: "automatic",
-              jsxImportSource: "react",
-              plugins: [],
-              define: {
-                "process.env.NODE_ENV": JSON.stringify(mode),
+            rolldownOptions: {
+              transform: {
+                jsx: "react-jsx",
+                define: {
+                  "process.env.NODE_ENV": JSON.stringify(mode),
+                  "__webpack_require__": "globalThis.__webpack_require__",
+                },
               },
             },
           },
@@ -162,12 +165,13 @@ export const configPlugin = ({
               "rwsdk/realtime/durableObject",
               "rwsdk/realtime/worker",
             ],
-            esbuildOptions: {
-              jsx: "automatic",
-              jsxImportSource: "react",
-              plugins: [],
-              define: {
-                "process.env.NODE_ENV": JSON.stringify(mode),
+            rolldownOptions: {
+              transform: {
+                jsx: "react-jsx",
+                define: {
+                  "process.env.NODE_ENV": JSON.stringify(mode),
+                  "__webpack_require__": "globalThis.__webpack_require__",
+                },
               },
             },
           },

--- a/sdk/src/vite/createDirectiveLookupPlugin.mts
+++ b/sdk/src/vite/createDirectiveLookupPlugin.mts
@@ -2,6 +2,7 @@ import debug from "debug";
 import MagicString from "magic-string";
 import path from "path";
 import { Plugin, ViteDevServer } from "vite";
+import { addOptimizeDepsPlugin } from "./addOptimizeDepsPlugin.mjs";
 import {
   VENDOR_CLIENT_BARREL_EXPORT_PATH,
   VENDOR_SERVER_BARREL_EXPORT_PATH,
@@ -99,43 +100,30 @@ export const createDirectiveLookupPlugin = async ({
       }
       log("Configuring environment: env=%s", env);
 
-      viteConfig.optimizeDeps ??= {};
-      viteConfig.optimizeDeps.esbuildOptions ??= {};
-      viteConfig.optimizeDeps.esbuildOptions.plugins ??= [];
-      viteConfig.optimizeDeps.esbuildOptions.plugins.push({
+      const escapedVirtualModuleName = config.virtualModuleName.replace(
+        /[-\/\\^$*+?.()|[\]{}]/g,
+        "\\$&",
+      );
+      const escapedPrefixedModuleName =
+        `/@id/${config.virtualModuleName}`.replace(
+          /[-\/\\^$*+?.()|[\]{}]/g,
+          "\\$&",
+        );
+      const lookupFilter = new RegExp(
+        `^(${escapedVirtualModuleName}|${escapedPrefixedModuleName})\\.js$`,
+      );
+
+      addOptimizeDepsPlugin(viteConfig, {
         name: `rwsdk:${config.pluginName}`,
-        setup(build) {
-          log("Setting up esbuild plugin for %s", config.virtualModuleName);
-
-          // Handle both direct virtual module name and /@id/ prefixed version
-          const escapedVirtualModuleName = config.virtualModuleName.replace(
-            /[-\/\\^$*+?.()|[\]{}]/g,
-            "\\$&",
-          );
-          const escapedPrefixedModuleName =
-            `/@id/${config.virtualModuleName}`.replace(
-              /[-\/\\^$*+?.()|[\]{}]/g,
-              "\\$&",
-            );
-
-          build.onResolve(
-            {
-              filter: new RegExp(
-                `^(${escapedVirtualModuleName}|${escapedPrefixedModuleName})\\.js$`,
-              ),
-            },
-            () => {
-              process.env.VERBOSE &&
-                log(
-                  "Esbuild onResolve: marking %s as external",
-                  config.virtualModuleName,
-                );
-              return {
-                path: `${config.virtualModuleName}.js`,
-                external: true,
-              };
-            },
-          );
+        resolveId(id: string) {
+          if (lookupFilter.test(id)) {
+            process.env.VERBOSE &&
+              log("Marking %s as external", config.virtualModuleName);
+            return {
+              id: `${config.virtualModuleName}.js`,
+              external: true,
+            };
+          }
         },
       });
 
@@ -146,6 +134,7 @@ export const createDirectiveLookupPlugin = async ({
       if (shouldOptimizeForEnv) {
         log("Applying optimizeDeps and aliasing for environment: %s", env);
 
+        viteConfig.optimizeDeps ??= {};
         viteConfig.optimizeDeps.include ??= [];
 
         for (const file of files) {

--- a/sdk/src/vite/directiveModulesDevPlugin.mts
+++ b/sdk/src/vite/directiveModulesDevPlugin.mts
@@ -158,62 +158,43 @@ export const directiveModulesDevPlugin = ({
           entries.push(APP_SERVER_BARREL_PATH);
         }
 
-        env.optimizeDeps.esbuildOptions ??= {};
-        env.optimizeDeps.esbuildOptions.plugins ??= [];
-        env.optimizeDeps.esbuildOptions.plugins.unshift({
+        const appBarrelPaths = [
+          APP_CLIENT_BARREL_PATH,
+          APP_SERVER_BARREL_PATH,
+        ];
+        const appBarrelFilter = new RegExp(
+          `(${appBarrelPaths
+            .map((p) => p.replace(/\\/g, "\\\\"))
+            .join("|")})$`,
+        );
+        const BARREL_PREFIX = "\0rwsdk-app-barrel:";
+
+        env.optimizeDeps.rolldownOptions ??= {};
+        (env.optimizeDeps.rolldownOptions as any).plugins ??= [];
+        ((env.optimizeDeps.rolldownOptions as any).plugins as any[]).unshift({
           name: "rwsdk:app-barrel-blocker",
-          setup(build) {
-            const appBarrelPaths = [
-              APP_CLIENT_BARREL_PATH,
-              APP_SERVER_BARREL_PATH,
-            ];
-            const appBarrelFilter = new RegExp(
-              `(${appBarrelPaths
-                .map((p) => p.replace(/\\/g, "\\\\"))
-                .join("|")})$`,
-            );
+          async resolveId(id: string) {
+            await scanPromise;
 
-            build.onResolve({ filter: /.*/ }, async (args: any) => {
-              // Block all resolutions until the scan is complete.
-              await scanPromise;
+            if (appBarrelFilter.test(id)) {
+              return `${BARREL_PREFIX}${id}`;
+            }
 
-              // Handle app barrel files
-              if (appBarrelFilter.test(args.path)) {
-                return {
-                  path: args.path,
-                  namespace: "rwsdk-app-barrel-ns",
-                };
-              }
-              // context(justinvdm, 11 Sep 2025): Prevent Vite from
-              // externalizing our application files. If we don't, paths
-              // imported in our application barrel files will be marked as
-              // external, and thus not scanned for dependencies.
-              if (
-                args.path.startsWith("/") &&
-                (args.path.includes("/src/") ||
-                  args.path.includes("/generated/")) &&
-                !args.path.includes("node_modules")
-              ) {
-                // By returning a result, we claim the module and prevent vite:dep-scan
-                // from marking it as external.
-                return {
-                  path: args.path,
-                };
-              }
-            });
-
-            build.onLoad(
-              { filter: /.*/, namespace: "rwsdk-app-barrel-ns" },
-              (args) => {
-                const isServerBarrel = args.path.includes("app-server-barrel");
-                const files = isServerBarrel ? serverFiles : clientFiles;
-                const content = generateAppBarrelContent(files, projectRootDir);
-                return {
-                  contents: content,
-                  loader: "js",
-                };
-              },
-            );
+            if (
+              id.startsWith("/") &&
+              (id.includes("/src/") || id.includes("/generated/")) &&
+              !id.includes("node_modules")
+            ) {
+              return id;
+            }
+          },
+          load(id: string) {
+            if (id.startsWith(BARREL_PREFIX)) {
+              const barrelPath = id.slice(BARREL_PREFIX.length);
+              const isServerBarrel = barrelPath.includes("app-server-barrel");
+              const files = isServerBarrel ? serverFiles : clientFiles;
+              return generateAppBarrelContent(files, projectRootDir);
+            }
           },
         });
       }

--- a/sdk/src/vite/directivesPlugin.mts
+++ b/sdk/src/vite/directivesPlugin.mts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { ViteDevServer } from "vite";
 import { Plugin } from "vite";
 import { normalizeModulePath } from "../lib/normalizeModulePath.mjs";
+import { addOptimizeDepsPlugin } from "./addOptimizeDepsPlugin.mjs";
 import { transformClientComponents } from "./transformClientComponents.mjs";
 import { transformServerFunctions } from "./transformServerFunctions.mjs";
 
@@ -120,158 +121,69 @@ export const directivesPlugin = ({
         return;
       }
       process.env.VERBOSE && log("Configuring environment: env=%s", env);
-      config.optimizeDeps ??= {};
-      config.optimizeDeps.esbuildOptions ??= {};
-      config.optimizeDeps.esbuildOptions.plugins ??= [];
 
-      config.optimizeDeps.esbuildOptions.plugins.push({
-        name: "rsc-directives-esbuild-transform",
-        setup(build) {
-          log("Setting up esbuild plugin for environment: %s", env);
-          build.onLoad(
-            { filter: /\.(js|ts|jsx|tsx|mts|mjs|cjs)$/ },
-            async (args) => {
-              process.env.VERBOSE &&
-                log(
-                  "Esbuild onLoad called for environment=%s, path=%s",
-                  env,
-                  args.path,
-                );
+      const directivesFileFilter = /\.(js|ts|jsx|tsx|mts|mjs|cjs)$/;
 
-              const normalizedPath = normalizeModulePath(
-                args.path,
-                projectRootDir,
-              );
+      async function handleDirectivesLoad(filePath: string) {
+        const normalizedPath = normalizeModulePath(filePath, projectRootDir);
 
-              // context(justinvdm,2025-06-15): If we're in app code,
-              // we will be doing the transform work in the vite plugin hooks,
-              // the only reason we're in esbuild land for app code is for
-              // dependency discovery, so we can skip transform work
-              // and use heuristics instead - see below inside if block
-              if (!args.path.includes("node_modules")) {
-                if (clientFiles.has(normalizedPath)) {
-                  // context(justinvdm,2025-06-15): If this is a client file:
-                  // * for ssr and client envs we can skip so esbuild looks at the
-                  // original source code to discovery dependencies
-                  // * for worker env, the transform would have just created
-                  // references and dropped all imports, so we can just return empty code
-                  if (env === "client" || env === "ssr") {
-                    log(
-                      "Esbuild onLoad skipping client module in app code for client or ssr env, path=%s",
-                      args.path,
-                    );
-                    return undefined;
-                  } else {
-                    log(
-                      "Esbuild onLoad returning empty code for server module in app code for worker env, path=%s to bypass esbuild dependency discovery",
-                      args.path,
-                    );
-                    return {
-                      contents: "",
-                      loader: "js",
-                    };
-                  }
-                } else if (serverFiles.has(normalizedPath)) {
-                  // context(justinvdm,2025-06-15): If this is a server file:
-                  // * for worker env, we can skip so esbuild looks at the
-                  // original source code to discovery dependencies
-                  // * for ssr and client envs, the transform would have just created
-                  // references and dropped all imports, so we can just return empty code
-                  if (env === "worker") {
-                    log(
-                      "Esbuild onLoad skipping server module in app code for worker env, path=%s",
-                      args.path,
-                    );
-                    return undefined;
-                  } else if (env === "ssr" || env === "client") {
-                    log(
-                      "Esbuild onLoad returning empty code for server module in app code for ssr or client env, path=%s",
-                      args.path,
-                    );
-                    return {
-                      contents: "",
-                      loader: "js",
-                    };
-                  }
-                }
-              }
+        if (!filePath.includes("node_modules")) {
+          if (clientFiles.has(normalizedPath)) {
+            if (env === "client" || env === "ssr") {
+              return undefined;
+            } else {
+              return { code: "", moduleType: "js" as const };
+            }
+          } else if (serverFiles.has(normalizedPath)) {
+            if (env === "worker") {
+              return undefined;
+            } else if (env === "ssr" || env === "client") {
+              return { code: "", moduleType: "js" as const };
+            }
+          }
+        }
 
-              let code: string;
+        let code: string;
+        try {
+          code = await fs.readFile(filePath, "utf-8");
+        } catch {
+          return undefined;
+        }
 
-              try {
-                code = await fs.readFile(args.path, "utf-8");
-              } catch {
-                process.env.VERBOSE &&
-                  log(
-                    "Failed to read file: %s, environment=%s",
-                    args.path,
-                    env,
-                  );
-                return undefined;
-              }
+        const clientResult = await transformClientComponents(
+          code,
+          normalizedPath,
+          { environmentName: env, clientFiles, isEsbuild: true },
+        );
+        if (clientResult) {
+          return { code: clientResult.code, moduleType: getLoader(filePath) };
+        }
 
-              const clientResult = await transformClientComponents(
-                code,
-                normalizedPath,
-                {
-                  environmentName: env,
-                  clientFiles,
-                  isEsbuild: true,
-                },
-              );
+        const serverResult = transformServerFunctions(
+          code,
+          normalizedPath,
+          env as "client" | "worker" | "ssr",
+          serverFiles,
+        );
+        if (serverResult) {
+          return { code: serverResult.code, moduleType: getLoader(filePath) };
+        }
 
-              if (clientResult) {
-                process.env.VERBOSE &&
-                  log(
-                    "Esbuild client component transformation successful for environment=%s, path=%s",
-                    env,
-                    args.path,
-                  );
-                process.env.VERBOSE &&
-                  log(
-                    "Esbuild client component transformation for environment=%s, path=%s, code: %j",
-                    env,
-                    args.path,
-                    clientResult.code,
-                  );
-                return {
-                  contents: clientResult.code,
-                  loader: getLoader(args.path),
-                };
-              }
+        return undefined;
+      }
 
-              const serverResult = transformServerFunctions(
-                code,
-                normalizedPath,
-                env as "client" | "worker" | "ssr",
-                serverFiles,
-              );
-
-              if (serverResult) {
-                process.env.VERBOSE &&
-                  log(
-                    "Esbuild server function transformation successful for environment=%s, path=%s",
-                    env,
-                    args.path,
-                  );
-                return {
-                  contents: serverResult.code,
-                  loader: getLoader(args.path),
-                };
-              }
-
-              process.env.VERBOSE &&
-                log(
-                  "Esbuild no transformation applied for environment=%s, path=%s",
-                  env,
-                  args.path,
-                );
-            },
-          );
+      addOptimizeDepsPlugin(config, {
+        name: "rsc-directives-transform",
+        async load(id: string) {
+          if (!directivesFileFilter.test(id)) {
+            return;
+          }
+          const result = await handleDirectivesLoad(id);
+          if (result) {
+            return { code: result.code, moduleType: result.moduleType };
+          }
         },
       });
-      process.env.VERBOSE &&
-        log("Environment configuration complete for env=%s", env);
     },
   };
 };

--- a/sdk/src/vite/knownDepsResolverPlugin.mts
+++ b/sdk/src/vite/knownDepsResolverPlugin.mts
@@ -159,7 +159,7 @@ export const knownDepsResolverPlugin = ({
     Object.keys(ENV_IMPORT_MAPPINGS).length,
   );
 
-  function createEsbuildResolverPlugin(
+  function createResolverPlugin(
     envName: string,
     mappings: Map<string, string>,
   ) {
@@ -167,48 +167,38 @@ export const knownDepsResolverPlugin = ({
       return null;
     }
 
-    // Create reverse mapping from slugified names to original imports
-    // Vite converts "react-dom/server.edge" -> "react-dom_server__edge"
-    // Pattern: / becomes _, . becomes __
     const slugifiedToOriginal = new Map<string, string>();
-    for (const [original, resolved] of mappings) {
+    for (const [original] of mappings) {
       const slugified = original.replace(/\//g, "_").replace(/\./g, "__");
       slugifiedToOriginal.set(slugified, original);
     }
 
     return {
-      name: `rwsdk:known-dependencies-resolver-esbuild-${envName}`,
-      setup(build: any) {
-        build.onResolve({ filter: /.*/ }, (args: any) => {
-          let resolved: string | undefined = mappings.get(args.path);
+      name: `rwsdk:known-dependencies-resolver-${envName}`,
+      resolveId(id: string) {
+        let resolved: string | undefined = mappings.get(id);
 
-          // If not found, check if it's a slugified version
-          if (!resolved) {
-            const originalImport = slugifiedToOriginal.get(args.path);
-            if (originalImport) {
-              resolved = mappings.get(originalImport);
-            }
+        if (!resolved) {
+          const originalImport = slugifiedToOriginal.get(id);
+          if (originalImport) {
+            resolved = mappings.get(originalImport);
           }
+        }
 
-          if (!resolved) {
-            resolved = resolveKnownImport(
-              args.path,
-              envName as keyof typeof ENV_RESOLVERS,
-              projectRootDir,
-            );
-          }
+        if (!resolved) {
+          resolved = resolveKnownImport(
+            id,
+            envName as keyof typeof ENV_RESOLVERS,
+            projectRootDir,
+          );
+        }
 
-          // Resolve for both entry points (importer === '') and regular imports
-          // Entry points come from optimizeDeps.include and are critical to intercept
-          if (resolved) {
-            if (args.path === "react-server-dom-webpack/client.edge") {
-              return;
-            }
-            return {
-              path: resolved,
-            };
+        if (resolved) {
+          if (id === "react-server-dom-webpack/client.edge") {
+            return;
           }
-        });
+          return resolved;
+        }
       },
     };
   }
@@ -243,25 +233,31 @@ export const knownDepsResolverPlugin = ({
 
           const envConfig = (config as any).environments[envName];
 
-          const esbuildPlugin = createEsbuildResolverPlugin(
-            envName,
-            mappings as Map<string, string>,
-          );
-          if (esbuildPlugin && mappings) {
+          if (mappings) {
             envConfig.optimizeDeps ??= {};
-            envConfig.optimizeDeps.esbuildOptions ??= {};
-            envConfig.optimizeDeps.esbuildOptions.define ??= {};
-            envConfig.optimizeDeps.esbuildOptions.define[
+            envConfig.optimizeDeps.rolldownOptions ??= {};
+            envConfig.optimizeDeps.rolldownOptions.transform ??= {};
+            envConfig.optimizeDeps.rolldownOptions.transform.define ??= {};
+            envConfig.optimizeDeps.rolldownOptions.transform.define[
               "process.env.NODE_ENV"
             ] = JSON.stringify(process.env.NODE_ENV);
-            envConfig.optimizeDeps.esbuildOptions.plugins ??= [];
-            envConfig.optimizeDeps.esbuildOptions.plugins.push(esbuildPlugin);
+            envConfig.optimizeDeps.rolldownOptions.plugins ??= [];
+
+            const plugin = createResolverPlugin(
+              envName,
+              mappings as Map<string, string>,
+            );
+            if (plugin) {
+              (envConfig.optimizeDeps.rolldownOptions.plugins as any[]).push(
+                plugin,
+              );
+            }
 
             envConfig.optimizeDeps.include ??= [];
             envConfig.optimizeDeps.include.push(...predefinedImports);
 
             log(
-              "Added esbuild plugin and optimizeDeps includes for environment: %s",
+              "Added optimizeDeps plugin and includes for environment: %s",
               envName,
             );
           }

--- a/sdk/src/vite/linkerPlugin.mts
+++ b/sdk/src/vite/linkerPlugin.mts
@@ -24,7 +24,7 @@ export function linkWorkerBundle({
   // 1. Replace the manifest placeholder with the actual manifest content.
   log("Injecting manifest into worker bundle");
   newCode = newCode.replace(
-    /['"]__RWSDK_MANIFEST_PLACEHOLDER__['"]/,
+    /['"`]__RWSDK_MANIFEST_PLACEHOLDER__['"`]/,
     manifestContent,
   );
 

--- a/sdk/src/vite/prismaPlugin.mts
+++ b/sdk/src/vite/prismaPlugin.mts
@@ -1,5 +1,6 @@
 import { resolve } from "node:path";
 import { Plugin } from "vite";
+import { addOptimizeDepsPlugin } from "./addOptimizeDepsPlugin.mjs";
 import { checkPrismaStatus } from "./checkIsUsingPrisma.mjs";
 import { ensureAliasArray } from "./ensureAliasArray.mjs";
 import { invalidateCacheIfPrismaClientChanged } from "./invalidateCacheIfPrismaClientChanged.mjs";
@@ -34,18 +35,14 @@ export const prismaPlugin = async ({
         "node_modules/.prisma/client/wasm.js",
       );
 
-      config.optimizeDeps ??= {};
-      config.optimizeDeps.esbuildOptions ??= {};
-      config.optimizeDeps.esbuildOptions.plugins ??= [];
+      const prismaFilter = /^.prisma\/client\/default/;
 
-      config.optimizeDeps.esbuildOptions.plugins.push({
+      addOptimizeDepsPlugin(config, {
         name: "rwsdk:prisma",
-        setup(build: any) {
-          build.onResolve({ filter: /^.prisma\/client\/default/ }, async () => {
-            return {
-              path: wasmPath,
-            };
-          });
+        resolveId(id: string) {
+          if (prismaFilter.test(id)) {
+            return wasmPath;
+          }
         },
       });
 

--- a/sdk/src/vite/ssrBridgePlugin.mts
+++ b/sdk/src/vite/ssrBridgePlugin.mts
@@ -2,6 +2,7 @@ import debug from "debug";
 import MagicString from "magic-string";
 import type { Plugin, ViteDevServer } from "vite";
 import { INTERMEDIATE_SSR_BRIDGE_PATH } from "../lib/constants.mjs";
+import { addOptimizeDepsPlugin } from "./addOptimizeDepsPlugin.mjs";
 import { externalModulesSet } from "./constants.mjs";
 import { findSsrImportCallSites } from "./findSsrSpecifiers.mjs";
 
@@ -77,42 +78,21 @@ export const ssrBridgePlugin = ({
       log("Configuring environment: env=%s", env);
 
       if (env === "worker") {
-        // Configure esbuild to mark rwsdk/__ssr paths as external for worker environment
-        log("Configuring esbuild options for worker environment");
         config.optimizeDeps ??= {};
-        config.optimizeDeps.esbuildOptions ??= {};
-        config.optimizeDeps.esbuildOptions.plugins ??= [];
         config.optimizeDeps.include ??= [];
 
-        config.optimizeDeps.esbuildOptions.plugins.push({
+        addOptimizeDepsPlugin(config, {
           name: "rwsdk-ssr-external",
-          setup(build) {
-            log(
-              "Setting up esbuild plugin to mark rwsdk/__ssr paths as external for worker",
-            );
-            build.onResolve({ filter: /.*$/ }, (args) => {
-              process.env.VERBOSE &&
-                log(
-                  "Esbuild onResolve called for path=%s, args=%O",
-                  args.path,
-                  args,
-                );
-
-              if (
-                args.path === "rwsdk/__ssr_bridge" ||
-                args.path.startsWith(VIRTUAL_SSR_PREFIX)
-              ) {
-                log("Marking as external: %s", args.path);
-                return {
-                  path: args.path,
-                  external: true,
-                };
-              }
-            });
+          resolveId(id: string) {
+            if (
+              id === "rwsdk/__ssr_bridge" ||
+              id.startsWith(VIRTUAL_SSR_PREFIX)
+            ) {
+              log("Marking as external: %s", id);
+              return { id, external: true };
+            }
           },
         });
-
-        log("Worker environment esbuild configuration complete");
       }
     },
     async resolveId(id, importer, options?: { custom?: any }) {

--- a/sdk/src/vite/statePlugin.mts
+++ b/sdk/src/vite/statePlugin.mts
@@ -2,6 +2,7 @@ import debug from "debug";
 import fs from "node:fs/promises";
 import type { Plugin } from "vite";
 import { RW_STATE_EXPORT_PATH } from "../lib/constants.mjs";
+import { addOptimizeDepsPlugin } from "./addOptimizeDepsPlugin.mjs";
 import { maybeResolveEnvImport } from "./envResolvers.mjs";
 
 const log = debug("rwsdk:vite:state-plugin");
@@ -34,27 +35,17 @@ export const statePlugin = ({
     },
     configEnvironment(env, config) {
       if (env === "worker") {
-        config.optimizeDeps ??= {};
-        config.optimizeDeps.esbuildOptions ??= {};
-        config.optimizeDeps.esbuildOptions.plugins ??= [];
-        config.optimizeDeps.esbuildOptions.plugins.push({
+        const stateFilter = new RegExp(
+          `^(${RW_STATE_EXPORT_PATH}|${VIRTUAL_STATE_PREFIX}.*)$`,
+        );
+
+        addOptimizeDepsPlugin(config, {
           name: "rwsdk-state-external",
-          setup(build) {
-            build.onResolve(
-              {
-                // context(justinvdm, 13 Oct 2025): Vite dep optimizer slugifies the export path
-                filter: new RegExp(
-                  `^(${RW_STATE_EXPORT_PATH}|${VIRTUAL_STATE_PREFIX}.*)$`,
-                ),
-              },
-              (args) => {
-                log("Marking as external: %s", args.path);
-                return {
-                  path: args.path,
-                  external: true,
-                };
-              },
-            );
+          resolveId(id: string) {
+            if (stateFilter.test(id)) {
+              log("Marking as external: %s", id);
+              return { id, external: true };
+            }
           },
         });
       }

--- a/sdk/src/vite/transformJsxScriptTagsPlugin.mts
+++ b/sdk/src/vite/transformJsxScriptTagsPlugin.mts
@@ -212,9 +212,9 @@ export async function transformJsxScriptTagsCode(
       const expressionText = expression.getText();
 
       if (
-        expressionText !== "jsx" &&
-        expressionText !== "jsxs" &&
-        expressionText !== "jsxDEV"
+        !expressionText.endsWith("jsx") &&
+        !expressionText.endsWith("jsxs") &&
+        !expressionText.endsWith("jsxDEV")
       ) {
         return;
       }


### PR DESCRIPTION
Restores the optimizeDeps esbuild -> Rolldown porting work that was silently dropped when main was merged into next.

Cherry-picks the lost commits:
- be34acb24: Port all 8 optimizeDeps plugins to native Rolldown
- 36fb0445e: Match aliased JSX function names
- 0f092d6fc: __webpack_require__ shim for strict-mode CJS
- 50c57912b: Traverse manifest imports for CSS discovery  
- 3785593b1: Handle Rolldown backtick template literals

Smoke tests pass locally (dev + release + realtime).