### PR TITLE
fix(router): scope except handlers to their enclosing prefix

### DIFF
--- a/docs/src/content/docs/reference/sdk-router.mdx
+++ b/docs/src/content/docs/reference/sdk-router.mdx
@@ -228,7 +228,9 @@ export default defineApp([
 In this example:
 - An error in `/admin/dashboard` is first checked by the admin-specific handler
 - If the admin handler doesn't handle it (returns `void`), the error bubbles up to the global handler
-- Errors in other routes (like `/`) are handled by the global handler
+- Errors in other routes (like `/`) are handled by the global handler — the admin handler is path-scoped to `/admin/*` and is skipped for requests outside it
+
+If you want a handler that runs for every error (regardless of which route threw), define it at the top level of `defineApp([...])` rather than inside a `prefix(...)`. Top-level `except` handlers are not path-scoped and fire for any route declared after them.
 
 ### Error Bubbling
 

--- a/sdk/src/runtime/lib/router.test.ts
+++ b/sdk/src/runtime/lib/router.test.ts
@@ -1989,5 +1989,118 @@ describe("defineRoutes - Request Handling Behavior", () => {
       expect(response.status).toBe(500);
       expect(await response.text()).toBe(`Caught: ${errorMessage}`);
     });
+
+    describe("prefix scoping", () => {
+      const makePrefixApp = () => {
+        const globalHandler = except(
+          () =>
+            new Response("[GLOBAL]", {
+              status: 500,
+            }),
+        );
+        const adminHandler = except(
+          () =>
+            new Response("[ADMIN]", {
+              status: 500,
+            }),
+        );
+        const router = defineRoutes([
+          globalHandler,
+          ...prefix("/admin", [
+            adminHandler,
+            route("/dashboard/", () => {
+              throw new Error("admin dashboard error");
+            }),
+          ]),
+          route("/", () => {
+            throw new Error("home route error");
+          }),
+        ]);
+        return router;
+      };
+
+      const handle = async (router: ReturnType<typeof defineRoutes>, path: string) => {
+        const deps = createMockDependencies();
+        deps.mockRequestInfo.request = new Request(`http://localhost:3000${path}`);
+        return router.handle({
+          request: new Request(`http://localhost:3000${path}`),
+          renderPage: deps.mockRenderPage,
+          getRequestInfo: deps.getRequestInfo,
+          onError: deps.onError,
+          runWithRequestInfoOverrides: deps.mockRunWithRequestInfoOverrides,
+          rscActionHandler: deps.mockRscActionHandler,
+        });
+      };
+
+      it("an except inside prefix should NOT catch errors from routes outside the prefix", async () => {
+        const router = makePrefixApp();
+        const response = await handle(router, "/");
+        expect(await response.text()).toBe("[GLOBAL]");
+      });
+
+      it("an except inside prefix should catch errors from routes inside the prefix", async () => {
+        const router = makePrefixApp();
+        const response = await handle(router, "/admin/dashboard/");
+        expect(await response.text()).toBe("[ADMIN]");
+      });
+
+      it("an except inside prefix that returns void should bubble to the global handler", async () => {
+        const router = defineRoutes([
+          except(() => new Response("[GLOBAL]", { status: 500 })),
+          ...prefix("/admin", [
+            except(() => undefined),
+            route("/dashboard/", () => {
+              throw new Error("boom");
+            }),
+          ]),
+        ]);
+        const response = await handle(router, "/admin/dashboard/");
+        expect(await response.text()).toBe("[GLOBAL]");
+      });
+
+      it("nested prefixes compose the scope path", async () => {
+        const router = defineRoutes([
+          except(() => new Response("[GLOBAL]", { status: 500 })),
+          ...prefix("/a", [
+            ...prefix("/b", [
+              except(() => new Response("[A/B]", { status: 500 })),
+              route("/c/", () => {
+                throw new Error("a/b/c error");
+              }),
+            ]),
+          ]),
+          route("/d/", () => {
+            throw new Error("d error");
+          }),
+        ]);
+
+        const inside = await handle(router, "/a/b/c/");
+        expect(await inside.text()).toBe("[A/B]");
+
+        const outside = await handle(router, "/d/");
+        expect(await outside.text()).toBe("[GLOBAL]");
+      });
+
+      it("parameterized prefixes scope the except handler", async () => {
+        const router = defineRoutes([
+          except(() => new Response("[GLOBAL]", { status: 500 })),
+          ...prefix("/users/:id", [
+            except(() => new Response("[USER]", { status: 500 })),
+            route("/profile/", () => {
+              throw new Error("profile error");
+            }),
+          ]),
+          route("/about/", () => {
+            throw new Error("about error");
+          }),
+        ]);
+
+        const inside = await handle(router, "/users/42/profile/");
+        expect(await inside.text()).toBe("[USER]");
+
+        const outside = await handle(router, "/about/");
+        expect(await outside.text()).toBe("[GLOBAL]");
+      });
+    });
   });
 });

