### PR TITLE
Harden agent-ci release flow

### DIFF
--- a/.agent-ci/workflows/community-release.yml
+++ b/.agent-ci/workflows/community-release.yml
@@ -8,7 +8,7 @@
 #
 # ALTERNATIVE (containerized): pnpm release:community:agent-ci
 #   Runs inside an agent-ci container. Requires auth tokens as env vars:
-#     NPM_TOKEN     npm publish token
+#     NPM_TOKEN     npm Automation/granular token with publish access
 #     VERSION_TYPE  patch | minor | major (default: patch)
 #
 # WHY agent-ci: Running releases in GitHub Actions exposes OIDC tokens and npm

--- a/.agent-ci/workflows/release.yml
+++ b/.agent-ci/workflows/release.yml
@@ -7,9 +7,12 @@
 #   gh CLI auth. No env vars needed.
 #
 # ALTERNATIVE (containerized): pnpm release:agent-ci
-#   Runs inside an agent-ci container. Requires auth tokens as env vars:
-#     NPM_TOKEN              npm publish token
-#     GH_TOKEN_FOR_RELEASES  GitHub token for release creation
+#   Runs inside an agent-ci container. The pnpm release wrapper runs preflight
+#   checks, reads local auth, and writes temporary credential files:
+#     NPM_TOKEN              npm Automation/granular token with publish access
+#                            (or ~/.npmrc auth)
+#     GH_TOKEN_FOR_RELEASES  GitHub token for push + release creation
+#                            (or GH_TOKEN / gh auth token)
 #     VERSION_TYPE           patch | minor | explicit | test | canary
 #     VERSION                explicit version (required for VERSION_TYPE=explicit)
 #     CREATE_GH_RELEASE      true | false (default: true)
@@ -44,7 +47,9 @@ jobs:
           # We need to fetch all history for semver to work correctly and to push changes.
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.GH_TOKEN_FOR_RELEASES }}
+          # The release script configures its own push auth. Persisted checkout
+          # credentials can override gh's credential helper and break pushes.
+          persist-credentials: false
 
       - name: Set up Git user
         run: |
@@ -77,8 +82,28 @@ jobs:
       - name: Setup .npmrc for publishing
         working-directory: sdk
         run: |
+          TOKEN_FILE="$GITHUB_WORKSPACE/.agent-ci/runtime/release-npm-token"
+          SIGNAL_TOKEN_FILE="/tmp/agent-ci-signals/release-npm-token"
+          DRY_RUN_VALUE="${{ secrets.DRY_RUN }}"
           echo "registry=https://registry.npmjs.org/" >> .npmrc
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> .npmrc
+
+          for _ in {1..120}; do
+            if [[ -s "$TOKEN_FILE" || -s "$SIGNAL_TOKEN_FILE" ]]; then
+              break
+            fi
+            sleep 0.5
+          done
+
+          if [[ -s "$TOKEN_FILE" ]]; then
+            printf '//registry.npmjs.org/:_authToken=%s\n' "$(< "$TOKEN_FILE")" >> .npmrc
+          elif [[ -s "$SIGNAL_TOKEN_FILE" ]]; then
+            printf '//registry.npmjs.org/:_authToken=%s\n' "$(< "$SIGNAL_TOKEN_FILE")" >> .npmrc
+          elif [[ "$DRY_RUN_VALUE" == "true" ]]; then
+            echo "No npm token file found; continuing because this is a dry run."
+          else
+            echo "::error::Missing npm token file. Run releases through pnpm release so preflight can prepare credentials."
+            exit 1
+          fi
 
       - name: Run release script
         id: release_script
@@ -87,7 +112,6 @@ jobs:
           CI: "1"
           GITHUB_ACTIONS: "1"
           GITHUB_EVENT_NAME: "pull_request"
-          GH_TOKEN: ${{ secrets.GH_TOKEN_FOR_RELEASES }}
           RWSDK_RELEASE_BRANCH: ${{ secrets.RWSDK_RELEASE_BRANCH }}
         run: |
           VERSION_TYPE="${{ secrets.VERSION_TYPE }}"
@@ -117,7 +141,6 @@ jobs:
       - name: Create GitHub Release
         if: success()
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN_FOR_RELEASES }}
           CREATE_GH_RELEASE: ${{ secrets.CREATE_GH_RELEASE }}
           DRY_RUN: ${{ secrets.DRY_RUN }}
         run: |
@@ -128,6 +151,18 @@ jobs:
           if [[ "${DRY_RUN:-false}" == "true" ]]; then
             echo "Skipping GitHub release creation for dry run."
             exit 0
+          fi
+
+          GH_TOKEN_FILE="$GITHUB_WORKSPACE/.agent-ci/runtime/release-gh-token"
+          SIGNAL_GH_TOKEN_FILE="/tmp/agent-ci-signals/release-gh-token"
+          if [[ -s "$GH_TOKEN_FILE" ]]; then
+            export GH_TOKEN="$(< "$GH_TOKEN_FILE")"
+          elif [[ -s "$SIGNAL_GH_TOKEN_FILE" ]]; then
+            export GH_TOKEN="$(< "$SIGNAL_GH_TOKEN_FILE")"
+          fi
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "::error::Missing GitHub token. Run releases through pnpm release so preflight can prepare credentials."
+            exit 1
           fi
 
           FLAGS="--generate-notes"

