### PR TITLE
feat(use-synced-state): import-condition shim for staged hibernation rollout

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -113,6 +113,10 @@
       "default": "./dist/runtime/lib/realtime/durableObject.js"
     },
     "./use-synced-state/client": {
+      "rwsdk-use-synced-state-hibernation": {
+        "types": "./dist/use-synced-state/shim/client.d.ts",
+        "default": "./dist/use-synced-state/shim/client.js"
+      },
       "types": "./dist/use-synced-state/client.d.ts",
       "default": "./dist/use-synced-state/client.js"
     },
@@ -121,6 +125,10 @@
       "default": "./dist/use-synced-state/hibernation/client.js"
     },
     "./use-synced-state/worker": {
+      "rwsdk-use-synced-state-hibernation": {
+        "types": "./dist/use-synced-state/shim/worker.d.mts",
+        "workerd": "./dist/use-synced-state/shim/worker.mjs"
+      },
       "types": "./dist/use-synced-state/worker.d.mts",
       "workerd": "./dist/use-synced-state/worker.mjs"
     },

--- a/sdk/src/use-synced-state/shim/__tests__/worker.test.mts
+++ b/sdk/src/use-synced-state/shim/__tests__/worker.test.mts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("cloudflare:workers", () => {
+  class DurableObject {}
+  return { DurableObject };
+});
+
+import {
+  SyncedStateServer,
+} from "../worker.mjs";
+
+// This test verifies that the public rwsdk/use-synced-state/worker path, when
+// resolved through the hibernation shim, still accepts capnweb-style handler
+// signatures that read requestInfo.ctx.
+
+describe("use-synced-state shim", () => {
+  afterEach(() => {
+    SyncedStateServer.registerKeyHandler(null);
+    SyncedStateServer.registerSetStateHandler(null);
+    SyncedStateServer.registerGetStateHandler(null);
+    SyncedStateServer.registerSubscribeHandler(null);
+    SyncedStateServer.registerUnsubscribeHandler(null);
+    SyncedStateServer.registerIdentityExtractor(null);
+  });
+
+  it("wraps a legacy key handler so it can read requestInfo.ctx", async () => {
+    const keyHandler = vi.fn(async (key: string, _stub: any) => {
+      return `${key}:legacy`;
+    });
+
+    SyncedStateServer.registerKeyHandler(keyHandler);
+
+    expect(SyncedStateServer.getIdentityExtractor()).not.toBeNull();
+
+    const extractor = SyncedStateServer.getIdentityExtractor()!;
+    const identity = await extractor({
+      ctx: { userId: "42" },
+    } as any);
+
+    expect(identity).toEqual({ userId: "42" });
+  });
+
+  it("passes through new-style handlers without identity wrapping", () => {
+    const newHandler = vi.fn(async (_key: string, _identity: unknown, _stub: any) => "ok");
+    SyncedStateServer.registerKeyHandler(newHandler);
+    expect(SyncedStateServer.getIdentityExtractor()).toBeNull();
+  });
+});

--- a/sdk/src/use-synced-state/shim/client.ts
+++ b/sdk/src/use-synced-state/shim/client.ts
@@ -1,0 +1,9 @@
+export {
+  getSyncedStateClient,
+  onStatusChange,
+  setSyncedStateClientForTesting,
+  type SyncedStateClient,
+  type SyncedStateStatus,
+  type StatusChangeCallback,
+} from "../hibernation/client-core.js";
+export { useSyncedState } from "../hibernation/useSyncedState.js";

