### PR TITLE
Skip script tag transform for SSR bridge modules

### DIFF
--- a/docs/architecture/ssrBridge.md
+++ b/docs/architecture/ssrBridge.md
@@ -11,8 +11,9 @@ A single Vite environment cannot be configured to handle both sets of dependency
 ## The Solution: A Bridge Between Vite Environments
 
 Vite's [Environments API](https://vitejs.dev/guide/api-vite-environment.html) provides the necessary foundation to solve this. It allows us to define multiple, isolated configuration contexts within a single Vite server. We use this to create two distinct environments:
--   **`worker`**: The primary environment, configured for RSC. It respects the `"react-server"` export condition. All code ultimately runs in this environment.
--   **`ssr`**: A secondary environment, configured for traditional SSR. It does **not** use the `"react-server"` condition.
+
+- **`worker`**: The primary environment, configured for RSC. It respects the `"react-server"` export condition. All code ultimately runs in this environment.
+- **`ssr`**: A secondary environment, configured for traditional SSR. It does **not** use the `"react-server"` condition.
 
 To connect them, we introduced the concept of the **SSR Bridge**. The bridge is a special entry point (`rwsdk/__ssr_bridge`) that acts as a gateway to the `ssr` environment. Any code that needs to be rendered on the server (i.e., the "SSR" part of the RSC-then-SSR process) must pass through this bridge.
 
@@ -31,12 +32,17 @@ The implementation differs slightly between development and production builds.
 #### In Development
 
 In development, the process is dynamic.
+
 1.  When the `ssrBridgePlugin` sees an import for the bridge in the `worker` environment, it returns a virtual module ID prefixed with `virtual:rwsdk:ssr:`.
 2.  Vite then asks the plugin's `load` hook how to resolve this virtual ID.
 3.  The plugin calls `devServer.environments.ssr.fetchModule()`, asking the `ssr` environment to process the actual file.
 4.  The `ssr` environment resolves and transforms the module according to its own rules (e.g., using the standard React build).
 5.  The transformed code is returned to the `worker` environment.
 6.  Before finishing, the plugin inspects the returned code for any further imports. It rewrites these imports to also be prefixed with `virtual:rwsdk:ssr:`, ensuring that the entire dependency chain remains within the virtual SSR subgraph.
+
+#### Worker Transform Boundary
+
+Modules inside the virtual SSR subgraph are identified by IDs that start with `virtual:rwsdk:ssr:`. Vite may also surface those modules through its `/@id/` URL form, which is normalized back to the same virtual ID before bridge logic runs. They have already been resolved and transformed by the `ssr` environment before the `worker` environment sees them. Worker-side discovery transforms must treat those IDs as read-only bridge output and must not rewrite them again. For example, script/link tag discovery runs on normal worker `.tsx` modules, but skips virtual SSR modules to avoid injecting duplicate imports into already-transformed bridge code.
 
 #### In Production
 

--- a/sdk/src/vite/miniflareHMRPlugin.mts
+++ b/sdk/src/vite/miniflareHMRPlugin.mts
@@ -14,7 +14,7 @@ import { normalizeModulePath } from "../lib/normalizeModulePath.mjs";
 import { hasDirective as sourceHasDirective } from "./hasDirective.mjs";
 import { invalidateModule } from "./invalidateModule.mjs";
 import { isJsFile } from "./isJsFile.mjs";
-import { VIRTUAL_SSR_PREFIX } from "./ssrBridgePlugin.mjs";
+import { VIRTUAL_SSR_PREFIX } from "./ssrVirtualModule.mjs";
 
 const log = debug("rwsdk:vite:hmr-plugin");
 

--- a/sdk/src/vite/ssrBridgePlugin.mts
+++ b/sdk/src/vite/ssrBridgePlugin.mts
@@ -4,10 +4,13 @@ import type { Plugin, ViteDevServer } from "vite";
 import { INTERMEDIATE_SSR_BRIDGE_PATH } from "../lib/constants.mjs";
 import { externalModulesSet } from "./constants.mjs";
 import { findSsrImportCallSites } from "./findSsrSpecifiers.mjs";
+import {
+  isVirtualSsrModuleId,
+  normalizeVirtualSsrModuleId,
+  VIRTUAL_SSR_PREFIX,
+} from "./ssrVirtualModule.mjs";
 
 const log = debug("rwsdk:vite:ssr-bridge-plugin");
