### PR TITLE
fix release log streaming and recover tag pushes

### DIFF
--- a/scripts/release-agent-ci.sh
+++ b/scripts/release-agent-ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR/.."
@@ -9,11 +9,6 @@ if [[ " $* " == *" --help "* ]]; then
   ./scripts/release.sh --help
   exit 0
 fi
-
-# Extract auth from existing tooling so we can keep `pnpm release` opaque.
-# npm token: from ~/.npmrc (or NPM_TOKEN override)
-# GitHub token: from gh CLI auth (or GH_TOKEN override)
-# Branch: from the current git checkout
 
 VERSION_TYPE=""
 VERSION=""
@@ -71,56 +66,15 @@ if [[ -z "$CURRENT_BRANCH" ]]; then
 fi
 
 CURRENT_SHA="$(git rev-parse HEAD 2>/dev/null || true)"
-NPM_TOKEN_SOURCE="NPM_TOKEN env"
+CURRENT_REMOTE_URL="$(git remote get-url origin 2>/dev/null || true)"
 
 if [[ -z "${NPM_TOKEN:-}" ]]; then
   USER_NPMRC="$(npm config get userconfig 2>/dev/null || true)"
-  NPM_TOKEN_SOURCE="${USER_NPMRC:-~/.npmrc}"
   if [[ -n "$USER_NPMRC" && -f "$USER_NPMRC" ]]; then
     NPM_TOKEN="$(grep -E '^[[:space:]]*//registry\.npmjs\.org/:_authToken=' "$USER_NPMRC" | tail -n1 | sed 's/.*=//')"
   else
     NPM_TOKEN=""
   fi
-fi
-
-validate_npm_publish_access() {
-  local temp_dir temp_npmrc npm_username npm_owners package_name
-
-  if [[ -z "$NPM_TOKEN" ]]; then
-    echo "[Release] Error: no npm token was found in $NPM_TOKEN_SOURCE."
-    echo "Set NPM_TOKEN or sign in to npm with a publish-capable token."
-    exit 1
-  fi
-
-  package_name="$(cd sdk && npm pkg get name | tr -d '"')"
-  temp_dir="$(mktemp -d)"
-  temp_npmrc="$temp_dir/.npmrc"
-
-  cat >"$temp_npmrc" <<EOF
-registry=https://registry.npmjs.org/
-//registry.npmjs.org/:_authToken=$NPM_TOKEN
-EOF
-
-  if ! npm_username="$(NPM_CONFIG_USERCONFIG="$temp_npmrc" npm whoami --registry=https://registry.npmjs.org/ 2>/dev/null)"; then
-    rm -rf "$temp_dir"
-    echo "[Release] Error: the npm token from $NPM_TOKEN_SOURCE cannot authenticate to registry.npmjs.org."
-    echo "Run npm login or set NPM_TOKEN to a publish-capable token."
-    exit 1
-  fi
-
-  npm_owners="$(npm owner ls "$package_name" --registry=https://registry.npmjs.org/ 2>/dev/null || true)"
-  if ! grep -qE "^${npm_username}[[:space:]]" <<<"$npm_owners"; then
-    rm -rf "$temp_dir"
-    echo "[Release] Error: npm token authenticates as '$npm_username', but '$package_name' is owned by:"
-    echo "$npm_owners"
-    exit 1
-  fi
-
-  rm -rf "$temp_dir"
-}
-
-if [[ "$DRY_RUN" != true ]]; then
-  validate_npm_publish_access
 fi
 
 if [[ -z "${GH_TOKEN:-}" ]]; then
@@ -132,14 +86,39 @@ if [[ "$GH_TOKEN" == "null" ]]; then
   GH_TOKEN=""
 fi
 