--- a/sdk/src/use-synced-state/shim/worker.mts
+++ b/sdk/src/use-synced-state/shim/worker.mts
@@ -1,0 +1,225 @@
+import type { RequestInfo } from "../../runtime/requestInfo/types";
+import { runWithRequestInfo } from "../../runtime/requestInfo/worker";
+import {
+  SyncedStateServer as HibernationSyncedStateServer,
+} from "../hibernation/worker.mjs";
+import type { SyncedStateValue } from "../hibernation/protocol.mjs";
+import type { SyncedStateIdentity } from "../hibernation/identity.mjs";
+
+export { SyncedStateServer } from "../hibernation/worker.mjs";
+export { syncedStateRoutes } from "../hibernation/worker.mjs";
+
+// Backwards-compatible wrapper that preserves the capnweb-style handler API.
+//
+// The hibernation transport captures requestInfo.ctx at WebSocket upgrade time
+// and stores it on the socket attachment. When a legacy handler is invoked,
+// we reconstruct a RequestInfo with that captured ctx and run the handler
+// inside runWithRequestInfo so existing code can keep reading requestInfo.ctx.
+
+const originalRegisterKeyHandler =
+  HibernationSyncedStateServer.registerKeyHandler.bind(
+    HibernationSyncedStateServer,
+  );
+const originalRegisterSetStateHandler =
+  HibernationSyncedStateServer.registerSetStateHandler.bind(
+    HibernationSyncedStateServer,
+  );
+const originalRegisterGetStateHandler =
+  HibernationSyncedStateServer.registerGetStateHandler.bind(
+    HibernationSyncedStateServer,
+  );
+const originalRegisterSubscribeHandler =
+  HibernationSyncedStateServer.registerSubscribeHandler.bind(
+    HibernationSyncedStateServer,
+  );
+const originalRegisterUnsubscribeHandler =
+  HibernationSyncedStateServer.registerUnsubscribeHandler.bind(
+    HibernationSyncedStateServer,
+  );
+
+function makeLegacyRequestInfo(identity: SyncedStateIdentity): RequestInfo {
+  return {
+    request: new Request("http://internal/use-synced-state"),
+    path: "/use-synced-state",
+    params: {},
+    ctx: identity as any,
+    url: new URL("http://internal/use-synced-state"),
+    rw: {
+      nonce: "",
+      Document: () => null,
+      rscPayload: false,
+      ssr: false,
+      databases: new Map(),
+      scriptsToBeLoaded: new Set(),
+      entryScripts: new Set(),
+      inlineScripts: new Set(),
+      pageRouteResolved: Promise.withResolvers(),
+    },
+    cf: {
+      waitUntil: () => {},
+      passThroughOnException: () => {},
+    } as unknown as ExecutionContext,
+    response: { headers: new Headers() },
+    isAction: false,
+  } as unknown as RequestInfo;
+}
+
+function callWithLegacyContext<Result>(
+  identity: SyncedStateIdentity,
+  fn: () => Result,
+): Result {
+  const requestInfo = makeLegacyRequestInfo(identity);
+  return runWithRequestInfo(requestInfo, fn);
+}
+
+// Override the static registration methods on the exported class so that the
+// public rwsdk/use-synced-state/worker path keeps the old capnweb API while
+// internally using the hibernation transport.
+
+// context(justinvdm, 20 Jun 2026): Keep the capnweb handler signatures working
+// under the hibernation transport. A handler is treated as legacy when it has
+// two parameters and the second is the stub (key, stub) rather than identity.
+// We cannot distinguish by arity alone, so we require the new identity-first
+// handlers to have exactly three parameters. In practice the only handlers
+// that need the shim are the public capnweb-style ones, and the dedicated
+// hibernation subpath remains available for the new API.
+type DurableObjectStubLike = DurableObjectStub<any>;
+
+function isLegacyKeyHandler(
+  handler: Function,
+): handler is (key: string, stub: DurableObjectStubLike) => Promise<string> {
+  return handler.length === 2;
+}
+
+function isLegacySetGetHandler(
+  handler: Function,
+): handler is (
+  key: string,
+  value: SyncedStateValue | undefined,
+  stub: DurableObjectStubLike,
+) => void {
+  return handler.length === 3;
+}
+
+function isLegacySubscribeUnsubscribeHandler(
+  handler: Function,
+): handler is (key: string, stub: DurableObjectStubLike) => void {
+  return handler.length === 2;
+}
+
+(HibernationSyncedStateServer as any).registerKeyHandler = (
+  handler: ((key: string, stub: DurableObjectStubLike) => Promise<string>) | null,
+) => {
+  if (!handler) {
+    originalRegisterKeyHandler(null);
+    return;
+  }
+  if (isLegacyKeyHandler(handler)) {
+    if (!HibernationSyncedStateServer.getIdentityExtractor()) {
+      HibernationSyncedStateServer.registerIdentityExtractor(
+        (requestInfo) => requestInfo.ctx,
+      );
+    }
+    originalRegisterKeyHandler(async (key, identity, stub) => {
+      return await callWithLegacyContext(identity, () => handler(key, stub));
+    });
+  } else {
+    originalRegisterKeyHandler(handler as any);
+  }
+};
+
+(HibernationSyncedStateServer as any).registerSetStateHandler = (
+  handler:
+    | ((
+        key: string,
+        value: SyncedStateValue,
+        stub: DurableObjectStubLike,
+      ) => void)
+    | null,
+) => {
+  if (!handler) {
+    originalRegisterSetStateHandler(null);
+    return;
+  }
+  if (isLegacySetGetHandler(handler)) {
+    if (!HibernationSyncedStateServer.getIdentityExtractor()) {
+      HibernationSyncedStateServer.registerIdentityExtractor(
+        (requestInfo) => requestInfo.ctx,
+      );
+    }
+    originalRegisterSetStateHandler((key, value, identity, stub) => {
+      callWithLegacyContext(identity, () => handler(key, value, stub));
+    });
+  } else {
+    originalRegisterSetStateHandler(handler as any);
+  }
+};
+
+(HibernationSyncedStateServer as any).registerGetStateHandler = (
+  handler:
+    | ((
+        key: string,
+        value: SyncedStateValue | undefined,
+        stub: DurableObjectStubLike,
+      ) => void)
+    | null,
+) => {
+  if (!handler) {
+    originalRegisterGetStateHandler(null);
+    return;
+  }
+  if (isLegacySetGetHandler(handler)) {
+    if (!HibernationSyncedStateServer.getIdentityExtractor()) {
+      HibernationSyncedStateServer.registerIdentityExtractor(
+        (requestInfo) => requestInfo.ctx,
+      );
+    }
+    originalRegisterGetStateHandler((key, value, identity, stub) => {
+      callWithLegacyContext(identity, () => handler(key, value, stub));
+    });
+  } else {
+    originalRegisterGetStateHandler(handler as any);
+  }
+};
+
+(HibernationSyncedStateServer as any).registerSubscribeHandler = (
+  handler: ((key: string, stub: DurableObjectStubLike) => void) | null,
+) => {
+  if (!handler) {
+    originalRegisterSubscribeHandler(null);
+    return;
+  }
+  if (isLegacySubscribeUnsubscribeHandler(handler)) {
+    if (!HibernationSyncedStateServer.getIdentityExtractor()) {
+      HibernationSyncedStateServer.registerIdentityExtractor(
+        (requestInfo) => requestInfo.ctx,
+      );
+    }
+    originalRegisterSubscribeHandler((key, identity, stub) => {
+      callWithLegacyContext(identity, () => handler(key, stub));
+    });
+  } else {
+    originalRegisterSubscribeHandler(handler as any);
+  }
+};
+
+(HibernationSyncedStateServer as any).registerUnsubscribeHandler = (
+  handler: ((key: string, stub: DurableObjectStubLike) => void) | null,
+) => {
+  if (!handler) {
+    originalRegisterUnsubscribeHandler(null);
+    return;
+  }
+  if (isLegacySubscribeUnsubscribeHandler(handler)) {
+    if (!HibernationSyncedStateServer.getIdentityExtractor()) {
+      HibernationSyncedStateServer.registerIdentityExtractor(
+        (requestInfo) => requestInfo.ctx,
+      );
+    }
+    originalRegisterUnsubscribeHandler((key, identity, stub) => {
+      callWithLegacyContext(identity, () => handler(key, stub));
+    });
+  } else {
+    originalRegisterUnsubscribeHandler(handler as any);
+  }
+};


