### PR TITLE
Fix server query re-export method metadata

### DIFF
--- a/sdk/src/vite/__snapshots__/transformServerFunctions.test.mts.snap
+++ b/sdk/src/vite/__snapshots__/transformServerFunctions.test.mts.snap
@@ -272,18 +272,14 @@ registerServerReference(__defaultServerFunction__, "/test.tsx", "default")
 `;
 
 exports[`useServerPlugin > TRANSFORMS > RE_EXPORT_CODE > CLIENT 1`] = `
-"import { createServerReference } from "rwsdk/client";
-
-export let sum = createServerReference("/test.tsx", "sum");
-export let multiply = createServerReference("/test.tsx", "multiply");
+"export { sum } from "./math";
+export { default as multiply } from "./multiply";
 "
 `;
 
 exports[`useServerPlugin > TRANSFORMS > RE_EXPORT_CODE > SSR 1`] = `
-"import { createServerReference } from "rwsdk/__ssr";
-
-export let sum = createServerReference("/test.tsx", "sum");
-export let multiply = createServerReference("/test.tsx", "multiply");
+"export { sum } from "./math";
+export { default as multiply } from "./multiply";
 "
 `;
 

--- a/sdk/src/vite/transformServerFunctions.mts
+++ b/sdk/src/vite/transformServerFunctions.mts
@@ -159,10 +159,12 @@ export const transformServerFunctions = (
       );
 
     const exportInfo = findExportInfo(code, normalizedId);
-    const allExports = new Set([
-      ...exportInfo.localFunctions,
-      ...exportInfo.reExports.map((r) => r.localName),
-    ]);
+    const reExportNames = new Set(exportInfo.reExports.map((r) => r.localName));
+    const allExports = new Set(
+      Array.from(exportInfo.localFunctions).filter(
+        (name) => !reExportNames.has(name),
+      ),
+    );
 
     // Check for default function exports that should also be named exports
     const defaultFunctionName = findDefaultFunctionName(code, normalizedId);
@@ -172,14 +174,40 @@ export const transformServerFunctions = (
 
     // Generate completely new code for SSR
     const s = new MagicString("");
-    if (environment === "ssr") {
-      s.append('import { createServerReference } from "rwsdk/__ssr";\n\n');
-    } else {
-      s.append('import { createServerReference } from "rwsdk/client";\n\n');
+    const hasDefExport = hasDefaultExport(code, normalizedId);
+    if (allExports.size > 0 || hasDefExport) {
+      if (environment === "ssr") {
+        s.append('import { createServerReference } from "rwsdk/__ssr";\n\n');
+      } else {
+        s.append('import { createServerReference } from "rwsdk/client";\n\n');
+      }
+    }
+
+    for (const reExport of exportInfo.reExports) {
+      const reExportStatement =
+        reExport.originalName === "default"
+          ? `export { default as ${reExport.localName} } from ${JSON.stringify(reExport.moduleSpecifier)};\n`
+          : reExport.originalName === reExport.localName
+            ? `export { ${reExport.originalName} } from ${JSON.stringify(reExport.moduleSpecifier)};\n`
+            : `export { ${reExport.originalName} as ${reExport.localName} } from ${JSON.stringify(reExport.moduleSpecifier)};\n`;
+
+      s.append(reExportStatement);
+      log(
+        `Preserved ${environment} re-export for function: %s (original: %s) from %s in normalizedId=%s`,
+        reExport.localName,
+        reExport.originalName,
+        reExport.moduleSpecifier,
+        normalizedId,
+      );
+    }
+
+    if (exportInfo.reExports.length > 0 && allExports.size > 0) {
+      s.append("\n");
     }
 
     const ext = path.extname(normalizedId).toLowerCase();
-    const lang = ext === ".tsx" || ext === ".jsx" ? Lang.Tsx : SgLang.TypeScript;
+    const lang =
+      ext === ".tsx" || ext === ".jsx" ? Lang.Tsx : SgLang.TypeScript;
     const root = sgParse(lang, code);
 
     for (const name of allExports) {
@@ -230,7 +258,7 @@ export const transformServerFunctions = (
     }
 
     // Check for default export in the actual module (not re-exports)
-    if (hasDefaultExport(code, normalizedId)) {
+    if (hasDefExport) {
       let method: string | undefined;
       let source: "action" | "query" = "action";
       const patterns = [

--- a/sdk/src/vite/transformServerFunctions.test.mts
+++ b/sdk/src/vite/transformServerFunctions.test.mts
@@ -190,6 +190,37 @@ export const getProject = serverQuery([
   };
 
   describe("TRANSFORMS", () => {
+    it("preserves client re-exports so serverQuery metadata comes from the defining module", () => {
+      const barrelResult = transformServerFunctions(
+        `
+"use server";
+
+export { getProject } from "./queries";
+`,
+        "/actions.ts",
+        "client",
+        new Set(),
+      );
+
+      expect(barrelResult?.code).toContain(
+        `export { getProject } from "./queries";`,
+      );
+      expect(barrelResult?.code).not.toContain(
+        `createServerReference("/actions.ts", "getProject")`,
+      );
+
+      const queryResult = transformServerFunctions(
+        SERVER_QUERY_GET_CODE,
+        "/queries.ts",
+        "client",
+        new Set(),
+      );
+
+      expect(queryResult?.code).toContain(
+        `createServerReference("/queries.ts", "getProject", "GET", "query")`,
+      );
+    });
+
     for (const [key, CODE] of Object.entries(TEST_CASES)) {
       describe(key, () => {
         it(`CLIENT`, () => {


### PR DESCRIPTION
## Problem

A `serverQuery` could break when it was re-exported from another `"use server"` file. The worker knew it was a `GET` query, but the client barrel created a new server reference that acted like a `POST` action. That mismatch caused a 405 response at runtime.

Fixes #1194.

## Solution

Client and SSR transforms now keep server-function re-exports as re-exports. This lets the original module create the server reference with the right method and query metadata. Barrel imports can keep working without turning queries into actions.

## Technical Summary

- Keep re-exported server functions linked to the module that defines them, instead of minting a new proxy from the barrel module.
- Continue creating `createServerReference` calls for local exports, where the transform can read `serverQuery` and `serverAction` metadata from the same file.
- Avoid importing `createServerReference` when a transformed client or SSR module only contains preserved re-exports.
- Add a regression test for a `"use server"` barrel that re-exports a `serverQuery`.