-AI_AGENT=1 \
-  NPM_TOKEN="$NPM_TOKEN" \
-  GH_TOKEN_FOR_RELEASES="$GH_TOKEN" \
-  RWSDK_RELEASE_BRANCH="$CURRENT_BRANCH" \
-  RWSDK_RELEASE_SHA="$CURRENT_SHA" \
-  VERSION_TYPE="$VERSION_TYPE" \
-  VERSION="$VERSION" \
-  CREATE_GH_RELEASE="$CREATE_GH_RELEASE" \
-  DRY_RUN="$DRY_RUN" \
-  SKIP_SMOKE_TESTS="$SKIP_SMOKE_TESTS" \
-  npx @redwoodjs/agent-ci run --workflow .agent-ci/workflows/release.yml
+AGENT_CI_ARGS=(run --workflow .agent-ci/workflows/release.yml)
+if [[ "$DRY_RUN" != true ]]; then
+  AGENT_CI_ARGS=(run --pause-on-failure --workflow .agent-ci/workflows/release.yml)
+fi
+
+export AI_AGENT=1
+export NPM_TOKEN="$NPM_TOKEN"
+export GH_TOKEN_FOR_RELEASES="$GH_TOKEN"
+export RWSDK_RELEASE_BRANCH="$CURRENT_BRANCH"
+export RWSDK_RELEASE_SHA="$CURRENT_SHA"
+export VERSION_TYPE="$VERSION_TYPE"
+export VERSION="$VERSION"
+export CREATE_GH_RELEASE="$CREATE_GH_RELEASE"
+export DRY_RUN="$DRY_RUN"
+export SKIP_SMOKE_TESTS="$SKIP_SMOKE_TESTS"
+
+REMOTE_URL_FILE=".agent-ci/runtime/release-remote-url"
+mkdir -p "$(dirname "$REMOTE_URL_FILE")"
+printf '%s\n' "$CURRENT_REMOTE_URL" > "$REMOTE_URL_FILE"
+
+LOGS_ROOT="$HOME/Library/Application Support/agent-ci/logs"
+cleanup() {
+  if [[ -n "${WATCHER_PID:-}" ]]; then
+    kill "$WATCHER_PID" 2>/dev/null || true
+  fi
+  rm -f "$REMOTE_URL_FILE"
+}
+trap cleanup EXIT
+
+node "$SCRIPT_DIR/watch-agent-ci-logs.mjs" "$LOGS_ROOT" &
+WATCHER_PID=$!
+
+npx --yes @redwoodjs/agent-ci "${AGENT_CI_ARGS[@]}"
+EXIT_CODE=$?
+cleanup
+exit "$EXIT_CODE"