--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,4 @@ starters/standard/.pnpm-store
 .devcontainer/kindling/
 .kindling/tasks/
 .env.agent-ci
+.agent-ci/runtime/

--- a/docs/architecture/releaseProcess.md
+++ b/docs/architecture/releaseProcess.md
@@ -35,6 +35,19 @@ This is the primary, manually-triggered event that kicks off a release. It deter
     -   **Stable & Beta versions** get the `--latest` flag, making them the primary release.
     -   **Pre-releases (alphas, etc.) and Test versions** get the `--prerelease` flag, marking them as such on GitHub.
 
+#### Local release preflight
+
+The supported release entrypoint is `pnpm release`. Before starting agent-ci, it checks that:
+
+- Docker is running.
+- The release is being run from an allowed branch (`main` or `next`, except `test`/`canary`).
+- npm auth is available through `NPM_TOKEN` or `~/.npmrc`.
+- npm package access can be confirmed when npm allows it. Granular publish tokens may not be able to list collaborators, so this check is informational and `npm publish` remains the final permission check.
+- GitHub auth is available through `GH_TOKEN_FOR_RELEASES`, `GH_TOKEN`, or `gh auth token`.
+- the GitHub token can read and push to `redwoodjs/sdk`.
+
+For real publishes, use an npm Automation/granular token with publish access. If npm asks for browser auth during publish, the token is not suitable for the containerized release.
+
 ### Stage 3: Artifact Release (`release-artifacts.yml`)
 
 The push of any new git tag automatically triggers this final stage, which prepares the starter and addon artifacts.

--- a/scripts/release-agent-ci.sh
+++ b/scripts/release-agent-ci.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR/.."
 
+DEPENDENCY_NAME="rwsdk"
+
 if [[ " $* " == *" --help "* ]]; then
   cd sdk
   ./scripts/release.sh --help
@@ -68,22 +70,251 @@ fi
 CURRENT_SHA="$(git rev-parse HEAD 2>/dev/null || true)"
 CURRENT_REMOTE_URL="$(git remote get-url origin 2>/dev/null || true)"
 
+NPM_TOKEN_SOURCE="NPM_TOKEN environment variable"
 if [[ -z "${NPM_TOKEN:-}" ]]; then
   USER_NPMRC="$(npm config get userconfig 2>/dev/null || true)"
   if [[ -n "$USER_NPMRC" && -f "$USER_NPMRC" ]]; then
     NPM_TOKEN="$(grep -E '^[[:space:]]*//registry\.npmjs\.org/:_authToken=' "$USER_NPMRC" | tail -n1 | sed 's/.*=//')"
+    NPM_TOKEN_SOURCE="$USER_NPMRC"
   else
     NPM_TOKEN=""
+    NPM_TOKEN_SOURCE="not found"
   fi
 fi
 
-if [[ -z "${GH_TOKEN:-}" ]]; then
+GH_TOKEN_SOURCE="GH_TOKEN environment variable"
+if [[ -z "${GH_TOKEN:-}" && -n "${GH_TOKEN_FOR_RELEASES:-}" ]]; then
+  GH_TOKEN="$GH_TOKEN_FOR_RELEASES"
+  GH_TOKEN_SOURCE="GH_TOKEN_FOR_RELEASES environment variable"
+elif [[ -z "${GH_TOKEN:-}" ]]; then
   if command -v gh >/dev/null 2>&1; then
     GH_TOKEN="$(gh auth token 2>/dev/null || true)"
+    GH_TOKEN_SOURCE="gh auth token"
+  else
+    GH_TOKEN=""
+    GH_TOKEN_SOURCE="not found"
   fi
 fi
 if [[ "$GH_TOKEN" == "null" ]]; then
   GH_TOKEN=""