-
-export const VIRTUAL_SSR_PREFIX = "virtual:rwsdk:ssr:";
 
 export const ssrBridgePlugin = ({
   clientFiles,
@@ -100,11 +103,13 @@ export const ssrBridgePlugin = ({
 
               if (
                 args.path === "rwsdk/__ssr_bridge" ||
-                args.path.startsWith(VIRTUAL_SSR_PREFIX)
+                isVirtualSsrModuleId(args.path)
               ) {
-                log("Marking as external: %s", args.path);
+                const path =
+                  normalizeVirtualSsrModuleId(args.path) ?? args.path;
+                log("Marking as external: %s", path);
                 return {
-                  path: args.path,
+                  path,
                   external: true,
                 };
               }
@@ -139,9 +144,10 @@ export const ssrBridgePlugin = ({
         // context(justinvdm, 27 May 2025): In dev, we need to dynamically load
         // SSR modules, so we return the virtual id so that the dynamic loading
         // can happen in load()
-        if (id.startsWith(VIRTUAL_SSR_PREFIX)) {
-          if (id.endsWith(".css")) {
-            const newId = id + ".js";
+        const virtualSsrId = normalizeVirtualSsrModuleId(id);
+        if (virtualSsrId) {
+          if (virtualSsrId.endsWith(".css")) {
+            const newId = virtualSsrId + ".js";
             log(
               "Virtual CSS module, adding .js suffix. old: %s, new: %s",
               id,
@@ -150,8 +156,8 @@ export const ssrBridgePlugin = ({
             return newId;
           }
 
-          log("Returning virtual SSR id for dev: %s", id);
-          return id;
+          log("Returning virtual SSR id for dev: %s", virtualSsrId);
+          return virtualSsrId;
         }
 
         // context(justinvdm, 28 May 2025): The SSR bridge module is a special case -
@@ -170,12 +176,13 @@ export const ssrBridgePlugin = ({
         }
       } else {
         // In build mode, the behavior depends on the build pass
-        if (id.startsWith(VIRTUAL_SSR_PREFIX)) {
+        const virtualSsrId = normalizeVirtualSsrModuleId(id);
+        if (virtualSsrId) {
           if (this.environment.name === "worker") {
             log(
               "Virtual SSR module case (build-worker pass): resolving to external",
             );
-            return { id, external: true };
+            return { id: virtualSsrId, external: true };
           }
         }
 
@@ -198,11 +205,9 @@ export const ssrBridgePlugin = ({
       }
     },
     async load(id) {
-      if (
-        id.startsWith(VIRTUAL_SSR_PREFIX) &&
-        this.environment.name === "worker"
-      ) {
-        const realId = id.slice(VIRTUAL_SSR_PREFIX.length);
+      const virtualSsrId = normalizeVirtualSsrModuleId(id);
+      if (virtualSsrId && this.environment.name === "worker") {
+        const realId = virtualSsrId.slice(VIRTUAL_SSR_PREFIX.length);
         let idForFetch = realId.endsWith(".css.js")
           ? realId.slice(0, -3)
           : realId;

--- a/sdk/src/vite/ssrVirtualModule.mts
+++ b/sdk/src/vite/ssrVirtualModule.mts
@@ -1,0 +1,15 @@
+const VITE_ID_PREFIX = "/@id/";
+
+export const VIRTUAL_SSR_PREFIX = "virtual:rwsdk:ssr:";
+
+export function normalizeVirtualSsrModuleId(id: string): string | undefined {
+  const normalizedId = id.startsWith(VITE_ID_PREFIX)
+    ? id.slice(VITE_ID_PREFIX.length)
+    : id;
+
+  return normalizedId.startsWith(VIRTUAL_SSR_PREFIX) ? normalizedId : undefined;
+}
+
+export function isVirtualSsrModuleId(id: string): boolean {
+  return normalizeVirtualSsrModuleId(id) !== undefined;
+}

--- a/sdk/src/vite/transformJsxScriptTagsPlugin.hook.test.mts
+++ b/sdk/src/vite/transformJsxScriptTagsPlugin.hook.test.mts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import {
+  isVirtualSsrModuleId,
+  normalizeVirtualSsrModuleId,
+  VIRTUAL_SSR_PREFIX,
+} from "./ssrVirtualModule.mjs";
+import { transformJsxScriptTagsPlugin } from "./transformJsxScriptTagsPlugin.mjs";
+
+describe("isVirtualSsrModuleId", () => {
+  it.each([
+    [`${VIRTUAL_SSR_PREFIX}/src/Preview.tsx`, true],
+    [`${VIRTUAL_SSR_PREFIX}rwsdk/__ssr_bridge`, true],
+    [`/@id/${VIRTUAL_SSR_PREFIX}/src/Preview.tsx`, true],
+    [`/src/${VIRTUAL_SSR_PREFIX}Preview.tsx`, false],
+    ["/src/Preview.tsx", false],
+  ])("identifies %s as virtual SSR module id: %s", (id, expected) => {
+    expect(isVirtualSsrModuleId(id)).toBe(expected);
+  });
+
+  it("normalizes Vite /@id/ virtual SSR module URLs to bare module ids", () => {
+    expect(
+      normalizeVirtualSsrModuleId(`/@id/${VIRTUAL_SSR_PREFIX}/src/Preview.tsx`),
+    ).toBe(`${VIRTUAL_SSR_PREFIX}/src/Preview.tsx`);
+  });
+});
+
+describe("transformJsxScriptTagsPlugin transform hook", () => {
+  function createPlugin() {
+    const clientEntryPoints = new Set<string>();
+    const plugin = transformJsxScriptTagsPlugin({
+      clientEntryPoints,
+      projectRootDir: "/project/root/dir",
+    });
+
+    const configResolved = plugin.configResolved;
+    if (typeof configResolved === "function") {
+      configResolved.call({} as any, { command: "serve", base: "/" } as any);
+    } else {
+      configResolved?.handler.call(
+        {} as any,
+        { command: "serve", base: "/" } as any,
+      );
+    }
+
+    const transform =
+      typeof plugin.transform === "function"
+        ? plugin.transform
+        : plugin.transform?.handler;
+
+    if (!transform) {
+      throw new Error("Expected transform hook to be defined");
+    }
+
+    return { clientEntryPoints, transform: transform as any };
+  }
+
+  it.each([
+    `${VIRTUAL_SSR_PREFIX}/src/Preview.tsx`,
+    `/@id/${VIRTUAL_SSR_PREFIX}/src/Preview.tsx`,
+  ])("skips virtual SSR bridge module ids in worker: %s", async (id) => {
+    // Regression for #1210: virtual SSR bridge modules have .tsx ids but are
+    // already transformed by the ssr environment, so the worker transform must
+    // not run script-tag discovery on them again.
+    const { clientEntryPoints, transform } = createPlugin();
+    const ssrBridgeCode = `
+      import { jsx } from "react/jsx-runtime";
+      const __vite_ssr_import_0__ = await __vite_ssr_import__("react/jsx-runtime", { importedNames: ["jsx"] });
+      export function Preview() {
+        return jsx("script", { async: true, src: "https://example.com/a.js" });
+      }
+    `;
+
+    const result = await transform.call(
+      { environment: { name: "worker" } } as any,
+      ssrBridgeCode,
+      id,
+    );
+
+    expect(result).toBeNull();
+    expect(clientEntryPoints.size).toBe(0);
+  });
+
+  it("still transforms non-bridge worker .tsx modules", async () => {
+    const { transform } = createPlugin();
+    const code = `
+      import { jsx } from "react/jsx-runtime";
+      export function Preview() {
+        return jsx("script", { async: true, src: "https://example.com/a.js" });
+      }
+    `;
+
+    const result = await transform.call(
+      { environment: { name: "worker" } } as any,
+      code,
+      "/src/Preview.tsx",
+    );
+
+    expect(result).toBeTruthy();
+    expect(
+      typeof result === "object" && result !== null && "code" in result
+        ? result.code
+        : "",
+    ).toContain("nonce: requestInfo.rw.nonce");
+  });
+});

--- a/sdk/src/vite/transformJsxScriptTagsPlugin.mts
+++ b/sdk/src/vite/transformJsxScriptTagsPlugin.mts
@@ -11,6 +11,7 @@ import {
 import { type Plugin } from "vite";
 import { normalizeModulePath } from "../lib/normalizeModulePath.mjs";
 import { stripBase } from "../lib/stripBase.mjs";
+import { isVirtualSsrModuleId } from "./ssrVirtualModule.mjs";
 
 const log = debug("rwsdk:vite:transform-jsx-script-tags");
 
@@ -533,7 +534,6 @@ export const transformJsxScriptTagsPlugin = ({
       base = config.base || "/";
     },
     async transform(code, id) {
-
       if (
         isBuild &&
         this.environment?.name === "worker" &&
@@ -544,6 +544,10 @@ export const transformJsxScriptTagsPlugin = ({
 
       if (
         this.environment?.name === "worker" &&
+        // context(peterp, 29 May 2026): SSR bridge modules are already
+        // transformed by the `ssr` environment; rerunning script-tag discovery
+        // in the worker injects duplicate imports into virtual SSR modules.
+        !isVirtualSsrModuleId(id) &&
         id.endsWith(".tsx") &&
         hasJsxFunctions(code)
       ) {


### PR DESCRIPTION
## Problem

In dev mode, a server `.tsx` file could crash when a client component imported it through the SSR bridge. The worker tried to run script and link tag discovery on bridge code that had already been transformed by the SSR environment. That could inject duplicate imports and break startup with `Identifier '__vite_ssr_import_0__' has already been declared`.

Fixes #1210.

## Solution

Virtual SSR bridge modules are now recognized in one shared place and skipped by the worker script-tag transform. The bridge also normalizes Vite's `/@id/` form back to the same virtual SSR ID, so both shapes follow the same path. Normal worker `.tsx` files still get script and link tag handling.

## Technical Summary

- Added `ssrVirtualModule.mts` with `VIRTUAL_SSR_PREFIX`, `isVirtualSsrModuleId`, and `normalizeVirtualSsrModuleId` so SSR bridge IDs have one shared contract.
- Updated `transformJsxScriptTagsPlugin` to skip virtual SSR modules before running script/link discovery, preventing duplicate import injection in bridge output.
- Updated `ssrBridgePlugin` and `miniflareHMRPlugin` to use the shared virtual SSR helpers instead of owning the prefix in the bridge plugin.
- Added hook-level tests for bare `virtual:rwsdk:ssr:` IDs, Vite `/@id/virtual:rwsdk:ssr:` IDs, and the normal non-bridge transform path.
- Documented the worker transform boundary in the SSR bridge architecture notes.