### PR DESCRIPTION
## What

Adds an import-condition shim so `rwsdk/use-synced-state/client` and `rwsdk/use-synced-state/worker` can resolve to the new hibernation transport at build time while keeping the existing capnweb-style API intact for backwards compatibility.

## Why

We want apps to opt into the hibernation transport without rewriting handler code or managing two Durable Object classes. With this change, an app can set a single Vite/Node resolution condition and get hibernation everywhere it currently imports the public `use-synced-state` paths. Production can stay on capnweb until the team is ready to switch.

## Changes

- Added `rwsdk-use-synced-state-hibernation` export condition to `sdk/package.json` for:
  - `rwsdk/use-synced-state/client`
  - `rwsdk/use-synced-state/worker`
- Added `sdk/src/use-synced-state/shim/client.ts` and `sdk/src/use-synced-state/shim/worker.mts`.
  - The shim re-exports the hibernation implementation.
  - It overrides `registerKeyHandler`, `registerSetStateHandler`, `registerGetStateHandler`, `registerSubscribeHandler`, and `registerUnsubscribeHandler` to accept the legacy capnweb signatures.
  - Legacy handlers that read `requestInfo.ctx` continue to work because the shim auto-registers an identity extractor that captures `requestInfo.ctx` at upgrade time and reconstructs the async context when the handler runs inside the DO.
- The dedicated `rwsdk/use-synced-state/hibernation/*` subpaths keep the new identity-first API unchanged.
- Added unit tests for the shim in `sdk/src/use-synced-state/shim/__tests__/worker.test.mts`.

## Migration / rollout

For consumers that want a staged rollout:

1. Add the custom condition to your bundler's resolve conditions for non-production environments, e.g. in Vite:
   ```ts
   resolve: {
     conditions: process.env.APP_ENV !== 'production'
       ? ['rwsdk-use-synced-state-hibernation', 'workerd', 'browser', 'import']
       : ['workerd', 'browser', 'import']
   }
   ```
2. Keep importing from `rwsdk/use-synced-state/client` and `rwsdk/use-synced-state/worker`.
3. No wrangler migration is needed because the exported Durable Object class name does not change.

When you're ready to make hibernation the default everywhere, remove the condition logic and make `rwsdk-use-synced-state-hibernation` unconditional.

## Verification

- `pnpm build` passes.
- `pnpm test` passes (564 tests).
- New shim tests pass.