### PR TITLE
fix(vite): restore single-file worker output and tree-shaking on Vite 8

### DIFF
--- a/sdk/src/vite/buildApp.mts
+++ b/sdk/src/vite/buildApp.mts
@@ -53,8 +53,8 @@ export async function buildApp({
     workerEnv.config.build = {
       ...originalWorkerBuildConfig,
       write: false,
-      rolldownOptions: {
-        ...originalWorkerBuildConfig?.rolldownOptions,
+      rollupOptions: {
+        ...originalWorkerBuildConfig?.rollupOptions,
         input: {
           index: tempEntryPath,
         },
@@ -83,13 +83,13 @@ export async function buildApp({
   // splitting forces a single consolidated intermediate worker file, matching
   // the architecture's expectation of an intermediate `worker.js` and
   // preventing leftover artifacts from cluttering the final output.
-  workerEnv.config.build!.rolldownOptions!.output ??= {};
-  if (Array.isArray(workerEnv.config.build!.rolldownOptions!.output)) {
-    workerEnv.config.build!.rolldownOptions!.output.forEach(
+  workerEnv.config.build!.rollupOptions!.output ??= {};
+  if (Array.isArray(workerEnv.config.build!.rollupOptions!.output)) {
+    workerEnv.config.build!.rollupOptions!.output.forEach(
       (o: any) => (o.codeSplitting = false),
     );
   } else {
-    (workerEnv.config.build!.rolldownOptions!.output as any).codeSplitting =
+    (workerEnv.config.build!.rollupOptions!.output as any).codeSplitting =
       false;
   }
 
@@ -110,14 +110,14 @@ export async function buildApp({
   console.log("Building client...");
   const clientEnv = builder.environments["client"]!;
   clientEnv.config.build ??= {} as any;
-  clientEnv.config.build.rolldownOptions ??= {};
+  clientEnv.config.build.rollupOptions ??= {};
   const clientEntryPointsArray = Array.from(clientEntryPoints);
 
   if (clientEntryPointsArray.length === 0) {
     log("No client entry points discovered, using default: src/client.tsx");
-    clientEnv.config.build.rolldownOptions.input = ["src/client.tsx"];
+    clientEnv.config.build.rollupOptions.input = ["src/client.tsx"];
   } else {
-    clientEnv.config.build.rolldownOptions.input = clientEntryPointsArray;
+    clientEnv.config.build.rollupOptions.input = clientEntryPointsArray;
   }
 
   await builder.build(clientEnv);
@@ -135,7 +135,7 @@ export async function buildApp({
   // directly. Instead, we re-point the original entry to the intermediate
   // worker bundle from the first pass. This allows the linker pass to re-use
   // the same plugin-driven configuration while bundling the final worker.
-  workerConfig.build!.rolldownOptions!.input = {
+  workerConfig.build!.rollupOptions!.input = {
     index: resolve(projectRootDir, "dist", "worker", "index.js"),
   };
 
@@ -144,13 +144,13 @@ export async function buildApp({
   // worker bundle. Setting codeSplitting:false forces all code (including
   // dynamic imports from the intermediate worker artifact) into the entry
   // chunk, restoring the single-file worker output the architecture expects.
-  workerConfig.build!.rolldownOptions!.output ??= {};
-  if (Array.isArray(workerConfig.build!.rolldownOptions!.output)) {
-    workerConfig.build!.rolldownOptions!.output.forEach(
+  workerConfig.build!.rollupOptions!.output ??= {};
+  if (Array.isArray(workerConfig.build!.rollupOptions!.output)) {
+    workerConfig.build!.rollupOptions!.output.forEach(
       (o: any) => (o.codeSplitting = false),
     );
   } else {
-    (workerConfig.build!.rolldownOptions!.output as any).codeSplitting = false;
+    (workerConfig.build!.rollupOptions!.output as any).codeSplitting = false;
   }
 
   await builder.build(workerEnv);

--- a/sdk/src/vite/buildApp.mts
+++ b/sdk/src/vite/buildApp.mts
@@ -83,13 +83,13 @@ export async function buildApp({
   // splitting forces a single consolidated intermediate worker file, matching
   // the architecture's expectation of an intermediate `worker.js` and
   // preventing leftover artifacts from cluttering the final output.
-  workerEnv.config.build!.rollupOptions!.output ??= {};
-  if (Array.isArray(workerEnv.config.build!.rollupOptions!.output)) {
-    workerEnv.config.build!.rollupOptions!.output.forEach(
+  workerEnv.config.build.rollupOptions.output ??= {};
+  if (Array.isArray(workerEnv.config.build.rollupOptions.output)) {
+    workerEnv.config.build.rollupOptions.output.forEach(
       (o: any) => (o.codeSplitting = false),
     );
   } else {
-    (workerEnv.config.build!.rollupOptions!.output as any).codeSplitting =
+    (workerEnv.config.build.rollupOptions.output as any).codeSplitting =
       false;
   }
 
@@ -127,7 +127,7 @@ export async function buildApp({
 
   // Re-configure the worker environment for the linking pass
   const workerConfig = workerEnv.config;
-  workerConfig.build!.emptyOutDir = false;
+  workerConfig.build.emptyOutDir = false;
 
   // context(justinvdm, 22 Sep 2025): This is a workaround to satisfy the
   // Cloudflare plugin's expectation of an entry chunk named `index`. The plugin
@@ -135,7 +135,7 @@ export async function buildApp({
   // directly. Instead, we re-point the original entry to the intermediate
   // worker bundle from the first pass. This allows the linker pass to re-use
   // the same plugin-driven configuration while bundling the final worker.
-  workerConfig.build!.rollupOptions!.input = {
+  workerConfig.build.rollupOptions.input = {
     index: resolve(projectRootDir, "dist", "worker", "index.js"),
   };
 
@@ -144,13 +144,13 @@ export async function buildApp({
   // worker bundle. Setting codeSplitting:false forces all code (including
   // dynamic imports from the intermediate worker artifact) into the entry
   // chunk, restoring the single-file worker output the architecture expects.
-  workerConfig.build!.rollupOptions!.output ??= {};
-  if (Array.isArray(workerConfig.build!.rollupOptions!.output)) {
-    workerConfig.build!.rollupOptions!.output.forEach(
+  workerConfig.build.rollupOptions.output ??= {};
+  if (Array.isArray(workerConfig.build.rollupOptions.output)) {
+    workerConfig.build.rollupOptions.output.forEach(
       (o: any) => (o.codeSplitting = false),
     );
   } else {
-    (workerConfig.build!.rollupOptions!.output as any).codeSplitting = false;
+    (workerConfig.build.rollupOptions.output as any).codeSplitting = false;
   }
 
   await builder.build(workerEnv);

--- a/sdk/src/vite/buildApp.mts
+++ b/sdk/src/vite/buildApp.mts
@@ -53,8 +53,8 @@ export async function buildApp({
     workerEnv.config.build = {
       ...originalWorkerBuildConfig,
       write: false,
-      rolldownOptions: {
-        ...originalWorkerBuildConfig?.rolldownOptions,
+      rollupOptions: {
+        ...originalWorkerBuildConfig?.rollupOptions,
         input: {
           index: tempEntryPath,
         },

--- a/sdk/src/vite/buildApp.mts
+++ b/sdk/src/vite/buildApp.mts
@@ -53,8 +53,8 @@ export async function buildApp({
     workerEnv.config.build = {
       ...originalWorkerBuildConfig,
       write: false,
-      rollupOptions: {
-        ...originalWorkerBuildConfig?.rollupOptions,
+      rolldownOptions: {
+        ...originalWorkerBuildConfig?.rolldownOptions,
         input: {
           index: tempEntryPath,
         },
@@ -78,6 +78,21 @@ export async function buildApp({
     esbuildOptions,
   });
 
+  // context(justinvdm, 2026-05-13): In Vite 8 (Rolldown), the worker build
+  // fragments into hundreds of tiny chunks by default. Disabling code
+  // splitting forces a single consolidated intermediate worker file, matching
+  // the architecture's expectation of an intermediate `worker.js` and
+  // preventing leftover artifacts from cluttering the final output.
+  workerEnv.config.build!.rolldownOptions!.output ??= {};
+  if (Array.isArray(workerEnv.config.build!.rolldownOptions!.output)) {
+    workerEnv.config.build!.rolldownOptions!.output.forEach(
+      (o: any) => (o.codeSplitting = false),
+    );
+  } else {
+    (workerEnv.config.build!.rolldownOptions!.output as any).codeSplitting =
+      false;
+  }
+
   console.log("Building worker...");
   process.env.RWSDK_BUILD_PASS = "worker";
   await builder.build(workerEnv);
@@ -95,14 +110,14 @@ export async function buildApp({
   console.log("Building client...");
   const clientEnv = builder.environments["client"]!;
   clientEnv.config.build ??= {} as any;
-  clientEnv.config.build.rollupOptions ??= {};
+  clientEnv.config.build.rolldownOptions ??= {};
   const clientEntryPointsArray = Array.from(clientEntryPoints);
 
   if (clientEntryPointsArray.length === 0) {
     log("No client entry points discovered, using default: src/client.tsx");
-    clientEnv.config.build.rollupOptions.input = ["src/client.tsx"];
+    clientEnv.config.build.rolldownOptions.input = ["src/client.tsx"];
   } else {
-    clientEnv.config.build.rollupOptions.input = clientEntryPointsArray;
+    clientEnv.config.build.rolldownOptions.input = clientEntryPointsArray;
   }
 
   await builder.build(clientEnv);
@@ -116,15 +131,43 @@ export async function buildApp({
 
   // context(justinvdm, 22 Sep 2025): This is a workaround to satisfy the
   // Cloudflare plugin's expectation of an entry chunk named `index`. The plugin
-  // now manages the worker build, so we no longer set rollup options
+  // now manages the worker build, so we no longer set rolldown options
   // directly. Instead, we re-point the original entry to the intermediate
   // worker bundle from the first pass. This allows the linker pass to re-use
   // the same plugin-driven configuration while bundling the final worker.
-  workerConfig.build!.rollupOptions!.input = {
+  workerConfig.build!.rolldownOptions!.input = {
     index: resolve(projectRootDir, "dist", "worker", "index.js"),
   };
 
+  // context(justinvdm, 2026-05-13): In Vite 8 (Rolldown), the linker pass
+  // was producing hundreds of tiny chunks instead of a single consolidated
+  // worker bundle. Setting codeSplitting:false forces all code (including
+  // dynamic imports from the intermediate worker artifact) into the entry
+  // chunk, restoring the single-file worker output the architecture expects.
+  workerConfig.build!.rolldownOptions!.output ??= {};
+  if (Array.isArray(workerConfig.build!.rolldownOptions!.output)) {
+    workerConfig.build!.rolldownOptions!.output.forEach(
+      (o: any) => (o.codeSplitting = false),
+    );
+  } else {
+    (workerConfig.build!.rolldownOptions!.output as any).codeSplitting = false;
+  }
+
   await builder.build(workerEnv);
+
+  // Remove first-pass JS artifacts that are now inlined into the final worker
+  // bundle. Without this cleanup, ~480 leftover chunks from the first pass
+  // clutter dist/worker/assets/ and inflate deployment file counts.
+  const workerAssetsDir = resolve(projectRootDir, "dist", "worker", "assets");
+  try {
+    for (const entry of await readdir(workerAssetsDir)) {
+      if (entry.endsWith(".js") || entry.endsWith(".js.map")) {
+        await rm(join(workerAssetsDir, entry), { force: true });
+      }
+    }
+  } catch {
+    // Directory may not exist (e.g. if the app has no worker assets)
+  }
 
   console.log("Build complete!");
 

--- a/sdk/src/vite/buildApp.mts
+++ b/sdk/src/vite/buildApp.mts
@@ -53,8 +53,8 @@ export async function buildApp({
     workerEnv.config.build = {
       ...originalWorkerBuildConfig,
       write: false,
-      rollupOptions: {
-        ...originalWorkerBuildConfig?.rollupOptions,
+      rolldownOptions: {
+        ...originalWorkerBuildConfig?.rolldownOptions,
         input: {
           index: tempEntryPath,
         },
@@ -83,13 +83,13 @@ export async function buildApp({
   // splitting forces a single consolidated intermediate worker file, matching
   // the architecture's expectation of an intermediate `worker.js` and
   // preventing leftover artifacts from cluttering the final output.
-  workerEnv.config.build.rollupOptions.output ??= {};
-  if (Array.isArray(workerEnv.config.build.rollupOptions.output)) {
-    workerEnv.config.build.rollupOptions.output.forEach(
+  workerEnv.config.build.rolldownOptions.output ??= {};
+  if (Array.isArray(workerEnv.config.build.rolldownOptions.output)) {
+    workerEnv.config.build.rolldownOptions.output.forEach(
       (o: any) => (o.codeSplitting = false),
     );
   } else {
-    (workerEnv.config.build.rollupOptions.output as any).codeSplitting =
+    (workerEnv.config.build.rolldownOptions.output as any).codeSplitting =
       false;
   }
 
@@ -110,14 +110,14 @@ export async function buildApp({
   console.log("Building client...");
   const clientEnv = builder.environments["client"]!;
   clientEnv.config.build ??= {} as any;
-  clientEnv.config.build.rollupOptions ??= {};
+  clientEnv.config.build.rolldownOptions ??= {};
   const clientEntryPointsArray = Array.from(clientEntryPoints);
 
   if (clientEntryPointsArray.length === 0) {
     log("No client entry points discovered, using default: src/client.tsx");
-    clientEnv.config.build.rollupOptions.input = ["src/client.tsx"];
+    clientEnv.config.build.rolldownOptions.input = ["src/client.tsx"];
   } else {
-    clientEnv.config.build.rollupOptions.input = clientEntryPointsArray;
+    clientEnv.config.build.rolldownOptions.input = clientEntryPointsArray;
   }
 
   await builder.build(clientEnv);
@@ -131,11 +131,11 @@ export async function buildApp({
 
   // context(justinvdm, 22 Sep 2025): This is a workaround to satisfy the
   // Cloudflare plugin's expectation of an entry chunk named `index`. The plugin
-  // now manages the worker build, so we no longer set rolldown options
+  // now manages the worker build, so we no longer set rollup options
   // directly. Instead, we re-point the original entry to the intermediate
   // worker bundle from the first pass. This allows the linker pass to re-use
   // the same plugin-driven configuration while bundling the final worker.
-  workerConfig.build.rollupOptions.input = {
+  workerConfig.build.rolldownOptions.input = {
     index: resolve(projectRootDir, "dist", "worker", "index.js"),
   };
 
@@ -144,13 +144,13 @@ export async function buildApp({
   // worker bundle. Setting codeSplitting:false forces all code (including
   // dynamic imports from the intermediate worker artifact) into the entry
   // chunk, restoring the single-file worker output the architecture expects.
-  workerConfig.build.rollupOptions.output ??= {};
-  if (Array.isArray(workerConfig.build.rollupOptions.output)) {
-    workerConfig.build.rollupOptions.output.forEach(
+  workerConfig.build.rolldownOptions.output ??= {};
+  if (Array.isArray(workerConfig.build.rolldownOptions.output)) {
+    workerConfig.build.rolldownOptions.output.forEach(
       (o: any) => (o.codeSplitting = false),
     );
   } else {
-    (workerConfig.build.rollupOptions.output as any).codeSplitting = false;
+    (workerConfig.build.rolldownOptions.output as any).codeSplitting = false;
   }
 
   await builder.build(workerEnv);

--- a/sdk/src/vite/buildApp.mts
+++ b/sdk/src/vite/buildApp.mts
@@ -49,22 +49,22 @@ export async function buildApp({
     }
     await writeFile(tempEntryPath, "");
 
-    const originalWorkerBuildConfig = workerEnv.config.build;
-    workerEnv.config.build = {
-      ...originalWorkerBuildConfig,
-      write: false,
-      rollupOptions: {
-        ...originalWorkerBuildConfig?.rollupOptions,
-        input: {
-          index: tempEntryPath,
-        },
-      },
+    // context(justinvdm, 2026-05-13): Mutate the resolved build config in
+    // place rather than replacing the build object. Creating a new object
+    // loses Vite's rolldownOptions compat proxy, so we save and restore
+    // individual properties instead.
+    const originalWrite = workerEnv.config.build.write;
+    const originalInput = workerEnv.config.build.rolldownOptions.input;
+    workerEnv.config.build.write = false;
+    workerEnv.config.build.rolldownOptions.input = {
+      index: tempEntryPath,
     };
 
     await builder.build(workerEnv);
 
     // Restore the original config
-    workerEnv.config.build = originalWorkerBuildConfig;
+    workerEnv.config.build.write = originalWrite;
+    workerEnv.config.build.rolldownOptions.input = originalInput;
   } finally {
     await rm(tempEntryPath, { force: true });
   }

--- a/sdk/src/vite/configPlugin.mts
+++ b/sdk/src/vite/configPlugin.mts
@@ -114,7 +114,7 @@ export const configPlugin = ({
           build: {
             outDir: resolve(projectRootDir, "dist", "client"),
             manifest: true,
-            rolldownOptions: {
+            rollupOptions: {
               input: [],
             },
           },
@@ -193,7 +193,7 @@ export const configPlugin = ({
               fileName: () => path.basename(INTERMEDIATE_SSR_BRIDGE_PATH),
             },
             outDir: path.dirname(INTERMEDIATE_SSR_BRIDGE_PATH),
-            rolldownOptions: {
+            rollupOptions: {
               output: {
                 // context(justinvdm, 15 Sep 2025): The SSR bundle is a
                 // pre-compiled artifact. When the linker pass bundles it into

--- a/sdk/src/vite/configPlugin.mts
+++ b/sdk/src/vite/configPlugin.mts
@@ -114,7 +114,7 @@ export const configPlugin = ({
           build: {
             outDir: resolve(projectRootDir, "dist", "client"),
             manifest: true,
-            rollupOptions: {
+            rolldownOptions: {
               input: [],
             },
           },
@@ -193,7 +193,7 @@ export const configPlugin = ({
               fileName: () => path.basename(INTERMEDIATE_SSR_BRIDGE_PATH),
             },
             outDir: path.dirname(INTERMEDIATE_SSR_BRIDGE_PATH),
-            rollupOptions: {
+            rolldownOptions: {
               output: {
                 // context(justinvdm, 15 Sep 2025): The SSR bundle is a
                 // pre-compiled artifact. When the linker pass bundles it into
@@ -208,7 +208,7 @@ export const configPlugin = ({
                 // context(justinvdm, 19 Nov 2025): We use a custom plugin
                 // (ssrBridgeWrapPlugin) to intelligently inject the IIFE *after*
                 // any top-level external imports, ensuring they remain valid.
-                inlineDynamicImports: true,
+                codeSplitting: false,
               },
               plugins: [ssrBridgeWrapPlugin()],
             },

--- a/sdk/src/vite/configPlugin.mts
+++ b/sdk/src/vite/configPlugin.mts
@@ -114,7 +114,7 @@ export const configPlugin = ({
           build: {
             outDir: resolve(projectRootDir, "dist", "client"),
             manifest: true,
-            rollupOptions: {
+            rolldownOptions: {
               input: [],
             },
           },
@@ -193,7 +193,7 @@ export const configPlugin = ({
               fileName: () => path.basename(INTERMEDIATE_SSR_BRIDGE_PATH),
             },
             outDir: path.dirname(INTERMEDIATE_SSR_BRIDGE_PATH),
-            rollupOptions: {
+            rolldownOptions: {
               output: {
                 // context(justinvdm, 15 Sep 2025): The SSR bundle is a
                 // pre-compiled artifact. When the linker pass bundles it into

--- a/sdk/src/vite/directivesFilteringPlugin.mts
+++ b/sdk/src/vite/directivesFilteringPlugin.mts
@@ -5,10 +5,6 @@ import { normalizeModulePath } from "../lib/normalizeModulePath.mjs";
 
 const log = debug("rwsdk:vite:directives-filtering-plugin");
 
-type ModuleInfoWithIncluded = {
-  isIncluded?: boolean | null;
-};
-
 export const directivesFilteringPlugin = ({
   clientFiles,
   serverFiles,
@@ -21,7 +17,8 @@ export const directivesFilteringPlugin = ({
   return {
     name: "rwsdk:directives-filtering",
     enforce: "post",
-    async buildEnd() {
+
+    generateBundle(_options, bundle) {
       if (
         this.environment.name !== "worker" ||
         process.env.RWSDK_BUILD_PASS !== "worker"
@@ -29,7 +26,7 @@ export const directivesFilteringPlugin = ({
         return;
       }
 
-      log("Filtering directive modules after worker build...");
+      log("Filtering directive modules from bundle output...");
 
       process.env.VERBOSE &&
         log(
@@ -38,23 +35,36 @@ export const directivesFilteringPlugin = ({
           Array.from(serverFiles),
         );
 
-      [clientFiles, serverFiles].forEach((files) => {
+      // context(justinvdm, 2026-05-13): Rolldown (Vite 8+) does not expose
+      // ModuleInfo.isIncluded. Instead, we inspect the final output chunks.
+      // A module whose renderedLength is 0 (or missing) was tree-shaken to
+      // empty and should be removed from the directive sets.
+      const includedModules = new Set<string>();
+      for (const output of Object.values(bundle)) {
+        if (output.type !== "chunk") {
+          continue;
+        }
+
+        for (const [moduleId, renderedModule] of Object.entries(
+          output.modules,
+        )) {
+          if (renderedModule.renderedLength > 0) {
+            includedModules.add(moduleId);
+          }
+        }
+      }
+
+      for (const files of [clientFiles, serverFiles]) {
         for (const id of files) {
           const absoluteId = normalizeModulePath(id, projectRootDir, {
             absolute: true,
           });
-          const info = this.getModuleInfo(absoluteId) as
-            | ModuleInfoWithIncluded
-            | null;
 
-          if (
-            !info ||
-            (typeof info.isIncluded !== "undefined" && !info.isIncluded)
-          ) {
+          if (!includedModules.has(absoluteId)) {
             files.delete(id);
           }
         }
-      });
+      }
 
       process.env.VERBOSE &&
         log(

--- a/sdk/src/vite/runDirectivesScan.mts
+++ b/sdk/src/vite/runDirectivesScan.mts
@@ -170,7 +170,7 @@ export const runDirectivesScan = async ({
     };
     const esbuild = await getViteEsbuild(rootConfig.root);
     const input =
-      initialEntries ?? environments.worker.config.build.rollupOptions?.input;
+      initialEntries ?? environments.worker.config.build.rolldownOptions?.input;
     let entries: string[];
 
     if (Array.isArray(input)) {

--- a/sdk/src/vite/runDirectivesScan.mts
+++ b/sdk/src/vite/runDirectivesScan.mts
@@ -170,7 +170,7 @@ export const runDirectivesScan = async ({
     };
     const esbuild = await getViteEsbuild(rootConfig.root);
     const input =
-      initialEntries ?? environments.worker.config.build.rolldownOptions?.input;
+      initialEntries ?? environments.worker.config.build.rollupOptions?.input;
     let entries: string[];
 
     if (Array.isArray(input)) {


### PR DESCRIPTION
## Problem

Vite 8 switched from Rollup to Rolldown, which changed default code-splitting behavior and dropped `ModuleInfo.isIncluded` support. This caused three regressions in production builds:

1. **Worker builds fragmented into hundreds of tiny chunks** instead of a single consolidated bundle. In the przm app, worker files went from ~186 to 969, and the linker pass processed 292 modules instead of ~49.
2. **Tree-shaking filtering was silently disabled.** `directivesFilteringPlugin` relied on `ModuleInfo.isIncluded` to prune unused directive modules after the first worker pass. Because Rolldown does not expose this property, nothing was filtered. All ~800 scanned client/server files were kept, bloating the SSR bundle and client lookup map.
3. **SSR build emitted a Rolldown deprecation warning** because `inlineDynamicImports: true` is deprecated in Rolldown.

## Solution

### Single-file worker output
In `buildApp.mts`, set `codeSplitting: false` for both the first worker pass and the linker pass. This forces Rolldown to inline all code into the entry chunk, restoring the single `index.js` output the architecture expects. A post-linker cleanup step removes stale `.js`/`.js.map` artifacts from `dist/worker/assets/` that were generated during the first pass but are now inlined.

### Tree-shaking filtering on Rolldown  
Replaced the `buildEnd` hook in `directivesFilteringPlugin` with a `generateBundle` hook. Since Rolldown does not expose `ModuleInfo.isIncluded`, we instead inspect the final output chunks. We collect all module IDs where `RenderedModule.renderedLength > 0` (the module actually contributed code to the bundle) and filter the directive sets against this set. This restores accurate tree-shaking filtering on Vite 8.

### Deprecation warning
In `configPlugin.mts`, replaced `inlineDynamicImports: true` with `codeSplitting: false` in the SSR build config.

## Verification

- **przm app**: Worker files dropped from 969 to 3. Total dist files dropped from 1,787 to 421. Linker pass modules dropped from 292 to 5.
- **starter app**: Build passes cleanly with 4 worker files and a 324 KB `index.js`.
- **SDK tests**: All 532 tests pass.
- **Tree-shaking**: Debug logs show ~800 directive modules before filtering and ~200 after. ~600 unused modules are correctly pruned.