+  GH_TOKEN_SOURCE="not found"
+fi
+
+repo_slug_from_remote() {
+  local remote_url="$1"
+  local repo_slug=""
+
+  case "$remote_url" in
+    https://github.com/*)
+      repo_slug="${remote_url#https://github.com/}"
+      repo_slug="${repo_slug%.git}"
+      ;;
+    git@github.com:*)
+      repo_slug="${remote_url#git@github.com:}"
+      repo_slug="${repo_slug%.git}"
+      ;;
+  esac
+
+  if [[ -z "$repo_slug" ]]; then
+    repo_slug="${GITHUB_REPOSITORY:-redwoodjs/sdk}"
+  fi
+
+  printf '%s' "$repo_slug"
+}
+
+sanitize_output() {
+  sed -E \
+    -e 's#(//registry\.npmjs\.org/:_authToken=)[^[:space:]"'"'"']+#\1***#g' \
+    -e 's#\b(npm_)[A-Za-z0-9_=-]+\b#\1***#g' \
+    -e 's#\b(github_pat_)[A-Za-z0-9_]+\b#\1***#g' \
+    -e 's#\b(gh[opsu]_)[A-Za-z0-9_]+\b#\1***#g' \
+    -e 's#(authId=)[A-Za-z0-9-]+#\1***#g'
+}
+
+PREFLIGHT_ERRORS=0
+PREFLIGHT_WARNINGS=0
+preflight_ok() {
+  echo "  ✓ $*"
+}
+preflight_warn() {
+  echo "  ⚠ $*"
+  PREFLIGHT_WARNINGS=$((PREFLIGHT_WARNINGS + 1))
+}
+preflight_error() {
+  echo "  ✗ $*"
+  PREFLIGHT_ERRORS=$((PREFLIGHT_ERRORS + 1))
+}
+
+run_release_preflight() {
+  PREFLIGHT_ERRORS=0
+  PREFLIGHT_WARNINGS=0
+
+  echo "[release] Preflight checks"
+  echo "[release] Requirements: Docker, Node/npm, an npm Automation/granular publish token for $DEPENDENCY_NAME, and a GitHub token that can push/create releases."
+
+  if command -v docker >/dev/null 2>&1; then
+    if docker info >/dev/null 2>&1; then
+      preflight_ok "Docker daemon is running"
+    else
+      preflight_error "Docker is installed, but the daemon is not reachable. Start Docker/OrbStack and retry."
+    fi
+  else
+    preflight_error "Docker CLI is not installed or not on PATH. agent-ci needs Docker to run the release container."
+  fi
+
+  if command -v node >/dev/null 2>&1; then
+    preflight_ok "Node is available ($(node --version))"
+  else
+    preflight_error "Node is not installed or not on PATH."
+  fi
+
+  if command -v npm >/dev/null 2>&1; then
+    preflight_ok "npm is available ($(npm --version 2>/dev/null))"
+  else
+    preflight_error "npm is not installed or not on PATH."
+  fi
+
+  if [[ "$VERSION_TYPE" == "explicit" && "$VERSION" == "none" ]]; then
+    preflight_error "explicit releases require --version <version>."
+  fi
+
+  if [[ "$VERSION_TYPE" != "test" && "$VERSION_TYPE" != "canary" ]]; then
+    case "$CURRENT_BRANCH" in
+      main|next)
+        preflight_ok "Release branch '$CURRENT_BRANCH' is allowed for $VERSION_TYPE releases"
+        ;;
+      *)
+        preflight_error "$VERSION_TYPE releases must run from main or next. Current branch is '$CURRENT_BRANCH'."
+        ;;
+    esac
+  else
+    preflight_ok "$VERSION_TYPE releases are allowed from branch '$CURRENT_BRANCH'"
+  fi
+
+  if [[ -n "$(git status --porcelain)" ]]; then
+    preflight_error "Working tree has uncommitted changes. Commit or stash them before running a real release."
+  else
+    preflight_ok "Working tree is clean"
+  fi
+
+  if [[ -n "$CURRENT_REMOTE_URL" ]]; then
+    preflight_ok "Git remote origin is configured"
+  else
+    preflight_warn "Git remote origin is not configured; final push may fail."
+  fi
+
+  local repo_slug
+  repo_slug="$(repo_slug_from_remote "$CURRENT_REMOTE_URL")"
+
+  if [[ "$DRY_RUN" == true ]]; then
+    preflight_ok "Dry run requested; npm/GitHub publish checks are informational"
+  fi
+
+  if [[ -z "$NPM_TOKEN" ]]; then
+    if [[ "$DRY_RUN" == true ]]; then
+      preflight_warn "No npm token found. Dry run can continue, but a real release needs NPM_TOKEN or ~/.npmrc auth."
+    else
+      preflight_error "No npm token found. Set NPM_TOKEN or add //registry.npmjs.org/:_authToken=... to your npm user config."
+    fi
+  else
+    preflight_ok "npm token found from $NPM_TOKEN_SOURCE"
+
+    local npmrc npm_user_output npm_user collabs_output permission profile_output tfa_mode
+    npmrc="$(mktemp)"
+    chmod 0600 "$npmrc"
+    {
+      printf 'registry=https://registry.npmjs.org/\n'
+      printf '//registry.npmjs.org/:_authToken=%s\n' "$NPM_TOKEN"
+    } > "$npmrc"
+
+    if npm_user_output="$(NPM_CONFIG_USERCONFIG="$npmrc" npm whoami --registry=https://registry.npmjs.org/ 2>&1)"; then
+      npm_user="$(printf '%s' "$npm_user_output" | tail -n1 | tr -d '\r')"
+      preflight_ok "npm token authenticates as $npm_user"
+
+      if collabs_output="$(NPM_CONFIG_USERCONFIG="$npmrc" npm access list collaborators "$DEPENDENCY_NAME" --json --registry=https://registry.npmjs.org/ 2>&1)"; then
+        permission="$(COLLABS_JSON="$collabs_output" NPM_USER="$npm_user" node -e 'const data = JSON.parse(process.env.COLLABS_JSON || "{}"); const user = process.env.NPM_USER || ""; process.stdout.write(data[user] || "");' 2>/dev/null || true)"
+        if [[ "$permission" == "read-write" ]]; then
+          preflight_ok "npm user has read-write access to $DEPENDENCY_NAME"
+        else
+          preflight_warn "Could not confirm package access for npm user '$npm_user' from this token (reported access: ${permission:-none}). Granular publish tokens often cannot list collaborators; continuing and letting npm publish be the final check."
+        fi
+      else
+        preflight_warn "Could not verify npm collaborator access for $DEPENDENCY_NAME: $(printf '%s' "$collabs_output" | sanitize_output | tail -n1)"
+      fi
+
+      if profile_output="$(NPM_CONFIG_USERCONFIG="$npmrc" npm profile get --json --registry=https://registry.npmjs.org/ 2>&1)"; then
+        tfa_mode="$(PROFILE_JSON="$profile_output" node -e 'const data = JSON.parse(process.env.PROFILE_JSON || "{}"); process.stdout.write(data?.tfa?.mode || "unknown");' 2>/dev/null || true)"
+        if [[ -n "$tfa_mode" && "$tfa_mode" != "unknown" ]]; then
+          preflight_ok "npm account 2FA mode: $tfa_mode"
+          if [[ "$tfa_mode" != "auth-only" && "$tfa_mode" != "disabled" ]]; then
+            preflight_warn "npm account has 2FA on writes; use an Automation/granular publish token so the container can publish non-interactively."
+          fi
+        fi
+      else
+        preflight_warn "Could not inspect npm profile 2FA settings."
+      fi
+    else
+      if [[ "$DRY_RUN" == true ]]; then
+        preflight_warn "npm token did not pass whoami: $(printf '%s' "$npm_user_output" | sanitize_output | tail -n1)"
+      else
+        preflight_error "npm token did not pass whoami: $(printf '%s' "$npm_user_output" | sanitize_output | tail -n1)"
+      fi
+    fi
+
+    rm -f "$npmrc"
+
+    if [[ "$DRY_RUN" != true ]]; then
+      preflight_warn "npm CLI cannot prove the token type before publish. If publish asks for browser auth or fails with E401/E404 from /-/v1/done, replace NPM_TOKEN with an npm Automation/granular token that has publish access to $DEPENDENCY_NAME."
+    fi
+  fi
+
+  if [[ -z "$GH_TOKEN" ]]; then
+    if [[ "$DRY_RUN" == true ]]; then
+      preflight_warn "No GitHub token found. Dry run can continue, but a real release needs GH_TOKEN or gh auth."
+    else
+      preflight_error "No GitHub token found. Set GH_TOKEN/GH_TOKEN_FOR_RELEASES or run gh auth login."
+    fi
+  else
+    preflight_ok "GitHub token found from $GH_TOKEN_SOURCE"
+    if command -v gh >/dev/null 2>&1; then
+      local gh_user gh_repo gh_push
+      if gh_user="$(GH_TOKEN="$GH_TOKEN" gh api user --jq '.login' 2>&1)"; then
+        preflight_ok "GitHub token authenticates as $gh_user"
+      else
+        preflight_error "GitHub token did not authenticate with gh api: $(printf '%s' "$gh_user" | sanitize_output | tail -n1)"
+      fi
+
+      if gh_repo="$(GH_TOKEN="$GH_TOKEN" gh api "repos/$repo_slug" --jq '.full_name' 2>&1)"; then
+        preflight_ok "GitHub token can read $gh_repo"
+        gh_push="$(GH_TOKEN="$GH_TOKEN" gh api "repos/$repo_slug" --jq '(.permissions.push // false) or (.permissions.admin // false)' 2>/dev/null || true)"
+        if [[ "$gh_push" == "true" ]]; then
+          preflight_ok "GitHub token reports push/admin access to $repo_slug"
+        else
+          preflight_warn "Could not confirm push/admin access for $repo_slug. The final git push may fail if the token is read-only."
+        fi
+      else
+        preflight_error "GitHub token cannot read repo $repo_slug: $(printf '%s' "$gh_repo" | sanitize_output | tail -n1)"
+      fi
+    else
+      preflight_warn "gh CLI is not installed locally, so GitHub token validity could not be checked."
+    fi
+  fi
+
+  echo
+  if [[ $PREFLIGHT_ERRORS -gt 0 ]]; then
+    echo "[release] Preflight failed with $PREFLIGHT_ERRORS error(s) and $PREFLIGHT_WARNINGS warning(s)."
+    echo "[release] Fix the items above, then rerun pnpm release."
+    exit 1
+  fi
+
+  echo "[release] Preflight passed with $PREFLIGHT_WARNINGS warning(s)."
+  echo
+}
+
+if [[ "${SKIP_RELEASE_PREFLIGHT:-false}" == "true" ]]; then
+  echo "[release] Skipping preflight checks because SKIP_RELEASE_PREFLIGHT=true"
+else
+  run_release_preflight
 fi
 
 AGENT_CI_ARGS=(run --workflow .agent-ci/workflows/release.yml)
