### PR TITLE
Ignore hash-only popstate navigation

### DIFF
--- a/sdk/src/runtime/client/navigation.test.ts
+++ b/sdk/src/runtime/client/navigation.test.ts
@@ -133,7 +133,7 @@ describe("onNavigate callback (issue #1123 regression)", () => {
       }),
     });
     vi.stubGlobal("window", {
-      location: { href: "http://localhost/" },
+      location: { href: "http://localhost/", pathname: "/", search: "" },
       addEventListener: vi.fn((event: string, handler: any) => {
         if (event === "popstate") capturedPopstateHandler = handler;
       }),
@@ -210,6 +210,7 @@ describe("onNavigate callback (issue #1123 regression)", () => {
 
     expect(capturedPopstateHandler).not.toBeNull();
 
+    (window.location as unknown as { pathname: string }).pathname = "/about";
     await capturedPopstateHandler!();
 
     expect(onNavigate).toHaveBeenCalled();
@@ -258,12 +259,14 @@ describe("initClientNavigation", () => {
   let capturedScrollHandler: (() => void) | null = null;
   let capturedPagehideHandler: (() => void) | null = null;
   let capturedVisibilityChangeHandler: (() => void) | null = null;
+  let capturedPopstateHandler: (() => Promise<void>) | null = null;
 
   beforeEach(() => {
     historyState = {};
     capturedScrollHandler = null;
     capturedPagehideHandler = null;
     capturedVisibilityChangeHandler = null;
+    capturedPopstateHandler = null;
     vi.clearAllMocks();
 
     const mockHistory = {
@@ -290,13 +293,16 @@ describe("initClientNavigation", () => {
     });
 
     vi.stubGlobal("window", {
-      location: { href: "http://localhost/" },
+      location: { href: "http://localhost/", pathname: "/", search: "" },
       addEventListener: vi.fn((event: string, handler: () => void) => {
         if (event === "scroll") {
           capturedScrollHandler = handler;
         }
         if (event === "pagehide") {
           capturedPagehideHandler = handler;
+        }
+        if (event === "popstate") {
+          capturedPopstateHandler = handler as () => Promise<void>;
         }
       }),
       history: mockHistory,
@@ -341,6 +347,27 @@ describe("initClientNavigation", () => {
     history.scrollRestoration = "auto";
     initClientNavigation();
     expect(history.scrollRestoration).toBe("manual");
+  });
+
+  it("ignores hash-only popstate events so anchor links keep their native scroll", async () => {
+    const onNavigate = vi.fn();
+    (globalThis as any).__rsc_callServer = vi.fn().mockResolvedValue(undefined);
+
+    const { onHydrated } = initClientNavigation({ onNavigate });
+    expect(capturedPopstateHandler).not.toBeNull();
+
+    (window.location as unknown as { hash: string; href: string }).hash =
+      "#heading";
+    (window.location as unknown as { hash: string; href: string }).href =
+      "http://localhost/#heading";
+    window.scrollY = 500;
+
+    await capturedPopstateHandler!();
+    onHydrated();
+
+    expect(onNavigate).not.toHaveBeenCalled();
+    expect((globalThis as any).__rsc_callServer).not.toHaveBeenCalled();
+    expect(window.scrollTo).not.toHaveBeenCalled();
   });
 
   it("does not write to history state on scroll", () => {

--- a/sdk/src/runtime/client/navigation.ts
+++ b/sdk/src/runtime/client/navigation.ts
@@ -63,6 +63,15 @@ export function validateClickEvent(event: MouseEvent, target: HTMLElement) {
 let IS_CLIENT_NAVIGATION = false;
 
 let scrollRestoration: ScrollRestorationController | null = null;
+let currentPathKey: string | null = null;
+
+function getLocationPathKey() {
+  return `${window.location.pathname ?? ""}${window.location.search ?? ""}`;
+}
+
+function getUrlPathKey(url: URL) {
+  return `${url.pathname ?? ""}${url.search ?? ""}` || getLocationPathKey();
+}
 
 export interface NavigateOptions {
   history?: "push" | "replace";
@@ -96,6 +105,7 @@ export async function navigate(
   } else {
     scrollRestoration?.replaceEntry(href, url, nextScrollPosition);
   }
+  currentPathKey = getUrlPathKey(url);
 
   if (scrollToTop) {
     scrollRestoration?.setPendingScroll({
@@ -156,6 +166,7 @@ export function initClientNavigation(opts: ClientNavigationOptions = {}) {
   IS_CLIENT_NAVIGATION = true;
   scrollRestoration = createScrollRestoration();
   scrollRestoration.initialize();
+  currentPathKey = getLocationPathKey();
 
   document.addEventListener(
     "click",
@@ -176,6 +187,14 @@ export function initClientNavigation(opts: ClientNavigationOptions = {}) {
   );
 
   window.addEventListener("popstate", async function handlePopState() {
+    const nextPathKey = getLocationPathKey();
+    const isHashOnlyChange = nextPathKey === currentPathKey;
+    currentPathKey = nextPathKey;
+
+    if (isHashOnlyChange) {
+      return;
+    }
+
     scrollRestoration?.restorePopStateScroll();
     await opts.onNavigate?.();
     await globalThis.__rsc_callServer(null, null, "navigation");


### PR DESCRIPTION
## Problem

Same-page anchor links could jump to the right heading, then immediately jump back to the top. This happened because the browser fired `popstate` for a hash-only URL change, and Redwood treated it like a full client navigation. The bug showed up on the RedwoodSDK docs site when using table-of-contents links.

Fixes #1215.

## Solution

Client navigation now remembers the current `pathname + search`. When `popstate` fires but only the hash changed, it lets the browser handle the anchor scroll on its own and skips the RSC navigation. The docs site uses `rwsdk` from the workspace, so it gets this fix the next time it deploys from this code.

## Technical Summary

- Track a path key for client navigation that ignores `location.hash`.
- Update the path key after `navigate()` pushes or replaces history, so normal route changes still work.
- Bail out of the `popstate` handler only when the path key did not change.
- Add a regression test that proves hash-only `popstate` does not call `onNavigate`, does not fetch a navigation payload, and does not apply pending scroll.

## Credit

Thanks to @arsdehnel for reporting this, explaining the root cause, and proposing the path-key fix in #1215.
