### PR TITLE
fix(vite): respect app sourcemap config

### DIFF
--- a/sdk/src/vite/configPlugin.mts
+++ b/sdk/src/vite/configPlugin.mts
@@ -27,8 +27,13 @@ export const configPlugin = ({
   esbuildOptions: ConfigurableEsbuildOptions;
 }): Plugin => ({
   name: "rwsdk:config",
-  config: async (_, { command }) => {
+  config: async (config, { command }) => {
     const mode = process.env.NODE_ENV;
+
+    // context(justinvdm, 2026-05-06): Only set a sourcemap default if the user
+    // hasn't already configured it in their vite config. This lets users opt in
+    // or out explicitly while still providing a sensible mode-aware default.
+    const sourcemap = config.build?.sourcemap ?? (mode === "development");
 
     const workerConfig: InlineConfig = {
       resolve: {
@@ -90,7 +95,7 @@ export const configPlugin = ({
       logLevel: silent ? "silent" : "info",
       build: {
         minify: mode !== "development",
-        sourcemap: true,
+        sourcemap,
       },
       define: {
         "process.env.NODE_ENV": JSON.stringify(mode),


### PR DESCRIPTION
**Problem**
Production builds in our Vite integration always emitted sourcemaps, and the plugin overrode any app-level sourcemap choice. That made large bundles such as mysql2 produce very large maps.

**Solution**
We move the sourcemap default into the Vite config hook. The plugin now applies a mode-aware default only when the app has not already set build.sourcemap. Development keeps sourcemaps on, production keeps them off, and explicit app config still wins.

**Verification**
We built the SDK, installed it into a temp app from create-rwsdk, and verified these cases:
- no mysql2, production: no sourcemaps
- no mysql2, development: sourcemaps on
- mysql2, production: no sourcemaps
- mysql2, development: sourcemaps on
- explicit build.sourcemap true and false are both respected