### PR TITLE
feat(vite): add sourcemaps option to redwoodPlugin

### DIFF
--- a/sdk/src/vite/configPlugin.mts
+++ b/sdk/src/vite/configPlugin.mts
@@ -11,6 +11,7 @@ import { ssrBridgeWrapPlugin } from "./ssrBridgeWrapPlugin.mjs";
 
 export const configPlugin = ({
   silent,
+  sourcemaps,
   projectRootDir,
   workerEntryPathname,
   clientFiles,
@@ -19,6 +20,7 @@ export const configPlugin = ({
   esbuildOptions,
 }: {
   silent: boolean;
+  sourcemaps: boolean | undefined;
   projectRootDir: string;
   workerEntryPathname: string;
   clientFiles: Set<string>;
@@ -90,7 +92,7 @@ export const configPlugin = ({
       logLevel: silent ? "silent" : "info",
       build: {
         minify: mode !== "development",
-        sourcemap: true,
+        sourcemap: sourcemaps ?? mode === "development",
       },
       define: {
         "process.env.NODE_ENV": JSON.stringify(mode),

--- a/sdk/src/vite/redwoodPlugin.mts
+++ b/sdk/src/vite/redwoodPlugin.mts
@@ -44,6 +44,7 @@ export type RedwoodPluginOptions = {
   configPath?: string;
   forceClientPaths?: string[];
   forceServerPaths?: string[];
+  sourcemaps?: boolean;
   entry?: {
     worker?: string;
   };
@@ -148,6 +149,7 @@ export const redwoodPlugin = async (
     }),
     configPlugin({
       silent: options.silent ?? false,
+      sourcemaps: options.sourcemaps,
       projectRootDir,
       workerEntryPathname,
       clientFiles,


### PR DESCRIPTION
Helllo,

While releasing and checking out some production assets, I noticed the sourcemaps where in there and I could not find a standard way to disable this trough the redwood Vite plugin. Maybe I am missing something, but anyway, here are my changes, slightly opinionated. Let me know if you require any changes. 

### Summary

Previously, sourcemaps were always enabled regardless of environment. This adds a `sourcemaps` option to `RedwoodPluginOptions` with a mode-aware default: enabled in development, disabled in production.

**Default behavior** (no option set):
- Development → sourcemaps on
- Production → sourcemaps off

**Override:**
```ts
// vite.config.mts
redwoodPlugin({ sourcemaps: true })  // force on in all envs
redwoodPlugin({ sourcemaps: false }) // force off in all envs
```

The default change is intentional — production sourcemaps expose source to end users and increase bundle size. Projects that need them (e.g. for error monitoring) can opt in explicitly.

### Changes

- `RedwoodPluginOptions` — added `sourcemaps?: boolean`
- `configPlugin` — accepts `sourcemaps: boolean | undefined`, resolves via `sourcemaps ?? mode === "development"`

### Verification

```sh
# Type check passes
cd sdk && npx tsc --noEmit
```

No E2E test added — this option controls a Vite build config value (`build.sourcemap`). The logic is a single nullish-coalesce expression; covered by type safety. Happy to add a unit test for `configPlugin` if the maintainers prefer.

---