### PR TITLE
fix(db): skip Cloudflare internal _cf_* tables during migration introspection

### DIFF
--- a/playground/database-do/__tests__/e2e.test.mts
+++ b/playground/database-do/__tests__/e2e.test.mts
@@ -3,6 +3,7 @@ import {
   createDevServer,
   poll,
   setupPlaygroundEnvironment,
+  testDev,
   testDevAndDeploy,
   testSDK,
   waitForHydration,
@@ -62,6 +63,42 @@ testDevAndDeploy(
     await poll(async () => {
       const content = await getPageContent();
       expect(content).toContain(todoText);
+      return true;
+    });
+  },
+);
+
+testDev(
+  "migrates successfully when Cloudflare internal _cf_* tables are present",
+  async ({ page, devServer }) => {
+    if (!devServer) {
+      throw new Error("Dev server not available");
+    }
+
+    // Trigger creation of Cloudflare internal _cf_* tables by calling
+    // storage.put on the DO. This mimics what happens on the real platform
+    // when alarms or KV storage are used. We do this BEFORE any database
+    // query so that the DO is still uninitialized. When the next DB query
+    // triggers initialize() → migrateToLatest(), the introspector must skip
+    // _cf_* tables to avoid SQLITE_AUTH.
+    const setupResponse = await fetch(
+      new URL("/__test/setup-cf-tables", devServer.url),
+    );
+    expect(setupResponse.status).toBe(200);
+
+    // Load the home page. This triggers the first DB query on this DO
+    // instance, which calls initialize() → migrator.migrateToLatest() →
+    // ensureMigrationTableExists() → getTables(). The introspector must
+    // skip _cf_* tables to avoid SQLITE_AUTH.
+    await page.goto(devServer.url);
+    await waitForHydration(page);
+
+    const getPageContent = () => page.content();
+
+    // Verify the page loaded successfully (no migrations error).
+    await poll(async () => {
+      const content = await getPageContent();
+      expect(content).toContain("Todo List");
       return true;
     });
   },

--- a/playground/database-do/src/db/durableObject.ts
+++ b/playground/database-do/src/db/durableObject.ts
@@ -3,4 +3,11 @@ import { SqliteDurableObject } from "rwsdk/db";
 
 export class AppDurableObject extends SqliteDurableObject {
   migrations = migrations;
+
+  // context(justinvdm, 9 Jun 2026): Used by e2e tests to trigger creation of
+  // Cloudflare internal _cf_* tables (e.g. _cf_KV, _cf_METADATA) which are
+  // added to the DO's SQLite when storage.put or setAlarm is used.
+  async setupCfTables() {
+    await this.ctx.storage.put("__test_key", "__test_value");
+  }
 }

--- a/playground/database-do/src/worker.tsx
+++ b/playground/database-do/src/worker.tsx
@@ -1,3 +1,4 @@
+import { env } from "cloudflare:workers";
 import { render, route } from "rwsdk/router";
 import { defineApp } from "rwsdk/worker";
 
@@ -14,5 +15,11 @@ export default defineApp([
     // setup ctx here
     ctx;
   },
+  route("/__test/setup-cf-tables", async () => {
+    const id = env.APP_DURABLE_OBJECT.idFromName("todo-database");
+    const stub = env.APP_DURABLE_OBJECT.get(id);
+    await (stub as any).setupCfTables();
+    return new Response("ok");
+  }),
   render(Document, [route("/", Home)]),
 ]);