--- a/scripts/watch-agent-ci-logs.mjs
+++ b/scripts/watch-agent-ci-logs.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const logsRoot = process.argv[2];
+if (!logsRoot) {
+  console.error('Usage: watch-agent-ci-logs.mjs <logs-root>');
+  process.exit(1);
+}
+
+const watched = new Map();
+let currentRunDir = '';
+let currentHeader = '';
+
+function latestRunDir() {
+  if (!fs.existsSync(logsRoot)) {
+    return '';
+  }
+  const dirs = fs
+    .readdirSync(logsRoot, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && d.name.startsWith('agent-ci-'))
+    .map((d) => path.join(logsRoot, d.name));
+  if (dirs.length === 0) {
+    return '';
+  }
+  dirs.sort((a, b) => {
+    const aStat = fs.statSync(a);
+    const bStat = fs.statSync(b);
+    return bStat.mtimeMs - aStat.mtimeMs;
+  });
+  return dirs[0];
+}
+
+function discoverFiles(runDir) {
+  const candidates = [];
+  const stepsDir = path.join(runDir, 'steps');
+  if (fs.existsSync(stepsDir)) {
+    for (const entry of fs.readdirSync(stepsDir, { withFileTypes: true })) {
+      if (entry.isFile() && entry.name.endsWith('.log')) {
+        candidates.push(path.join(stepsDir, entry.name));
+      }
+    }
+  }
+  return candidates;
+}
+
+function streamNewBytes(filePath) {
+  try {
+    const stat = fs.statSync(filePath);
+    const prev = watched.get(filePath) ?? 0;
+    if (stat.size < prev) {
+      watched.set(filePath, 0);
+      return;
+    }
+    if (stat.size === prev) {
+      return;
+    }
+    const fd = fs.openSync(filePath, 'r');
+    const chunk = Buffer.alloc(stat.size - prev);
+    fs.readSync(fd, chunk, 0, chunk.length, prev);
+    fs.closeSync(fd);
+    if (!currentHeader) {
+      currentHeader = filePath;
+      process.stdout.write(`\n--- ${path.relative(logsRoot, filePath)} ---\n`);
+    } else if (currentHeader !== filePath) {
+      currentHeader = filePath;
+      process.stdout.write(`\n--- ${path.relative(logsRoot, filePath)} ---\n`);
+    }
+    const text = chunk.toString('utf8');
+    for (const line of text.split(/\r?\n/)) {
+      if (line.length > 0) {
+        process.stdout.write(`[${new Date().toISOString()}] ${line}\n`);
+      }
+    }
+    watched.set(filePath, stat.size);
+  } catch {
+    // ignore transient file disappearance
+  }
+}
+
+function rescan() {
+  const runDir = latestRunDir();
+  if (!runDir) {
+    return;
+  }
+  if (runDir !== currentRunDir) {
+    currentRunDir = runDir;
+    watched.clear();
+    currentHeader = '';
+  }
+  for (const filePath of discoverFiles(runDir)) {
+    if (!watched.has(filePath)) {
+      watched.set(filePath, 0);
+    }
+    streamNewBytes(filePath);
+  }
+}
+
+const interval = setInterval(rescan, 250);
+process.on('SIGINT', () => {
+  clearInterval(interval);
+  process.exit(0);
+});
+process.on('SIGTERM', () => {
+  clearInterval(interval);
+  process.exit(0);
+});
+
+rescan();

--- a/sdk/scripts/release.sh
+++ b/sdk/scripts/release.sh
@@ -387,6 +387,11 @@ else
 fi
 
 echo -e "\n🚀 Publishing version $NEW_VERSION..."
+PUBLISH_ALREADY_DONE=false
+if npm view "${DEPENDENCY_NAME}@${NEW_VERSION}" version --registry=https://registry.npmjs.org/ >/dev/null 2>&1; then
+  PUBLISH_ALREADY_DONE=true
+  echo "  ℹ️  ${DEPENDENCY_NAME}@${NEW_VERSION} is already on npm; skipping publish."
+fi
 if [[ "$DRY_RUN" == true ]]; then
   if [[ "$VERSION_TYPE" == "test" ]]; then
     echo "  [DRY RUN] npm publish '$TARBALL_PATH' --tag test"
@@ -394,30 +399,38 @@ if [[ "$DRY_RUN" == true ]]; then
     echo "  [DRY RUN] npm publish '$TARBALL_PATH' --tag canary"
   elif [[ "$NEW_VERSION" == *"-beta."* ]]; then
     echo "  [DRY RUN] npm publish '$TARBALL_PATH' --tag latest"
-  elif [[ "$NEW_VERSION" == *"-"* ]]; then
+  elif [[ "$NEW_VERSION" == *"-*" ]]; then
     echo "  [DRY RUN] npm publish '$TARBALL_PATH' --tag pre"
   else
     echo "  [DRY RUN] npm publish '$TARBALL_PATH'"
   fi
+elif [[ "$PUBLISH_ALREADY_DONE" == true ]]; then
+  echo "  ✅ Publish already completed earlier."
 else
-  PUBLISH_CMD="npm publish \"$TARBALL_PATH\""
+  PUBLISH_CMD=(env npm_config_browser=false npm publish "$TARBALL_PATH")
   if [[ "$VERSION_TYPE" == "test" ]]; then
-    PUBLISH_CMD="$PUBLISH_CMD --tag test"
+    PUBLISH_CMD+=(--tag test)
   elif [[ "$VERSION_TYPE" == "canary" || "$IS_CANARY_VERSION" == true ]]; then