--- a/sdk/src/runtime/lib/router.ts
+++ b/sdk/src/runtime/lib/router.ts
@@ -18,6 +18,10 @@ export type ExceptHandler<T extends RequestInfo = RequestInfo> = {
     error: unknown,
     requestInfo: T,
   ) => MaybePromise<React.JSX.Element | Response | void>;
+  // Set by `prefix(...)` when this handler is nested inside one. The handler
+  // only runs for requests whose path is under this prefix. Top-level
+  // `except` handlers leave this undefined and run for every route.
+  pathPattern?: string;
 };
 
 type RouteFunction<T extends RequestInfo = RequestInfo> = BivariantRouteHandler<
@@ -426,6 +430,26 @@ export function defineRoutes<T extends RequestInfo = RequestInfo>(
         return route.type === "except";
       }
 
+      function isPathInExceptScope(
+        pathPattern: string,
+        requestPath: string,
+      ): boolean {
+        const normalized = pathPattern.endsWith("/")
+          ? pathPattern
+          : pathPattern + "/";
+        const hasParams = normalized.includes(":") || normalized.includes("*");
+        if (hasParams) {
+          const wildcardPattern = normalized.slice(0, -1) + "/*";
+          return (
+            matchPath(wildcardPattern, requestPath) !== null ||
+            matchPath(normalized.slice(0, -1), requestPath) !== null
+          );
+        }
+        return (
+          requestPath === normalized || requestPath.startsWith(normalized)
+        );
+      }
+
       async function executeExceptHandlers(
         error: unknown,
         startIndex: number,
@@ -434,6 +458,13 @@ export function defineRoutes<T extends RequestInfo = RequestInfo>(
         for (let i = startIndex; i >= 0; i--) {
           const route = compiledRoutes[i];
           if (isExceptHandler(route)) {
+            const pattern = route.handler.pathPattern;
+            if (
+              pattern &&
+              !isPathInExceptScope(pattern, getRequestInfo().path)
+            ) {
+              continue;
+            }
             try {
               const result = await route.handler.handler(
                 error,
@@ -871,8 +902,16 @@ export function prefix<
       "__rwExcept" in r &&
       r.__rwExcept === true
     ) {
-      // Pass through ExceptHandler as-is
-      return r as PrefixedRouteValue<Prefix, typeof r>;
+      const existing = (r as ExceptHandler<T>).pathPattern;
+      const combined = existing
+        ? joinPaths(normalizedPrefix, existing)
+        : normalizedPrefix;
+      const scoped: ExceptHandler<T> = {
+        __rwExcept: true,
+        handler: (r as ExceptHandler<T>).handler,
+        pathPattern: combined,
+      };
+      return scoped as PrefixedRouteValue<Prefix, typeof r>;
     }
     if (Array.isArray(r)) {
       // Recursively process nested route arrays


### PR DESCRIPTION
## Problem

When you use `prefix("/admin", [...])` to group routes under a path, you can put an `except` error handler inside that group. The router docs ([sdk-router#multiple-handlers-and-nesting](https://docs.rwsdk.com/reference/sdk-router/#multiple-handlers-and-nesting)) describe this handler as scoped to the prefix — meaning it should only catch errors thrown by routes under `/admin`. It doesn't. The handler runs for any route declared after it, including routes outside the prefix.

The example in the docs only appears to work because the inner handler returns nothing for errors it doesn't recognise, so unrelated errors fall through to the global handler. The moment someone writes an inner handler that always returns a response (a reasonable thing to do for an API that formats errors as JSON), errors from unrelated pages start coming back as JSON from the API handler.

Reported in #1195.

## Solution

Make `except` handlers inside `prefix(...)` actually scoped to that prefix's path:

1. When `prefix("/admin", [...])` wraps an `except`, remember which path the handler belongs to.
2. When an error is thrown, the router walks back through the route list looking for a handler. Skip any handler whose remembered path doesn't match the request.
3. Top-level `except` handlers (not inside a `prefix`) keep working exactly as before — they fire for every route.
4. Update the docs so the path-scoping behaviour is described accurately, and tell readers that a handler placed at the top level (outside any `prefix`) is the way to catch errors from every route.

## Technical Summary

- `ExceptHandler` gets an optional `pathPattern` field. Top-level handlers leave it undefined; `prefix(...)` sets it to the joined prefix path. Nested prefixes compose: `prefix("/a", [prefix("/b", [except(...)])])` ends up with `pathPattern: "/a/b/"`.
- `executeExceptHandlers` checks `pathPattern` against the current request path before invoking each handler. The check supports static prefixes (`startsWith` after normalising the trailing slash) and parameterised prefixes (`/users/:id` and `/foo/*`) via the existing `matchPath` helper.
- New tests under `router.test.ts › except - Error Handling › prefix scoping` cover: handler skipped for routes outside its prefix, handler fires for routes inside, returning `void` still bubbles to the global handler, nested prefix composition, and parameterised prefixes.