@@ -92,8 +323,6 @@ if [[ "$DRY_RUN" != true ]]; then
 fi
 
 export AI_AGENT=1
-export NPM_TOKEN="$NPM_TOKEN"
-export GH_TOKEN_FOR_RELEASES="$GH_TOKEN"
 export RWSDK_RELEASE_BRANCH="$CURRENT_BRANCH"
 export RWSDK_RELEASE_SHA="$CURRENT_SHA"
 export VERSION_TYPE="$VERSION_TYPE"
@@ -102,23 +331,114 @@ export CREATE_GH_RELEASE="$CREATE_GH_RELEASE"
 export DRY_RUN="$DRY_RUN"
 export SKIP_SMOKE_TESTS="$SKIP_SMOKE_TESTS"
 
-REMOTE_URL_FILE=".agent-ci/runtime/release-remote-url"
-mkdir -p "$(dirname "$REMOTE_URL_FILE")"
-printf '%s\n' "$CURRENT_REMOTE_URL" > "$REMOTE_URL_FILE"
-
 LOGS_ROOT="$HOME/Library/Application Support/agent-ci/logs"
+RUN_STARTED_MS="$(node -e 'process.stdout.write(String(Date.now()))')"
+
+find_release_runner_name() {
+  node --input-type=module - "$LOGS_ROOT" "$RUN_STARTED_MS" <<'NODE'
+import fs from 'node:fs';
+import path from 'node:path';
+
+const [logsRoot, startedMsRaw] = process.argv.slice(2);
+const startedMs = Number(startedMsRaw || '0') - 30_000;
+let best;
+
+try {
+  for (const entry of fs.readdirSync(logsRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory() || !entry.name.startsWith('agent-ci-')) continue;
+    const metadataPath = path.join(logsRoot, entry.name, 'metadata.json');
+    let metadata;
+    try {
+      metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
+    } catch {
+      continue;
+    }
+    if ((metadata.date || 0) < startedMs) continue;
+    if (metadata.taskId !== 'release') continue;
+    if (!String(metadata.workflowPath || '').endsWith('.agent-ci/workflows/release.yml')) continue;
+    if (!best || metadata.date > best.date) best = { name: entry.name, date: metadata.date };
+  }
+} catch {
+  // ignore
+}
+
+if (best) process.stdout.write(best.name);
+NODE
+}
+
+sync_release_credentials() {
+  local runner_name=""
+  local deadline=$((SECONDS + 300))
+
+  while (( SECONDS < deadline )); do
+    if [[ -z "$runner_name" ]]; then
+      runner_name="$(find_release_runner_name 2>/dev/null || true)"
+    fi
+
+    if [[ -n "$runner_name" ]] && docker inspect "$runner_name" >/dev/null 2>&1; then
+      if [[ "$(docker inspect -f '{{.State.Running}}' "$runner_name" 2>/dev/null || true)" == "true" ]]; then
+        printf '%s' "$NPM_TOKEN" | docker exec -i "$runner_name" sh -c 'umask 077; cat > /tmp/agent-ci-signals/release-npm-token' >/dev/null 2>&1 || true
+        printf '%s' "$CURRENT_REMOTE_URL" | docker exec -i "$runner_name" sh -c 'umask 077; cat > /tmp/agent-ci-signals/release-remote-url' >/dev/null 2>&1 || true
+        if [[ -n "$GH_TOKEN" ]]; then
+          printf '%s' "$GH_TOKEN" | docker exec -i "$runner_name" sh -c 'umask 077; cat > /tmp/agent-ci-signals/release-gh-token' >/dev/null 2>&1 || true
+        else
+          docker exec "$runner_name" rm -f /tmp/agent-ci-signals/release-gh-token >/dev/null 2>&1 || true
+        fi
+        echo "[release] Prepared release credentials for $runner_name"
+        return 0
+      fi
+    fi
+
+    sleep 0.5
+  done
+
+  echo "[release] Warning: timed out waiting to prepare release credentials for the agent-ci runner."
+}
+
 cleanup() {
   if [[ -n "${WATCHER_PID:-}" ]]; then
     kill "$WATCHER_PID" 2>/dev/null || true
+    wait "$WATCHER_PID" 2>/dev/null || true
+    WATCHER_PID=""
   fi
-  rm -f "$REMOTE_URL_FILE"
+  if [[ -n "${CREDENTIAL_SYNC_PID:-}" ]]; then
+    kill "$CREDENTIAL_SYNC_PID" 2>/dev/null || true
+    wait "$CREDENTIAL_SYNC_PID" 2>/dev/null || true
+    CREDENTIAL_SYNC_PID=""
+  fi
 }
 trap cleanup EXIT
 