-    PUBLISH_CMD="$PUBLISH_CMD --tag canary"
+    PUBLISH_CMD+=(--tag canary)
   elif [[ "$NEW_VERSION" == *"-beta."* ]]; then
-    PUBLISH_CMD="$PUBLISH_CMD --tag latest"
-  elif [[ "$NEW_VERSION" == *"-"* ]]; then
+    PUBLISH_CMD+=(--tag latest)
+  elif [[ "$NEW_VERSION" == *"-*" ]]; then
     # Other pre-releases should use the 'pre' dist-tag
-    PUBLISH_CMD="$PUBLISH_CMD --tag pre"
+    PUBLISH_CMD+=(--tag pre)
   fi
-  if ! eval $PUBLISH_CMD; then
-    echo -e "\n❌ Publish failed. Rolling back version commit..."
+
+  printf '  [PUBLISH] %q ' "${PUBLISH_CMD[@]}"
+  printf '\n'
+  PUBLISH_CMD_STR=$(printf '%q ' "${PUBLISH_CMD[@]}")
+  if script -q -e -c "$PUBLISH_CMD_STR" /dev/null; then
+    echo "  ✅ Published successfully."
+  else
+    echo ""
+    echo "  ❌ Publish failed."
     git reset --hard HEAD~1
     # The trap will clean up the tarball
     exit 1
   fi
-  echo "  ✅ Published successfully."
 fi
 
 echo -e "\n💾 Pushing commit and tag..."
@@ -433,6 +446,24 @@ if [[ "$DRY_RUN" == true ]]; then
     echo "    - Push: origin with tags"
   fi
 else
+  REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  RELEASE_REMOTE_URL_FILE="$REPO_ROOT/.agent-ci/runtime/release-remote-url"
+  RELEASE_REMOTE_URL=""
+  if [[ -f "$RELEASE_REMOTE_URL_FILE" ]]; then
+    RELEASE_REMOTE_URL="$(tr -d '\r\n' < "$RELEASE_REMOTE_URL_FILE")"
+    rm -f "$RELEASE_REMOTE_URL_FILE"
+  fi
+  if [[ -z "$RELEASE_REMOTE_URL" ]]; then
+    RELEASE_REMOTE_URL="$(git remote get-url origin 2>/dev/null || true)"
+  fi
+  if [[ -n "$RELEASE_REMOTE_URL" ]]; then
+    echo "  - Updating origin remote to $RELEASE_REMOTE_URL"
+    git remote set-url origin "$RELEASE_REMOTE_URL"
+  fi
+  if command -v gh >/dev/null 2>&1; then
+    gh auth setup-git >/dev/null 2>&1 || true
+  fi
+
   if [[ "$VERSION_TYPE" == "test" || "$VERSION_TYPE" == "canary" || "$IS_CANARY_VERSION" == true ]]; then
     echo "  - Creating tag for canary release..."
     git tag "$TAG_NAME"


### PR DESCRIPTION
## Problem

The containerized release path could publish a canary to npm and then fail while pushing the Git tag because the checkout remote inside agent-ci pointed at a localhost mirror. At the same time, the release logs were hard to follow because the actual step output stayed in agent-ci log files rather than the terminal.

## Solution

We keep the release flow containerized and make it recoverable after a partial run.

- We stream the agent-ci step logs to the terminal so the release URL and step output are visible while the run is in progress.
- We pass the real repository remote through the mounted workspace and have the release script rewrite `origin` before the tag push step.
- We skip npm publish when the exact version is already on npm, which makes a rerun finish the missing Git push instead of republishing the same tarball.

## Background

This change stays in the SDK repo and does not require any agent-ci repo changes. The release wrapper writes the real remote URL into the mounted workspace, and the release script reads it back during the push phase. That keeps the release fix local to the SDK while still letting us recover from the half-finished canary release we observed.

The release path was already exercised end to end: npm publish succeeded, the real GitHub remote was restored, and the missing tag was pushed successfully on rerun.