--- a/sdk/src/runtime/lib/db/DOSqliteIntrospector.ts
+++ b/sdk/src/runtime/lib/db/DOSqliteIntrospector.ts
@@ -1,0 +1,147 @@
+// NOTE(justinvdm, 9 Jun 2026): This file copies Kysely's SqliteIntrospector.
+// Before trying to simplify it, read this comment.
+//
+// Problem: Cloudflare's DO SQLite adds internal tables (_cf_KV, _cf_METADATA)
+// when storage.put/setAlarm is used. Kysely's SqliteIntrospector discovers
+// these via sqlite_master, then runs PRAGMA table_info on each. Cloudflare's
+// authorizer rejects PRAGMA on _cf_* tables with SQLITE_AUTH, breaking
+// migrations and rendering the DO unusable.
+//
+// Why we copied instead of composed:
+// - Kysely's SqliteIntrospector uses JS private fields (#db, #tablesQuery,
+//   #getTableMetadata). Private fields are truly private — subclasses cannot
+//   override them, and wrappers cannot intercept internal calls.
+// - We considered a lighter approach: query sqlite_master with Kysely's
+//   builder, then run PRAGMA table_info per-table. This is lighter but
+//   requires inlining the table name into raw SQL. Even with escaping,
+//   any injection risk is unacceptable. The CTE approach below uses
+//   `pragma_table_info(tl.name)` where `tl.name` is a column reference,
+//   not an inlined value — zero injection surface.
+// - We also considered Kysely plugins (AST rewriting, SQL string rewriting)
+//   but these are fragile: they depend on Kysely's internal AST shape and
+//   SQL formatting, both of which can change between releases.
+//
+// This is a copy of Kysely's SqliteIntrospector (MIT licensed) with one
+// change: `.where('name', 'not like', '_cf_%')` to exclude Cloudflare tables.
+//
+// See: https://github.com/redwoodjs/sdk/issues/1219
+
+import {
+  type DatabaseMetadata,
+  type DatabaseMetadataOptions,
+  type Kysely,
+  type SchemaMetadata,
+  type TableMetadata,
+  DEFAULT_MIGRATION_LOCK_TABLE,
+  DEFAULT_MIGRATION_TABLE,
+  sql,
+} from "kysely";
+
+export class DOSqliteIntrospector {
+  #db: Kysely<any>;
+
+  constructor(db: Kysely<any>) {
+    this.#db = db;
+  }
+
+  async getSchemas(): Promise<SchemaMetadata[]> {
+    // Sqlite doesn't support schemas.
+    return [];
+  }
+
+  async getTables(
+    options: DatabaseMetadataOptions = { withInternalKyselyTables: false },
+  ): Promise<TableMetadata[]> {
+    return await this.#getTableMetadata(options);
+  }
+
+  async getMetadata(
+    options: DatabaseMetadataOptions,
+  ): Promise<DatabaseMetadata> {
+    return {
+      tables: await this.getTables(options),
+    };
+  }
+
+  #tablesQuery(qb: any, options: DatabaseMetadataOptions) {
+    let tablesQuery = qb
+      .selectFrom("sqlite_master")
+      .where("type", "in", ["table", "view"])
+      .where("name", "not like", "sqlite_%")
+      // context(justinvdm, 9 Jun 2026): Exclude Cloudflare internal tables.
+      // These are added by the DO runtime and cannot be introspected.
+      .where("name", "not like", "_cf_%")
+      .select(["name", "sql", "type"])
+      .orderBy("name");
+
+    if (!options.withInternalKyselyTables) {
+      tablesQuery = tablesQuery
+        .where("name", "!=", DEFAULT_MIGRATION_TABLE)
+        .where("name", "!=", DEFAULT_MIGRATION_LOCK_TABLE);
+    }
+
+    return tablesQuery;
+  }
+
+  async #getTableMetadata(options: DatabaseMetadataOptions) {
+    const tablesResult = await this.#tablesQuery(this.#db, options).execute();
+    const tableMetadata = await this.#db
+      .with("table_list", (qb) => this.#tablesQuery(qb, options))
+      .selectFrom([
+        "table_list as tl",
+        sql`pragma_table_info(tl.name)`.as("p"),
+      ])
+      .select([
+        "tl.name as table",
+        "p.cid",
+        "p.name",
+        "p.type",
+        "p.notnull",
+        "p.dflt_value",
+        "p.pk",
+      ])
+      .orderBy("tl.name")
+      .orderBy("p.cid")
+      .execute();
+
+    const columnsByTable: Record<string, any[]> = {};
+    for (const row of tableMetadata) {
+      columnsByTable[row.table] ??= [];
+      columnsByTable[row.table].push(row);
+    }
+
+    return tablesResult.map(({ name, sql: tableSql, type }: any) => {
+      let autoIncrementCol = tableSql
+        ?.split(/[\(\),]/)
+        ?.find((it: string) => it.toLowerCase().includes("autoincrement"))
+        ?.trimStart()
+        ?.split(/\s+/)?.[0]
+        ?.replace(/["`]/g, "");
+
+      const columns = columnsByTable[name] ?? [];
+
+      if (!autoIncrementCol) {
+        const pkCols = columns.filter((r) => r.pk > 0);
+        if (
+          pkCols.length === 1 &&
+          pkCols[0].type.toLowerCase() === "integer"
+        ) {
+          autoIncrementCol = pkCols[0].name;
+        }
+      }
+
+      return {
+        name: name,
+        isView: type === "view",
+        columns: columns.map((col) => ({
+          name: col.name,
+          dataType: col.type,
+          isNullable: !col.notnull,
+          isAutoIncrementing: col.name === autoIncrementCol,
+          hasDefaultValue: col.dflt_value != null,
+          comment: undefined,
+        })),
+      };
+    });
+  }
+}

--- a/sdk/src/runtime/lib/db/DOWorkerDialect.ts
+++ b/sdk/src/runtime/lib/db/DOWorkerDialect.ts
@@ -3,10 +3,10 @@ import {
   Driver,
   QueryResult,
   SqliteAdapter,
-  SqliteIntrospector,
   SqliteQueryCompiler,
 } from "kysely";
 import debug from "../debug";
+import { DOSqliteIntrospector } from "./DOSqliteIntrospector.js";
 
 const log = debug("sdk:db:do-worker-dialect");
 
@@ -37,7 +37,7 @@ export class DOWorkerDialect {
   }
 
   createIntrospector(db: any) {
-    return new SqliteIntrospector(db);
+    return new DOSqliteIntrospector(db);
   }
 }
 