-node "$SCRIPT_DIR/watch-agent-ci-logs.mjs" "$LOGS_ROOT" &
+echo "[release] Starting agent-ci release"
+echo "[release] Version type: $VERSION_TYPE"
+if [[ "$VERSION" != "none" ]]; then
+  echo "[release] Version: $VERSION"
+fi
+echo "[release] Branch: $CURRENT_BRANCH (${CURRENT_SHA:0:12})"
+echo "[release] npm token: $NPM_TOKEN_SOURCE"
+if [[ -n "$GH_TOKEN" ]]; then
+  echo "[release] GitHub token: $GH_TOKEN_SOURCE"
+else
+  echo "[release] GitHub token: not found"
+fi
+echo "[release] Logs: $LOGS_ROOT"
+echo
+
+node "$SCRIPT_DIR/watch-agent-ci-logs.mjs" "$LOGS_ROOT" "$RUN_STARTED_MS" &
 WATCHER_PID=$!
 
-npx --yes @redwoodjs/agent-ci "${AGENT_CI_ARGS[@]}"
+sync_release_credentials &
+CREDENTIAL_SYNC_PID=$!
+
+set +e
+env -u NPM_TOKEN -u GH_TOKEN -u GH_TOKEN_FOR_RELEASES npx --yes @redwoodjs/agent-ci "${AGENT_CI_ARGS[@]}"
 EXIT_CODE=$?
-cleanup
+set -e
+
+if [[ $EXIT_CODE -ne 0 ]]; then
+  echo
+  echo "[release] agent-ci failed with exit code $EXIT_CODE"
+  echo "[release] Logs are in: $LOGS_ROOT"
+fi
+
 exit "$EXIT_CODE"

--- a/scripts/watch-agent-ci-logs.mjs
+++ b/scripts/watch-agent-ci-logs.mjs
@@ -3,100 +3,207 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const logsRoot = process.argv[2];
+const sinceMs = Number(process.argv[3] || process.env.AGENT_CI_WATCH_SINCE_MS || '0');
+const initialCutoffMs = Number.isFinite(sinceMs) && sinceMs > 0 ? sinceMs - 30_000 : 0;
+
 if (!logsRoot) {
-  console.error('Usage: watch-agent-ci-logs.mjs <logs-root>');
+  console.error('Usage: watch-agent-ci-logs.mjs <logs-root> [since-ms]');
   process.exit(1);
 }
 
 const watched = new Map();
 let currentRunDir = '';
 let currentHeader = '';
+let announcedWaiting = false;
+let announcedRunDir = '';
+let announcedStreamingForRun = '';
+
+function safeStat(filePath) {
+  try {
+    return fs.statSync(filePath);
+  } catch {
+    return undefined;
+  }
+}
+
+function readMetadataDate(runDir) {
+  try {
+    const metadata = JSON.parse(fs.readFileSync(path.join(runDir, 'metadata.json'), 'utf8'));
+    return typeof metadata.date === 'number' ? metadata.date : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function discoverFiles(runDir, { includeInternal = false } = {}) {
+  const candidates = [];
+  const stepsDir = path.join(runDir, 'steps');
+  if (!fs.existsSync(stepsDir)) {
+    return candidates;
+  }
+
+  for (const entry of fs.readdirSync(stepsDir, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith('.log')) {
+      continue;
+    }
+
+    // Internal agent-ci/action runner logs are usually numeric or UUID-named.
+    // The human-named step logs contain the useful command output.
+    if (!includeInternal && (/^\d+\.log$/.test(entry.name) || /^[0-9a-f-]{36}\.log$/i.test(entry.name))) {
+      continue;
+    }
+
+    candidates.push(path.join(stepsDir, entry.name));
+  }
+
+  candidates.sort((a, b) => {
+    const aStat = safeStat(a);
+    const bStat = safeStat(b);
+    return (aStat?.mtimeMs ?? 0) - (bStat?.mtimeMs ?? 0) || a.localeCompare(b);
+  });
+  return candidates;
+}
+
+function runScore(runDir) {
+  let score = readMetadataDate(runDir);
+  for (const fileName of ['metadata.json', 'timeline.json', 'debug.log', 'outputs.json']) {
+    const stat = safeStat(path.join(runDir, fileName));
+    if (stat) {
+      score = Math.max(score, stat.mtimeMs);
+    }
+  }
+  const stepsStat = safeStat(path.join(runDir, 'steps'));
+  if (stepsStat) {
+    score = Math.max(score, stepsStat.mtimeMs);
+  }
+
+  // Standalone use (no since-ms) should still pick the latest updated run,
+  // even if only a step log changed. Release runs pass since-ms and avoid this
+  // more expensive scan across historical log directories.
+  if (initialCutoffMs === 0) {
+    for (const filePath of discoverFiles(runDir, { includeInternal: true })) {
+      const stat = safeStat(filePath);
+      if (stat) {
+        score = Math.max(score, stat.mtimeMs);
+      }
+    }
+  }
+  return score;
+}
 
 function latestRunDir() {
   if (!fs.existsSync(logsRoot)) {
     return '';
   }
+
   const dirs = fs
     .readdirSync(logsRoot, { withFileTypes: true })
     .filter((d) => d.isDirectory() && d.name.startsWith('agent-ci-'))
     .map((d) => path.join(logsRoot, d.name));
+
   if (dirs.length === 0) {
     return '';
   }
-  dirs.sort((a, b) => {
-    const aStat = fs.statSync(a);
-    const bStat = fs.statSync(b);
-    return bStat.mtimeMs - aStat.mtimeMs;
-  });
-  return dirs[0];
+
+  const scored = dirs
+    .map((dir) => ({ dir, score: runScore(dir) }))
+    .filter((entry) => entry.score >= initialCutoffMs);
+
+  if (initialCutoffMs > 0 && scored.length === 0) {
+    return '';
+  }
+
+  const candidates = scored.length > 0 ? scored : dirs.map((dir) => ({ dir, score: runScore(dir) }));
+  candidates.sort((a, b) => b.score - a.score || b.dir.localeCompare(a.dir));
+  return candidates[0]?.dir ?? '';
 }
 
-function discoverFiles(runDir) {
-  const candidates = [];
-  const stepsDir = path.join(runDir, 'steps');
-  if (fs.existsSync(stepsDir)) {
-    for (const entry of fs.readdirSync(stepsDir, { withFileTypes: true })) {
-      if (entry.isFile() && entry.name.endsWith('.log')) {
-        candidates.push(path.join(stepsDir, entry.name));
-      }
-    }
+function redact(text) {
+  return text
+    .replace(/(\/\/registry\.npmjs\.org\/:_authToken=)[^\s"']+/g, '$1***')
+    .replace(/(authId=)[A-Za-z0-9-]+/g, '$1***')
+    .replace(/\bnpm_[A-Za-z0-9_=-]+\b/g, 'npm_***')
+    .replace(/\bgithub_pat_[A-Za-z0-9_]+\b/g, 'github_pat_***')
+    .replace(/\bgh[opsu]_[A-Za-z0-9_]+\b/g, 'gh_***')
+    .replace(/((?:NPM_TOKEN|GH_TOKEN|GH_TOKEN_FOR_RELEASES|NODE_AUTH_TOKEN)\s*[:=]\s*)[^\s]+/g, '$1***');
+}
+
+function printHeader(filePath) {
+  if (announcedStreamingForRun !== currentRunDir) {
+    announcedStreamingForRun = currentRunDir;
+    process.stdout.write(`[release] Streaming agent-ci logs from ${path.basename(currentRunDir)}\n`);
   }
-  return candidates;
+
+  if (!currentHeader) {
+    currentHeader = filePath;
+    process.stdout.write(`\n--- ${path.relative(logsRoot, filePath)} ---\n`);
+  } else if (currentHeader !== filePath) {
+    currentHeader = filePath;
+    process.stdout.write(`\n--- ${path.relative(logsRoot, filePath)} ---\n`);
+  }
 }
 
 function streamNewBytes(filePath) {
   try {
     const stat = fs.statSync(filePath);
-    const prev = watched.get(filePath) ?? 0;
+    let prev = watched.get(filePath);
+
+    if (prev === undefined) {
+      // When agent-ci reuses a log directory, it can leave stale step logs behind.
+      // Skip old files, but stream new/current step logs from the beginning.
+      prev = initialCutoffMs > 0 && stat.mtimeMs < initialCutoffMs ? stat.size : 0;
+    }
+
     if (stat.size < prev) {
-      watched.set(filePath, 0);
-      return;
+      prev = 0;
     }
     if (stat.size === prev) {
+      watched.set(filePath, prev);
       return;
     }
+
     const fd = fs.openSync(filePath, 'r');
     const chunk = Buffer.alloc(stat.size - prev);
     fs.readSync(fd, chunk, 0, chunk.length, prev);
     fs.closeSync(fd);
-    if (!currentHeader) {
-      currentHeader = filePath;
-      process.stdout.write(`\n--- ${path.relative(logsRoot, filePath)} ---\n`);
-    } else if (currentHeader !== filePath) {
-      currentHeader = filePath;
-      process.stdout.write(`\n--- ${path.relative(logsRoot, filePath)} ---\n`);
-    }
-    const text = chunk.toString('utf8');
-    for (const line of text.split(/\r?\n/)) {
-      if (line.length > 0) {
-        process.stdout.write(`[${new Date().toISOString()}] ${line}\n`);
-      }
-    }
+
+    printHeader(filePath);
+    const text = redact(chunk.toString('utf8'));
+    process.stdout.write(text.endsWith('\n') ? text : `${text}\n`);
     watched.set(filePath, stat.size);
   } catch {
-    // ignore transient file disappearance
+    // Ignore transient file disappearance while agent-ci rotates/creates logs.
   }
 }
 
 function rescan() {
   const runDir = latestRunDir();
   if (!runDir) {
+    if (!announcedWaiting) {
+      process.stdout.write(`[release] Waiting for agent-ci logs in ${logsRoot}\n`);
+      announcedWaiting = true;
+    }
     return;
   }
+
   if (runDir !== currentRunDir) {
     currentRunDir = runDir;
     watched.clear();
     currentHeader = '';
+    announcedStreamingForRun = '';
   }
+
+  if (announcedRunDir !== runDir) {
+    announcedRunDir = runDir;
+    process.stdout.write(`[release] Found agent-ci run ${path.basename(runDir)}; waiting for runner output...\n`);
+  }
+
   for (const filePath of discoverFiles(runDir)) {
-    if (!watched.has(filePath)) {
-      watched.set(filePath, 0);
-    }
     streamNewBytes(filePath);
   }
 }
 
-const interval = setInterval(rescan, 250);
+const interval = setInterval(rescan, 500);
 process.on('SIGINT', () => {
   clearInterval(interval);
   process.exit(0);

--- a/sdk/scripts/release.sh
+++ b/sdk/scripts/release.sh
@@ -142,8 +142,11 @@ if [[ "$DRY_RUN" == true ]]; then
   echo "  [DRY RUN] git pull --rebase"
 else
   if [[ -n "$AGENT_CI_LOCAL" ]]; then
-    echo "  [AGENT CI] Resetting tracked workspace changes and skipping pull"
+    echo "  [AGENT CI] Resetting tracked workspace changes and checking out origin/${RWSDK_RELEASE_BRANCH:-main}"
     git reset --hard HEAD
+    RELEASE_BRANCH_FOR_CHECKOUT="${RWSDK_RELEASE_BRANCH:-main}"
+    git fetch origin "$RELEASE_BRANCH_FOR_CHECKOUT" --tags
+    git checkout -B "$RELEASE_BRANCH_FOR_CHECKOUT" "origin/$RELEASE_BRANCH_FOR_CHECKOUT"
   else
     git pull --rebase
   fi
@@ -427,6 +430,9 @@ else
   else
     echo ""
     echo "  ❌ Publish failed."
+    echo "  Hint: If npm printed an auth URL or returned E401/E404 from /-/v1/done,"
+    echo "  verify NPM_TOKEN is an npm automation/granular token with publish access"
+    echo "  to $DEPENDENCY_NAME. Interactive/2FA tokens cannot publish from agent-ci."
     git reset --hard HEAD~1
     # The trap will clean up the tarball
     exit 1
@@ -448,10 +454,21 @@ if [[ "$DRY_RUN" == true ]]; then
 else
   REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
   RELEASE_REMOTE_URL_FILE="$REPO_ROOT/.agent-ci/runtime/release-remote-url"
+  RELEASE_GH_TOKEN_FILE="$REPO_ROOT/.agent-ci/runtime/release-gh-token"
+  RELEASE_SIGNAL_DIR="${AGENT_CI_SIGNAL_DIR:-/tmp/agent-ci-signals}"
+  RELEASE_SIGNAL_REMOTE_URL_FILE="$RELEASE_SIGNAL_DIR/release-remote-url"
+  RELEASE_SIGNAL_GH_TOKEN_FILE="$RELEASE_SIGNAL_DIR/release-gh-token"
   RELEASE_REMOTE_URL=""
   if [[ -f "$RELEASE_REMOTE_URL_FILE" ]]; then
     RELEASE_REMOTE_URL="$(tr -d '\r\n' < "$RELEASE_REMOTE_URL_FILE")"
     rm -f "$RELEASE_REMOTE_URL_FILE"
+  elif [[ -f "$RELEASE_SIGNAL_REMOTE_URL_FILE" ]]; then
+    RELEASE_REMOTE_URL="$(tr -d '\r\n' < "$RELEASE_SIGNAL_REMOTE_URL_FILE")"
+  fi
+  if [[ -s "$RELEASE_GH_TOKEN_FILE" ]]; then
+    export GH_TOKEN="$(< "$RELEASE_GH_TOKEN_FILE")"
+  elif [[ -s "$RELEASE_SIGNAL_GH_TOKEN_FILE" ]]; then
+    export GH_TOKEN="$(< "$RELEASE_SIGNAL_GH_TOKEN_FILE")"
   fi
   if [[ -z "$RELEASE_REMOTE_URL" ]]; then
     RELEASE_REMOTE_URL="$(git remote get-url origin 2>/dev/null || true)"
@@ -462,6 +479,23 @@ else
   fi
   if command -v gh >/dev/null 2>&1; then
     gh auth setup-git >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${GH_TOKEN:-}" ]]; then
+    # actions/checkout can leave an http.extraheader with a short-lived local
+    # token. That header takes precedence over gh's credential helper and causes
+    # authenticated pushes to fail in agent-ci, so remove checkout credentials
+    # and set an explicit authenticated push URL for GitHub remotes.
+    git config --local --get-regexp '^includeif\..*\.path$' 2>/dev/null | while read -r key _; do
+      git config --local --unset-all "$key" || true
+    done
+    git config --local --unset-all http.https://github.com/.extraheader 2>/dev/null || true
+    git config --global --unset-all http.https://github.com/.extraheader 2>/dev/null || true
+    case "$RELEASE_REMOTE_URL" in
+      https://github.com/*)
+        RELEASE_PUSH_URL="https://x-access-token:${GH_TOKEN}@${RELEASE_REMOTE_URL#https://}"
+        git remote set-url --push origin "$RELEASE_PUSH_URL"
+        ;;
+    esac
   fi
 
   if [[ "$VERSION_TYPE" == "test" || "$VERSION_TYPE" == "canary" || "$IS_CANARY_VERSION" == true ]]; then


### PR DESCRIPTION
## Problem

The local release flow could get past npm publish and then fail during the GitHub push. It also hid useful progress in log files, and some credential checks were confusing for npm publish tokens. That made a failed release hard to understand and risky to recover.

## Solution

The release wrapper now runs clear preflight checks before agent-ci starts. It streams safer, redacted logs, prepares release credentials for the runner without putting tokens in workflow commands, and makes Git push use the intended GitHub token. The release docs and workflow comments now say what tokens are needed and what to expect.

## Validation

- `bash -n scripts/release-agent-ci.sh`
- `bash -n sdk/scripts/release.sh`
- `node --check scripts/watch-agent-ci-logs.mjs`
- `git diff --check`
- `./scripts/release-agent-ci.sh --help`