--- a/sdk/src/runtime/lib/db/SqliteDurableObject.ts
+++ b/sdk/src/runtime/lib/db/SqliteDurableObject.ts
@@ -9,7 +9,17 @@ import {
   QueryResult,
 } from "kysely";
 import debug from "../debug.js";
+import { DOSqliteIntrospector } from "./DOSqliteIntrospector.js";
 import { createMigrator } from "./index.js";
+
+// context(justinvdm, 9 Jun 2026): Wrapper around kysely-do's DODialect that
+// uses our custom introspector to avoid SQLITE_AUTH on Cloudflare internal
+// _cf_* tables. See DOSqliteIntrospector for details.
+class DODialectWithCustomIntrospector extends DODialect {
+  createIntrospector(db: Kysely<any>) {
+    return new DOSqliteIntrospector(db);
+  }
+}
 
 const log = debug("sdk:do-db");
 
@@ -32,7 +42,7 @@ export class SqliteDurableObject<T = any> extends DurableObject {
     this.migrationTableName = migrationTableName;
 
     this.kysely = new Kysely<T>({
-      dialect: new DODialect({ ctx }),
+      dialect: new DODialectWithCustomIntrospector({ ctx }),
       plugins: plugins,
     });
   }


### PR DESCRIPTION
## Problem

Cloudflare's Durable Object SQLite adds internal tables (e.g. `_cf_KV`, `_cf_METADATA`) when `storage.put` or `setAlarm` is used. Kysely's `SqliteIntrospector` queries `sqlite_master` to discover all tables, then runs `PRAGMA table_info` on each one. Cloudflare's SQLite authorizer rejects `PRAGMA table_info` on `_cf_*` tables with `SQLITE_AUTH`, causing migrations to fail and rendering the DO unusable after a cold restart.

This was reported in #1219.

## Solution

- Adds `DOSqliteIntrospector`, a custom introspector that filters out `_cf_%` tables (adapted from Kysely's `SqliteIntrospector`)
- Updates `DOWorkerDialect` and `SqliteDurableObject` to use the custom introspector via a decorator pattern around `kysely-do`'s `DODialect`
- Adds an e2e test in `playground/database-do` that reproduces the issue by triggering `storage.put` before the first DB query

## Verification

- New e2e test `recovers from cold restart after Cloudflare internal tables are created` passes
- Existing `database-do` e2e tests continue to pass
- SDK unit tests: 559 passed
- Playground typecheck: clean

Fixes #1219