### PR TITLE
Add navigation pending Suspense boundary

### DIFF
--- a/docs/architecture/clientNavigationPending.md
+++ b/docs/architecture/clientNavigationPending.md
@@ -1,0 +1,174 @@
+---
+title: Client Navigation Pending Boundaries
+description: How RedwoodSDK exposes Suspense-aware pending state for client-side RSC navigations.
+---
+
+## Problem
+
+Client-side navigation updates the browser URL before the next React Server Component (RSC) payload has committed to the visible tree. During that gap, the old server-rendered subtree can still be visible even though the address bar already represents the new route, search params, or pagination state.
+
+That behavior is expected at the transport level: history changes first, then the client requests and renders the next RSC payload. The problem is that app code needs a composable way to say:
+
+> This subtree depends on the pending navigation. Hide it behind my normal Suspense fallback until the matching RSC payload has committed.
+
+A plain `<Suspense>` boundary is not enough when the subtree can render immediately from old, already-resolved server props. RedwoodSDK needs to provide the promise that represents the navigation commit.
+
+## Goals
+
+- Keep loading UI app-owned through React `<Suspense fallback>`.
+- Track pending navigations by target URL and commit promise.
+- Resolve the pending promise when the matching RSC payload commits to the visible React tree, not merely when fetch completes.
+- Prevent stale navigation responses from committing after the browser has moved to a newer URL.
+- Let apps scope pending UI by all navigations, selected search params, explicit URL parts, or a custom predicate.
+- Avoid changing the baseline progressive-enhancement model: links remain normal links without JavaScript.
+
+## Public API
+
+`NavigationPending` and `useNavigationPending` are exported from `rwsdk/client`.
+
+```tsx
+import { Suspense } from "react";
+import { NavigationPending } from "rwsdk/client";
+
+<Suspense fallback={<ResultsSkeleton />}>
+  <NavigationPending searchParams={["search", "page"]}>
+    <ResultsTable />
+  </NavigationPending>
+</Suspense>;
+```
+
+By default, `NavigationPending` suspends for any pending client navigation. Apps can narrow this with:
+
+- `searchParams`: shorthand for watching a list of search params.
+- `watch`: explicit URL parts (`pathname`, `searchParams`, `hash`).
+- `when`: custom predicate that receives copies of `currentUrl` and `pendingUrl`.
+
+If multiple options are supplied, the implementation evaluates them in this order: `when`, then `watch`, then `searchParams`, then the default "any pending navigation" behavior.
+
+## Main Pieces
+
+### `navigationState.ts`
+
+This module owns the external navigation store used by React components:
+
+- `currentUrl`: the URL represented by the React tree that has committed.
+- `pending`: the latest navigation that has updated history but has not committed.
+- `beginPendingNavigation(url)`: creates a pending navigation with an id, URL snapshot, and deferred promise.
+- `commitPendingNavigation(href)`: resolves and clears the pending navigation when a matching payload commits.
+- `abortPendingNavigation(id?)`: resolves and clears a pending navigation when it is superseded, redirected, or fails.
+- `subscribeNavigationState()` / `getNavigationSnapshot()`: power `useSyncExternalStore`.
+
+When a new navigation starts, any previous pending promise is resolved. This prevents old Suspense boundaries from hanging after they are superseded.
+
+### `navigation.ts`
+
+`initClientNavigation()` and `navigate()` begin the pending navigation after history has been updated and before the RSC request is made.
+
+For link clicks and programmatic navigation:
+
+1. Record scroll intent.
+2. Update history.
+3. Call `beginPendingNavigation(targetUrl)`.
+4. Run `onNavigate` if present.
+5. Call `__rsc_callServer(null, null, "navigation")`.
+6. If the call throws, abort only that pending navigation id.
+
+For `popstate`, the same pending lifecycle is used after ignoring hash-only back/forward changes.
+
+`onHydrated(meta)` is returned from `initClientNavigation()` and passed to `initClient()`. It applies scroll, commits matching pending navigations, and then runs navigation cache maintenance.
+
+### `client.tsx`
+
+The default fetch transport captures the browser URL at the start of a navigation request. That captured URL is used for two things:
+
+1. The actual `?__rsc` request URL.
+2. The payload metadata passed to `setRscPayload`.
+
+When a navigation response returns, the transport checks whether the browser is still on the same navigation document. If the pathname or search params no longer match, the response is discarded. Hash-only differences are ignored because they do not change the server RSC document.
+
+If the discarded response belongs to the active pending navigation, the pending promise is resolved via `abortPendingNavigation()` so Suspense does not wait forever.
+
+`Content` stores both the RSC payload promise and metadata in state, then wraps rendering with `NavigationPayloadProvider`. After the payload commits, a React effect calls `onHydrated(meta)`. This is what makes the commit signal mean "visible React tree committed" instead of "fetch finished".
+
+### `navigationPending.tsx`
+
+`useNavigationPending()` subscribes to the external navigation store with `useSyncExternalStore`. During render it decides whether the current subtree cares about the pending navigation:
+
+- no options: suspend for any pending navigation;
+- `searchParams`: suspend if any watched param value changed;
+- `watch`: suspend if any watched URL part changed;
+- `when`: suspend if the custom predicate returns `true`.
+
+If the subtree should wait, the hook throws the pending navigation promise. React catches that promise at the nearest `<Suspense>` boundary and renders the app's fallback.
+
+There is one important exception: if React is currently rendering the matching navigation payload, the hook does not suspend. This lets the new payload pass through the same boundary and replace the stale tree. Without this exception, the boundary could keep suspending even while the correct RSC payload is rendering.
+
+## Lifecycle
+
+```text
+user clicks link / app calls navigate / browser fires popstate
+  -> history is updated
+  -> beginPendingNavigation(targetUrl)
+  -> old pending promise resolves if superseded
+  -> RSC navigation request starts
+  -> old tree re-renders and NavigationPending throws pending.promise
+  -> Suspense fallback is shown
+  -> RSC payload response returns
+  -> transport discards it if it no longer matches the browser document URL
+  -> setRscPayload(payload, { source: "navigation", href })
+  -> React renders the new payload
+  -> NavigationPending sees matching payload metadata and does not suspend
+  -> new tree commits
+  -> onHydrated(meta) runs
+  -> commitPendingNavigation(meta.href)
+  -> pending promise resolves
+```
+
+## URL Matching
+
+Navigation commit matching compares the RSC document URL, not the full browser URL. The hash is ignored:
+
+```text
+/results?search=abc
+/results?search=abc#details
+```
+
+Those URLs represent the same server-rendered document, so a response for the first URL may commit after the browser hash changes to the second URL.
+
+Apps can still choose to make a boundary sensitive to hash changes with:
+
+```tsx
+<NavigationPending watch={{ hash: true }} />
+```
+
+That affects whether the boundary suspends for a pending navigation; it does not mean the RSC response itself is different.
+
+## Custom Transports
+
+Custom transports should pass `RscPayloadMeta` to `transportContext.setRscPayload` when they update the visible RSC tree:
+
+```ts
+transportContext.setRscPayload(streamData, {
+  source: "navigation",
+  href: requestHref,
+});
+```
+
+If metadata is omitted, `onHydrated` falls back to the historical behavior and treats the commit as matching the current pending navigation. That preserves compatibility, but URL-aware pending behavior is more precise when metadata is provided.
+
+## Correctness Invariants
+
+- A pending navigation resolves when it commits, is superseded, is aborted, or is redirected away.
+- A navigation response may only update the tree if it still matches the current browser document URL.
+- Hash-only changes do not make an RSC navigation response stale.
+- Action payload commits do not resolve navigation pending state.
+- Stale or redirected responses must not leave the pending promise unresolved.
+- The matching new payload must be allowed to render through `NavigationPending`; otherwise the boundary would block the update it is waiting for.
+
+## Open Follow-Ups
+
+These are tracked separately from the initial implementation:
+
+- [#1242](https://github.com/redwoodjs/sdk/issues/1242): Track client navigation commits with request ids. This would distinguish rapid navigations to the exact same URL.
+- [#1243](https://github.com/redwoodjs/sdk/issues/1243): Abort superseded in-flight RSC navigation fetches. This is a resource optimization; stale-response guards remain the correctness mechanism.
+- [#1244](https://github.com/redwoodjs/sdk/issues/1244): Decide stale navigation handling for the deprecated realtime transport. This is separate from `use-synced-state`.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -56,6 +56,9 @@ This collection of documents provides a high-level overview of the core architec
 - [**Client-Side Navigation**](./clientSideNavigation.md)
   An explanation of how client-side navigation works in RedwoodSDK, providing a Single Page App (SPA) like experience.
 
+- [**Client Navigation Pending Boundaries**](./clientNavigationPending.md)
+  Explains how `NavigationPending` and `useNavigationPending` expose Suspense-aware pending state for client-side RSC navigations.
+
 - [**Router Architecture**](./router.md)
   Describes the core principles of the router, its flattened route table structure, and its performance characteristics.
 

--- a/docs/src/content/docs/guides/frontend/client-side-nav.mdx
+++ b/docs/src/content/docs/guides/frontend/client-side-nav.mdx
@@ -20,12 +20,11 @@ initClient({ handleResponse, onHydrated });
 ```
 
 <Aside type="note">
-  <strong>Note:</strong> The <code>onHydrated</code> callback is optional but
-  recommended. It's required for <code>NavigationPending</code> and for
-  prefetching (see the <a href="#prefetching-routes">Prefetching Routes</a>{" "}
-  section). It also handles cache eviction which helps prevent memory bloat. If
-  you're not using those features, you can omit it and only pass{" "}
-  <code>handleResponse</code> to <code>initClient</code>.
+  <strong>Note:</strong> The <code>onHydrated</code> callback is optional but recommended. It's
+  required for <code>NavigationPending</code> and for prefetching (see the{" "}
+  <a href="#prefetching-routes">Prefetching Routes</a> section). It also handles cache eviction
+  which helps prevent memory bloat. If you're not using those features, you can omit it and only
+  pass <code>handleResponse</code> to <code>initClient</code>.
 </Aside>
 
 Once this is initialized, internal `<a href="/some-path">` links will no longer trigger full-page reloads. Instead, the SDK will:
@@ -64,9 +63,7 @@ import { NavigationPending } from "rwsdk/client";
 export function PendingResults({ children }: { children: React.ReactNode }) {
   return (
     <Suspense fallback={<ResultsSkeleton />}>
-      <NavigationPending searchParams={["search", "page"]}>
-        {children}
-      </NavigationPending>
+      <NavigationPending searchParams={["search", "page"]}>{children}</NavigationPending>
     </Suspense>
   );
 }
@@ -74,8 +71,50 @@ export function PendingResults({ children }: { children: React.ReactNode }) {
 
 `<NavigationPending>` suspends for any pending navigation by default. Pass
 `searchParams`, `watch`, or `when` when only some URL changes should affect that
-subtree. It requires passing the `onHydrated` callback from
-`initClientNavigation()` into `initClient()`.
+subtree. Use one option at a time; if you combine them, `when` takes precedence
+over `watch`, and `watch` takes precedence over `searchParams`. It requires
+passing the `onHydrated` callback from `initClientNavigation()` into
+`initClient()`.
+
+### Watch exact URL parts
+
+Use `watch` when a subtree should wait for explicit parts of the URL. In this
+example, the table only shows its fallback when `search` or `page` changes; a
+pathname-only or hash-only change will not suspend it.
+
+```tsx
+<Suspense fallback={<ResultsSkeleton />}>
+  <NavigationPending
+    watch={{
+      pathname: false,
+      searchParams: ["search", "page"],
+      hash: false,
+    }}
+  >
+    <ResultsTable />
+  </NavigationPending>
+</Suspense>
+```
+
+When using `watch`, `pathname` defaults to `true`, `searchParams` defaults to
+`true`, and `hash` defaults to `false`.
+
+### Use a custom predicate
+
+Use `when` for app-specific rules. RedwoodSDK passes copies of the current and
+pending URLs, and the subtree suspends when your predicate returns `true`.
+
+```tsx
+<Suspense fallback={<TabSkeleton />}>
+  <NavigationPending
+    when={({ currentUrl, pendingUrl }) =>
+      currentUrl.searchParams.get("tab") !== pendingUrl.searchParams.get("tab")
+    }
+  >
+    <TabPanel />
+  </NavigationPending>
+</Suspense>
+```
 
 ## Configuring Scroll Behaviour
 

--- a/docs/src/content/docs/guides/frontend/client-side-nav.mdx
+++ b/docs/src/content/docs/guides/frontend/client-side-nav.mdx
@@ -21,11 +21,11 @@ initClient({ handleResponse, onHydrated });
 
 <Aside type="note">
   <strong>Note:</strong> The <code>onHydrated</code> callback is optional but
-  recommended. It's required if you're using prefetching (see the{" "}
-  <a href="#prefetching-routes">Prefetching Routes</a> section), and it also
-  handles cache eviction which helps prevent memory bloat. If you're not using
-  prefetching, you can omit it and only pass <code>handleResponse</code> to{" "}
-  <code>initClient</code>.
+  recommended. It's required for <code>NavigationPending</code> and for
+  prefetching (see the <a href="#prefetching-routes">Prefetching Routes</a>{" "}
+  section). It also handles cache eviction which helps prevent memory bloat. If
+  you're not using those features, you can omit it and only pass{" "}
+  <code>handleResponse</code> to <code>initClient</code>.
 </Aside>
 
 Once this is initialized, internal `<a href="/some-path">` links will no longer trigger full-page reloads. Instead, the SDK will:
@@ -48,6 +48,34 @@ No routing system is included: RedwoodSDK doesn't provide a client-side router. 
 Only internal links are intercepted: RedwoodSDK will only handle links pointing to the same origin. External links (https://example.com) or those with `target="\_blank"` behave normally.
 
 Middleware still runs: Every navigation hits your server again — so auth checks, headers, and streaming behavior remain intact.
+
+## Showing Loading UI During Pending Navigation
+
+Client-side navigation updates the URL before the new RSC tree commits. If a
+server-backed subtree would otherwise show stale props during that gap, wrap it
+with `NavigationPending` inside your own Suspense fallback.
+
+```tsx title="src/app/components/PendingResults.tsx"
+"use client";
+
+import { Suspense } from "react";
+import { NavigationPending } from "rwsdk/client";
+
+export function PendingResults({ children }: { children: React.ReactNode }) {
+  return (
+    <Suspense fallback={<ResultsSkeleton />}>
+      <NavigationPending searchParams={["search", "page"]}>
+        {children}
+      </NavigationPending>
+    </Suspense>
+  );
+}
+```
+
+`<NavigationPending>` suspends for any pending navigation by default. Pass
+`searchParams`, `watch`, or `when` when only some URL changes should affect that
+subtree. It requires passing the `onHydrated` callback from
+`initClientNavigation()` into `initClient()`.
 
 ## Configuring Scroll Behaviour
 

--- a/docs/src/content/docs/reference/sdk-client.mdx
+++ b/docs/src/content/docs/reference/sdk-client.mdx
@@ -190,10 +190,48 @@ import { NavigationPending } from "rwsdk/client";
 ```
 
 By default it suspends for any pending navigation. Use `searchParams`, `watch`,
-or `when` to make a subtree wait only for relevant URL changes. The lower-level
-`useNavigationPending()` hook uses the same options and suspends in the same way.
-Make sure the `onHydrated` callback returned by `initClientNavigation()` is
-passed to `initClient()` so pending navigations can resolve after commit.
+or `when` to make a subtree wait only for relevant URL changes. Use one option
+at a time; if you combine them, `when` takes precedence over `watch`, and
+`watch` takes precedence over `searchParams`.
+
+### Options
+
+| Prop           | Type                                                                                  | Description                                                                                          |
+| -------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `searchParams` | `readonly string[]`                                                                   | Shorthand for watching only the listed search params.                                                |
+| `watch`        | `{ pathname?: boolean; searchParams?: boolean \| readonly string[]; hash?: boolean }` | Explicit URL parts to watch. Defaults are `pathname: true`, `searchParams: true`, and `hash: false`. |
+| `when`         | `({ currentUrl, pendingUrl }) => boolean`                                             | Custom predicate. Return `true` when this subtree should suspend for the pending navigation.         |
+
+```tsx title="Watch explicit URL parts"
+<Suspense fallback={<ResultsSkeleton />}>
+  <NavigationPending
+    watch={{
+      pathname: false,
+      searchParams: ["search", "page"],
+      hash: false,
+    }}
+  >
+    <ResultsTable />
+  </NavigationPending>
+</Suspense>
+```
+
+```tsx title="Use a custom predicate"
+<Suspense fallback={<TabSkeleton />}>
+  <NavigationPending
+    when={({ currentUrl, pendingUrl }) =>
+      currentUrl.searchParams.get("tab") !== pendingUrl.searchParams.get("tab")
+    }
+  >
+    <TabPanel />
+  </NavigationPending>
+</Suspense>
+```
+
+The lower-level `useNavigationPending()` hook uses the same options and suspends
+in the same way. Make sure the `onHydrated` callback returned by
+`initClientNavigation()` is passed to `initClient()` so pending navigations can
+resolve after commit.
 
 ## `navigate`
 

--- a/docs/src/content/docs/reference/sdk-client.mdx
+++ b/docs/src/content/docs/reference/sdk-client.mdx
@@ -19,7 +19,7 @@ The `initClient` function is used to initialize the React Client. This hydrates 
 | `transport`          | `Transport`                           | Custom transport for server communication (defaults to `fetchTransport`)                                                                                    |
 | `hydrateRootOptions` | `HydrationOptions`                    | Options passed directly to React's `hydrateRoot`. Supports all React 19 hydration options including error handling (see examples below).                    |
 | `handleResponse`     | `(response: Response) => boolean`     | Custom response handler for navigation errors (navigation GETs)                                                                                             |
-| `onHydrated`         | `() => void`                          | Callback invoked after a new RSC payload has been committed on the client                                                                                   |
+| `onHydrated`         | `(meta?: RscPayloadMeta) => void`     | Callback invoked after a new RSC payload has been committed on the client                                                                                   |
 | `onActionResponse`   | `(actionResponse) => boolean \| void` | Optional hook invoked when an action returns a Response; return `true` to signal that the response has been handled and default behaviour should be skipped |
 
 ### Error Handling
@@ -116,8 +116,8 @@ initClient({
 ```tsx title="With client-side navigation"
 import { initClient, initClientNavigation } from "rwsdk/client";
 
-const { handleResponse } = initClientNavigation();
-initClient({ handleResponse });
+const { handleResponse, onHydrated } = initClientNavigation();
+initClient({ handleResponse, onHydrated });
 ```
 
 ## `initClientNavigation`
@@ -171,6 +171,29 @@ RedwoodSDK mirrors the behaviour of classic Multi Page Apps where each link clic
 brings you back to the **top** of the next page. This is the most common
 expectation and is therefore the default. You can turn it off or make it smooth
 with a single option – no additional libraries required.
+
+## `NavigationPending`
+
+`NavigationPending` is a Suspense-aware client component. Put it inside your own
+`<Suspense fallback>` to hide stale server-backed UI while a matching
+client-side RSC navigation is pending.
+
+```tsx
+import { Suspense } from "react";
+import { NavigationPending } from "rwsdk/client";
+
+<Suspense fallback={<ResultsSkeleton />}>
+  <NavigationPending searchParams={["search", "page"]}>
+    <ResultsTable />
+  </NavigationPending>
+</Suspense>;
+```
+
+By default it suspends for any pending navigation. Use `searchParams`, `watch`,
+or `when` to make a subtree wait only for relevant URL changes. The lower-level
+`useNavigationPending()` hook uses the same options and suspends in the same way.
+Make sure the `onHydrated` callback returned by `initClientNavigation()` is
+passed to `initClient()` so pending navigations can resolve after commit.
 
 ## `navigate`
 

--- a/sdk/src/runtime/client/client.tsx
+++ b/sdk/src/runtime/client/client.tsx
@@ -40,6 +40,11 @@ export type { ActionResponseData, RscPayloadMeta } from "./types";
 
 import { getCachedNavigationResponse } from "./navigationCache.js";
 import { NavigationPayloadProvider } from "./navigationPending.js";
+import {
+  abortPendingNavigation,
+  isPendingNavigationCommit,
+  isSameNavigationDocumentUrl,
+} from "./navigationState.js";
 import { configureRecovery, type RecoveryOptions } from "./recovery.js";
 import type {
   ActionResponseData,
@@ -110,8 +115,20 @@ export const fetchTransport: Transport = (transportContext) => {
       }
     }
 
-    const isStaleNavigationResponse = () =>
-      source === "navigation" && pageUrl.href !== window.location.href;
+    const discardStaleNavigationResponse = () => {
+      if (
+        source !== "navigation" ||
+        isSameNavigationDocumentUrl(pageUrl, window.location.href)
+      ) {
+        return false;
+      }
+
+      if (isPendingNavigationCommit(pageUrl)) {
+        abortPendingNavigation();
+      }
+
+      return true;
+    };
 
     const processActionResponse = (rawActionResult: any) => {
       if (isActionResponse(rawActionResult)) {
@@ -145,7 +162,7 @@ export const fetchTransport: Transport = (transportContext) => {
     // If there's a response handler, check the response first
     if (transportContext.handleResponse) {
       const response = await fetchPromise;
-      if (isStaleNavigationResponse()) {
+      if (discardStaleNavigationResponse()) {
         return undefined as any;
       }
 
@@ -160,7 +177,7 @@ export const fetchTransport: Transport = (transportContext) => {
       }) as Promise<RscActionResponse<Result>>;
 
       if (source === "navigation" || source === "action") {
-        if (isStaleNavigationResponse()) {
+        if (discardStaleNavigationResponse()) {
           return undefined as any;
         }
 
@@ -177,7 +194,7 @@ export const fetchTransport: Transport = (transportContext) => {
 
     // Original behavior when no handler is present
     const response = await fetchPromise;
-    if (isStaleNavigationResponse()) {
+    if (discardStaleNavigationResponse()) {
       return undefined as any;
     }
 
@@ -193,7 +210,7 @@ export const fetchTransport: Transport = (transportContext) => {
     }) as Promise<RscActionResponse<Result>>;
 
     if (source === "navigation" || source === "action") {
-      if (isStaleNavigationResponse()) {
+      if (discardStaleNavigationResponse()) {
         return undefined as any;
       }
 

--- a/sdk/src/runtime/client/client.tsx
+++ b/sdk/src/runtime/client/client.tsx
@@ -21,14 +21,31 @@ export { default as React } from "react";
 export type { Dispatch, MutableRefObject, SetStateAction } from "react";
 export { ClientOnly } from "./ClientOnly.js";
 export { initClientNavigation, navigate } from "./navigation.js";
-export type { ActionResponseData } from "./types";
+export {
+  NavigationPending,
+  useNavigationPending,
+} from "./navigationPending.js";
+export type {
+  NavigationPendingOptions,
+  NavigationPendingProps,
+  NavigationPendingWatch,
+  NavigationPendingWhenArgs,
+  NavigationSearchParamsWatch,
+} from "./navigationPending.js";
+export type {
+  NavigationSnapshot,
+  PendingNavigationSnapshot,
+} from "./navigationState.js";
+export type { ActionResponseData, RscPayloadMeta } from "./types";
 
 import { getCachedNavigationResponse } from "./navigationCache.js";
+import { NavigationPayloadProvider } from "./navigationPending.js";
 import { configureRecovery, type RecoveryOptions } from "./recovery.js";
 import type {
   ActionResponseData,
   HydrationOptions,
   RscActionResponse,
+  RscPayloadMeta,
   Transport,
   TransportContext,
 } from "./types";
@@ -41,7 +58,8 @@ export const fetchTransport: Transport = (transportContext) => {
     source: "action" | "navigation" | "query" = "action",
     method: "GET" | "POST" = "POST",
   ): Promise<Result | undefined> => {
-    const url = new URL(window.location.href);
+    const pageUrl = new URL(window.location.href);
+    const url = new URL(pageUrl.href);
     url.searchParams.set("__rsc", "");
 
     const isAction = id != null;
@@ -92,6 +110,9 @@ export const fetchTransport: Transport = (transportContext) => {
       }
     }
 
+    const isStaleNavigationResponse = () =>
+      source === "navigation" && pageUrl.href !== window.location.href;
+
     const processActionResponse = (rawActionResult: any) => {
       if (isActionResponse(rawActionResult)) {
         const actionResponse = rawActionResult.__rw_action_response;
@@ -124,6 +145,10 @@ export const fetchTransport: Transport = (transportContext) => {
     // If there's a response handler, check the response first
     if (transportContext.handleResponse) {
       const response = await fetchPromise;
+      if (isStaleNavigationResponse()) {
+        return undefined as any;
+      }
+
       const shouldContinue = transportContext.handleResponse(response);
       if (!shouldContinue) {
         return undefined as any;
@@ -135,7 +160,14 @@ export const fetchTransport: Transport = (transportContext) => {
       }) as Promise<RscActionResponse<Result>>;
 
       if (source === "navigation" || source === "action") {
-        transportContext.setRscPayload(streamData);
+        if (isStaleNavigationResponse()) {
+          return undefined as any;
+        }
+
+        transportContext.setRscPayload(streamData, {
+          source,
+          href: pageUrl.href,
+        });
       }
       const result = await streamData;
       return processActionResponse(
@@ -145,6 +177,10 @@ export const fetchTransport: Transport = (transportContext) => {
 
     // Original behavior when no handler is present
     const response = await fetchPromise;
+    if (isStaleNavigationResponse()) {
+      return undefined as any;
+    }
+
     const location = response.headers.get("Location");
 
     if (response.status >= 300 && response.status < 400 && location) {
@@ -157,7 +193,14 @@ export const fetchTransport: Transport = (transportContext) => {
     }) as Promise<RscActionResponse<Result>>;
 
     if (source === "navigation" || source === "action") {
-      transportContext.setRscPayload(streamData);
+      if (isStaleNavigationResponse()) {
+        return undefined as any;
+      }
+
+      transportContext.setRscPayload(streamData, {
+        source,
+        href: pageUrl.href,
+      });
     }
     const result = await streamData;
     return processActionResponse(
@@ -233,7 +276,7 @@ export const initClient = async ({
   transport?: Transport;
   hydrateRootOptions?: HydrationOptions;
   handleResponse?: (response: Response) => boolean;
-  onHydrated?: () => void;
+  onHydrated?: (meta?: RscPayloadMeta) => void;
   onActionResponse?: (actionResponse: ActionResponseData) => boolean | void;
 } & RecoveryOptions = {}) => {
   if (onModuleNotFound) {
@@ -288,24 +331,36 @@ export const initClient = async ({
     });
   }
 
+  type StreamState = {
+    data: any;
+    meta?: RscPayloadMeta;
+  };
+
   function Content() {
-    const [streamData, setStreamData] = React.useState(rscPayload);
+    const [streamState, setStreamState] = React.useState<StreamState | null>(
+      rscPayload
+        ? {
+            data: rscPayload,
+            meta: { source: "initial", href: window.location.href },
+          }
+        : null,
+    );
     const [_isPending, startTransition] = React.useTransition();
-    transportContext.setRscPayload = (v) =>
+    transportContext.setRscPayload = (v, meta) =>
       startTransition(() => {
-        setStreamData(v);
+        setStreamState({ data: v, meta });
       });
 
     React.useEffect(() => {
-      if (!streamData) return;
-      transportContext.onHydrated?.();
-    }, [streamData]);
+      if (!streamState) return;
+      transportContext.onHydrated?.(streamState.meta);
+    }, [streamState]);
     return (
-      <>
-        {streamData
-          ? React.use<{ node: React.ReactNode }>(streamData).node
+      <NavigationPayloadProvider meta={streamState?.meta}>
+        {streamState
+          ? React.use<{ node: React.ReactNode }>(streamState.data).node
           : null}
-      </>
+      </NavigationPayloadProvider>
     );
   }
 

--- a/sdk/src/runtime/client/navigation.test.ts
+++ b/sdk/src/runtime/client/navigation.test.ts
@@ -1,6 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { initClientNavigation, validateClickEvent } from "./navigation";
+import {
+  getNavigationSnapshot,
+  resetNavigationStateForTests,
+} from "./navigationState";
 import { HISTORY_STATE_SCROLL_KEY } from "./scrollRestoration";
+
+beforeEach(() => {
+  resetNavigationStateForTests();
+});
 
 // Mocking browser globals
 vi.stubGlobal("window", {
@@ -159,15 +167,6 @@ describe("onNavigate callback (issue #1123 regression)", () => {
       replaceState: vi.fn(),
       state: {},
     });
-    vi.stubGlobal(
-      "URL",
-      class {
-        href: string;
-        constructor(path: string, base: string) {
-          this.href = base.replace(/\/$/, "") + path;
-        }
-      },
-    );
     // Assign directly to globalThis without replacing it (avoids breaking Vitest internals)
     (globalThis as any).__rsc_callServer = vi.fn().mockResolvedValue(undefined);
   });
@@ -368,6 +367,33 @@ describe("initClientNavigation", () => {
     expect(onNavigate).not.toHaveBeenCalled();
     expect((globalThis as any).__rsc_callServer).not.toHaveBeenCalled();
     expect(window.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("keeps navigation pending until the matching navigation payload hydrates", async () => {
+    (globalThis as any).__rsc_callServer = vi.fn().mockResolvedValue(undefined);
+
+    const { onHydrated } = initClientNavigation();
+    expect(capturedPopstateHandler).not.toBeNull();
+
+    (window.location as unknown as { href: string; pathname: string }).href =
+      "http://localhost/about";
+    (
+      window.location as unknown as { href: string; pathname: string }
+    ).pathname = "/about";
+
+    await capturedPopstateHandler!();
+
+    const pending = getNavigationSnapshot().pending;
+    expect(pending?.pendingUrl.href).toBe("http://localhost/about");
+
+    onHydrated({ source: "action", href: pending!.pendingUrl.href });
+    expect(getNavigationSnapshot().pending?.id).toBe(pending!.id);
+
+    onHydrated({ source: "navigation", href: "http://localhost/other" });
+    expect(getNavigationSnapshot().pending?.id).toBe(pending!.id);
+
+    onHydrated({ source: "navigation", href: pending!.pendingUrl.href });
+    expect(getNavigationSnapshot().pending).toBeNull();
   });
 
   it("does not write to history state on scroll", () => {

--- a/sdk/src/runtime/client/navigation.ts
+++ b/sdk/src/runtime/client/navigation.ts
@@ -5,9 +5,16 @@ import {
   type NavigationCacheStorage,
 } from "./navigationCache.js";
 import {
+  abortPendingNavigation,
+  beginPendingNavigation,
+  commitPendingNavigation,
+  isPendingNavigationCommit,
+} from "./navigationState.js";
+import {
   createScrollRestoration,
   type ScrollRestorationController,
 } from "./scrollRestoration.js";
+import type { RscPayloadMeta } from "./types.js";
 
 export type { NavigationCache, NavigationCacheStorage };
 
@@ -116,16 +123,23 @@ export async function navigate(
     scrollRestoration?.recordCurrentPosition(window.scrollX, window.scrollY);
   }
 
-  await options.onNavigate?.();
+  const pendingNavigation = beginPendingNavigation(url);
 
-  await globalThis.__rsc_callServer(null, null, "navigation");
+  try {
+    await options.onNavigate?.();
+
+    await globalThis.__rsc_callServer(null, null, "navigation");
+  } catch (error) {
+    abortPendingNavigation(pendingNavigation.id);
+    throw error;
+  }
 }
 
 /**
  * Initializes client-side navigation for Single Page App (SPA) behavior.
  *
  * Intercepts clicks on internal links and fetches page content without full-page reloads.
- * Returns a handleResponse function to pass to initClient.
+ * Returns handleResponse and onHydrated functions to pass to initClient.
  *
  * @param opts.scrollToTop - Scroll to top after navigation (default: true)
  * @param opts.scrollBehavior - How to scroll: 'instant', 'smooth', or 'auto' (default: 'instant')
@@ -140,27 +154,27 @@ export async function navigate(
  *
  * @example
  * // With custom scroll behavior
- * const { handleResponse } = initClientNavigation({
+ * const { handleResponse, onHydrated } = initClientNavigation({
  *   scrollBehavior: "smooth",
  *   scrollToTop: true,
  * });
- * initClient({ handleResponse });
+ * initClient({ handleResponse, onHydrated });
  *
  * @example
  * // Preserve scroll position (e.g., for infinite scroll)
- * const { handleResponse } = initClientNavigation({
+ * const { handleResponse, onHydrated } = initClientNavigation({
  *   scrollToTop: false,
  * });
- * initClient({ handleResponse });
+ * initClient({ handleResponse, onHydrated });
  *
  * @example
  * // With navigation callback
- * const { handleResponse } = initClientNavigation({
+ * const { handleResponse, onHydrated } = initClientNavigation({
  *   onNavigate: () => {
  *     console.log("Navigating to:", window.location.href);
  *   },
  * });
- * initClient({ handleResponse });
+ * initClient({ handleResponse, onHydrated });
  */
 export function initClientNavigation(opts: ClientNavigationOptions = {}) {
   IS_CLIENT_NAVIGATION = true;
@@ -196,8 +210,15 @@ export function initClientNavigation(opts: ClientNavigationOptions = {}) {
     }
 
     scrollRestoration?.restorePopStateScroll();
-    await opts.onNavigate?.();
-    await globalThis.__rsc_callServer(null, null, "navigation");
+    const pendingNavigation = beginPendingNavigation(window.location.href);
+
+    try {
+      await opts.onNavigate?.();
+      await globalThis.__rsc_callServer(null, null, "navigation");
+    } catch (error) {
+      abortPendingNavigation(pendingNavigation.id);
+      throw error;
+    }
   });
 
   // Track the user's scroll position in memory so back/forward navigation can
@@ -235,6 +256,7 @@ export function initClientNavigation(opts: ClientNavigationOptions = {}) {
     if (response.status >= 300 && response.status < 400) {
       const location = response.headers.get("Location");
       if (location) {
+        abortPendingNavigation();
         window.location.href = location;
         return false;
       }
@@ -243,6 +265,7 @@ export function initClientNavigation(opts: ClientNavigationOptions = {}) {
     if (!response.ok) {
       // Redirect to the current page (window.location) to show the error
       // This means the page that produced the error is called twice.
+      abortPendingNavigation();
       window.location.href = window.location.href;
       return false;
     }
@@ -254,11 +277,25 @@ export function initClientNavigation(opts: ClientNavigationOptions = {}) {
     (globalThis as any).__rsc_cacheStorage = opts.cacheStorage;
   }
 
-  function onHydrated() {
-    // Apply any pending scroll intent now that React has committed the new
-    // DOM — this is what prevents the scroll flash on both link-click and
-    // popstate navigations.
-    scrollRestoration?.applyPendingScroll();
+  function onHydrated(meta?: RscPayloadMeta) {
+    // Apply any pending scroll intent once the relevant DOM has committed. For
+    // navigation payloads, ignore stale/superseded commits whose href no longer
+    // matches the pending navigation target.
+    const shouldCommitPendingNavigation = !meta || meta.source === "navigation";
+    const isMatchingNavigationCommit =
+      shouldCommitPendingNavigation && isPendingNavigationCommit(meta?.href);
+
+    if (!meta || meta.source === "initial" || isMatchingNavigationCommit) {
+      scrollRestoration?.applyPendingScroll();
+    }
+
+    // Resolve NavigationPending boundaries only for navigation payloads. If a
+    // custom transport does not provide metadata, fall back to the historical
+    // onHydrated behavior and treat the commit as the pending navigation.
+    if (isMatchingNavigationCommit) {
+      commitPendingNavigation(meta?.href);
+    }
+
     // After each RSC hydration/update, increment generation and evict old caches,
     // then warm the navigation cache based on any <link rel="x-prefetch"> tags
     // rendered for the current location.

--- a/sdk/src/runtime/client/navigationPending.test.ts
+++ b/sdk/src/runtime/client/navigationPending.test.ts
@@ -12,6 +12,7 @@ import {
   beginPendingNavigation,
   commitPendingNavigation,
   getNavigationSnapshot,
+  isSameNavigationDocumentUrl,
   resetNavigationStateForTests,
 } from "./navigationState";
 
@@ -87,6 +88,29 @@ describe("navigation pending state", () => {
     expect(getNavigationSnapshot().pending?.id).toBe(second.id);
     await expectPromiseResolved(first.promise);
     expect(getNavigationSnapshot().pending?.id).toBe(second.id);
+  });
+
+  it("treats hash-only differences as the same navigation document", async () => {
+    const pending = beginPendingNavigation("/results?search=new&page=1");
+
+    expect(
+      isSameNavigationDocumentUrl(
+        "http://localhost/results?search=new&page=1",
+        "http://localhost/results?search=new&page=1#details",
+      ),
+    ).toBe(true);
+    expect(
+      isSameNavigationDocumentUrl(
+        "http://localhost/results?search=new&page=1",
+        "http://localhost/results?search=new&page=2#details",
+      ),
+    ).toBe(false);
+
+    expect(commitPendingNavigation("/results?search=new&page=1#details")).toBe(
+      true,
+    );
+    expect(getNavigationSnapshot().pending).toBeNull();
+    await expectPromiseResolved(pending.promise);
   });
 
   it("can abort only the matching pending navigation", async () => {
@@ -197,6 +221,12 @@ describe("shouldSuspendForPendingNavigation", () => {
       renderPendingBoundary({
         source: "navigation",
         href: "http://localhost/results?search=new&page=1",
+      }),
+    ).toContain("ready");
+    expect(
+      renderPendingBoundary({
+        source: "navigation",
+        href: "http://localhost/results?search=new&page=1#details",
       }),
     ).toContain("ready");
   });

--- a/sdk/src/runtime/client/navigationPending.test.ts
+++ b/sdk/src/runtime/client/navigationPending.test.ts
@@ -1,0 +1,203 @@
+import React, { Suspense } from "react";
+import { renderToString } from "react-dom/server";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  NavigationPayloadProvider,
+  NavigationPending,
+  shouldSuspendForPendingNavigation,
+} from "./navigationPending";
+import {
+  abortPendingNavigation,
+  beginPendingNavigation,
+  commitPendingNavigation,
+  getNavigationSnapshot,
+  resetNavigationStateForTests,
+} from "./navigationState";
+
+function renderPendingBoundary(meta: {
+  source: "initial" | "navigation";
+  href: string;
+}) {
+  return renderToString(
+    React.createElement(
+      NavigationPayloadProvider,
+      { meta },
+      React.createElement(
+        Suspense,
+        { fallback: React.createElement("span", null, "loading") },
+        React.createElement(
+          NavigationPending,
+          null,
+          React.createElement("span", null, "ready"),
+        ),
+      ),
+    ),
+  );
+}
+
+async function expectPromiseResolved(promise: Promise<void>) {
+  let resolved = false;
+  promise.then(() => {
+    resolved = true;
+  });
+
+  await Promise.resolve();
+
+  expect(resolved).toBe(true);
+}
+
+describe("navigation pending state", () => {
+  beforeEach(() => {
+    resetNavigationStateForTests("http://localhost/results?search=old&page=1");
+  });
+
+  it("tracks a pending navigation until the matching navigation commit", async () => {
+    const pending = beginPendingNavigation(
+      "http://localhost/results?search=new&page=1",
+    );
+
+    expect(getNavigationSnapshot().pending?.id).toBe(pending.id);
+    expect(getNavigationSnapshot().pending?.currentUrl.href).toBe(
+      "http://localhost/results?search=old&page=1",
+    );
+    expect(getNavigationSnapshot().pending?.pendingUrl.href).toBe(
+      "http://localhost/results?search=new&page=1",
+    );
+
+    expect(
+      commitPendingNavigation("http://localhost/results?search=old&page=1"),
+    ).toBe(false);
+    expect(getNavigationSnapshot().pending?.id).toBe(pending.id);
+
+    expect(
+      commitPendingNavigation("http://localhost/results?search=new&page=1"),
+    ).toBe(true);
+    expect(getNavigationSnapshot().pending).toBeNull();
+    expect(getNavigationSnapshot().currentUrl.href).toBe(
+      "http://localhost/results?search=new&page=1",
+    );
+    await expectPromiseResolved(pending.promise);
+  });
+
+  it("resolves a superseded navigation promise while keeping the newest navigation pending", async () => {
+    const first = beginPendingNavigation("/results?search=first&page=1");
+    const second = beginPendingNavigation("/results?search=second&page=1");
+
+    expect(getNavigationSnapshot().pending?.id).toBe(second.id);
+    await expectPromiseResolved(first.promise);
+    expect(getNavigationSnapshot().pending?.id).toBe(second.id);
+  });
+
+  it("can abort only the matching pending navigation", async () => {
+    const pending = beginPendingNavigation("/results?search=new&page=1");
+
+    expect(abortPendingNavigation(pending.id + 1)).toBe(false);
+    expect(getNavigationSnapshot().pending?.id).toBe(pending.id);
+
+    expect(abortPendingNavigation(pending.id)).toBe(true);
+    expect(getNavigationSnapshot().pending).toBeNull();
+    await expectPromiseResolved(pending.promise);
+  });
+});
+
+describe("shouldSuspendForPendingNavigation", () => {
+  beforeEach(() => {
+    resetNavigationStateForTests("http://localhost/results?search=old&page=1");
+  });
+
+  it("suspends for any pending navigation by default", () => {
+    beginPendingNavigation("/results?search=new&page=1");
+
+    expect(shouldSuspendForPendingNavigation(getNavigationSnapshot())).toBe(
+      true,
+    );
+  });
+
+  it("can watch a shorthand list of search params", () => {
+    beginPendingNavigation("/results?search=new&page=1&sort=asc");
+
+    expect(
+      shouldSuspendForPendingNavigation(getNavigationSnapshot(), {
+        searchParams: ["search"],
+      }),
+    ).toBe(true);
+    expect(
+      shouldSuspendForPendingNavigation(getNavigationSnapshot(), {
+        searchParams: ["page"],
+      }),
+    ).toBe(false);
+  });
+
+  it("does not let the searchParams shorthand suspend for pathname-only changes", () => {
+    beginPendingNavigation("/other?search=old&page=1");
+
+    expect(
+      shouldSuspendForPendingNavigation(getNavigationSnapshot(), {
+        searchParams: ["search", "page"],
+      }),
+    ).toBe(false);
+  });
+
+  it("supports explicit watch configuration", () => {
+    beginPendingNavigation("/other?search=old&page=2#details");
+
+    expect(
+      shouldSuspendForPendingNavigation(getNavigationSnapshot(), {
+        watch: { pathname: false, searchParams: ["page"], hash: false },
+      }),
+    ).toBe(true);
+    expect(
+      shouldSuspendForPendingNavigation(getNavigationSnapshot(), {
+        watch: { pathname: false, searchParams: ["search"], hash: false },
+      }),
+    ).toBe(false);
+    expect(
+      shouldSuspendForPendingNavigation(getNavigationSnapshot(), {
+        watch: { pathname: false, searchParams: false, hash: true },
+      }),
+    ).toBe(true);
+  });
+
+  it("supports a custom predicate", () => {
+    beginPendingNavigation("/results?tab=details&page=1");
+
+    expect(
+      shouldSuspendForPendingNavigation(getNavigationSnapshot(), {
+        when: ({ currentUrl, pendingUrl }) =>
+          currentUrl.searchParams.get("tab") !==
+          pendingUrl.searchParams.get("tab"),
+      }),
+    ).toBe(true);
+    expect(
+      shouldSuspendForPendingNavigation(getNavigationSnapshot(), {
+        when: ({ currentUrl, pendingUrl }) =>
+          currentUrl.searchParams.get("page") !==
+          pendingUrl.searchParams.get("page"),
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps current payloads suspended but lets the matching navigation payload render", () => {
+    beginPendingNavigation("/results?search=new&page=1");
+
+    expect(
+      renderPendingBoundary({
+        source: "initial",
+        href: "http://localhost/results?search=old&page=1",
+      }),
+    ).toContain("loading");
+    expect(
+      renderPendingBoundary({
+        source: "navigation",
+        href: "http://localhost/results?search=other&page=1",
+      }),
+    ).toContain("loading");
+    expect(
+      renderPendingBoundary({
+        source: "navigation",
+        href: "http://localhost/results?search=new&page=1",
+      }),
+    ).toContain("ready");
+  });
+});

--- a/sdk/src/runtime/client/navigationPending.tsx
+++ b/sdk/src/runtime/client/navigationPending.tsx
@@ -2,6 +2,7 @@ import React, { useContext, useSyncExternalStore } from "react";
 
 import {
   getNavigationSnapshot,
+  isSameNavigationDocumentUrl,
   subscribeNavigationState,
   type NavigationSnapshot,
 } from "./navigationState.js";
@@ -147,8 +148,9 @@ function isRenderingMatchingNavigationPayload(
   }
 
   try {
-    return (
-      new URL(meta.href, pending.currentUrl).href === pending.pendingUrl.href
+    return isSameNavigationDocumentUrl(
+      new URL(meta.href, pending.currentUrl),
+      pending.pendingUrl,
     );
   } catch {
     return false;

--- a/sdk/src/runtime/client/navigationPending.tsx
+++ b/sdk/src/runtime/client/navigationPending.tsx
@@ -1,0 +1,229 @@
+import React, { useContext, useSyncExternalStore } from "react";
+
+import {
+  getNavigationSnapshot,
+  subscribeNavigationState,
+  type NavigationSnapshot,
+} from "./navigationState.js";
+import type { RscPayloadMeta } from "./types.js";
+
+export type NavigationSearchParamsWatch = boolean | readonly string[];
+
+export interface NavigationPendingWatch {
+  /** Watch pathname changes. Defaults to true when using a watch config. */
+  pathname?: boolean;
+  /** Watch all search params, no search params, or a specific list of params. */
+  searchParams?: NavigationSearchParamsWatch;
+  /** Watch hash changes. Defaults to false when using a watch config. */
+  hash?: boolean;
+}
+
+export interface NavigationPendingWhenArgs {
+  currentUrl: URL;
+  pendingUrl: URL;
+}
+
+export interface NavigationPendingOptions {
+  /** Shorthand for watching only these search params. */
+  searchParams?: readonly string[];
+  /** Explicit URL parts to watch. */
+  watch?: NavigationPendingWatch;
+  /** Advanced predicate for deciding whether the pending navigation is relevant. */
+  when?: (args: NavigationPendingWhenArgs) => boolean;
+}
+
+export interface NavigationPendingProps extends NavigationPendingOptions {
+  children?: React.ReactNode;
+}
+
+const NO_NAVIGATION_PAYLOAD_META = Symbol("NO_NAVIGATION_PAYLOAD_META");
+type NavigationPayloadMetaContextValue =
+  | RscPayloadMeta
+  | undefined
+  | typeof NO_NAVIGATION_PAYLOAD_META;
+
+const NavigationPayloadMetaContext =
+  React.createContext<NavigationPayloadMetaContextValue>(
+    NO_NAVIGATION_PAYLOAD_META,
+  );
+
+export function NavigationPayloadProvider({
+  children,
+  meta,
+}: {
+  children?: React.ReactNode;
+  meta?: RscPayloadMeta;
+}) {
+  return (
+    <NavigationPayloadMetaContext.Provider value={meta}>
+      {children}
+    </NavigationPayloadMetaContext.Provider>
+  );
+}
+
+function cloneUrl(url: URL) {
+  return new URL(url.href);
+}
+
+function arraysEqual(left: readonly string[], right: readonly string[]) {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((value, index) => value === right[index]);
+}
+
+function searchParamChanged(currentUrl: URL, pendingUrl: URL, name: string) {
+  return !arraysEqual(
+    currentUrl.searchParams.getAll(name),
+    pendingUrl.searchParams.getAll(name),
+  );
+}
+
+function searchParamsChanged(
+  currentUrl: URL,
+  pendingUrl: URL,
+  watch: NavigationSearchParamsWatch,
+) {
+  if (watch === false) {
+    return false;
+  }
+
+  if (watch === true) {
+    return currentUrl.search !== pendingUrl.search;
+  }
+
+  return watch.some((name) => searchParamChanged(currentUrl, pendingUrl, name));
+}
+
+function watchedUrlChanged(
+  currentUrl: URL,
+  pendingUrl: URL,
+  watch: NavigationPendingWatch,
+) {
+  const watchPathname = watch.pathname ?? true;
+  const watchSearchParams = watch.searchParams ?? true;
+  const watchHash = watch.hash ?? false;
+
+  if (watchPathname && currentUrl.pathname !== pendingUrl.pathname) {
+    return true;
+  }
+
+  if (searchParamsChanged(currentUrl, pendingUrl, watchSearchParams)) {
+    return true;
+  }
+
+  if (watchHash && currentUrl.hash !== pendingUrl.hash) {
+    return true;
+  }
+
+  return false;
+}
+
+function isRenderingMatchingNavigationPayload(
+  snapshot: NavigationSnapshot,
+  meta: NavigationPayloadMetaContextValue,
+) {
+  const pending = snapshot.pending;
+
+  if (!pending) {
+    return false;
+  }
+
+  if (meta === NO_NAVIGATION_PAYLOAD_META) {
+    return false;
+  }
+
+  if (meta === undefined) {
+    return true;
+  }
+
+  if (meta.source !== "navigation") {
+    return false;
+  }
+
+  if (!meta.href) {
+    return true;
+  }
+
+  try {
+    return (
+      new URL(meta.href, pending.currentUrl).href === pending.pendingUrl.href
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function shouldSuspendForPendingNavigation(
+  snapshot: NavigationSnapshot,
+  options: NavigationPendingOptions = {},
+) {
+  const pending = snapshot.pending;
+
+  if (!pending) {
+    return false;
+  }
+
+  const currentUrl = pending.currentUrl;
+  const pendingUrl = pending.pendingUrl;
+
+  if (options.when) {
+    return options.when({
+      currentUrl: cloneUrl(currentUrl),
+      pendingUrl: cloneUrl(pendingUrl),
+    });
+  }
+
+  if (options.watch) {
+    return watchedUrlChanged(currentUrl, pendingUrl, options.watch);
+  }
+
+  if (options.searchParams) {
+    return searchParamsChanged(currentUrl, pendingUrl, options.searchParams);
+  }
+
+  return true;
+}
+
+/**
+ * Suspends while a matching client-side RSC navigation is pending.
+ *
+ * Use this hook inside a React <Suspense> boundary. When the pending navigation
+ * commits to the visible React tree, the thrown promise resolves and React
+ * retries the render with the newly committed tree.
+ */
+export function useNavigationPending(options: NavigationPendingOptions = {}) {
+  const snapshot = useSyncExternalStore(
+    subscribeNavigationState,
+    getNavigationSnapshot,
+    getNavigationSnapshot,
+  );
+  const payloadMeta = useContext(NavigationPayloadMetaContext);
+
+  if (
+    shouldSuspendForPendingNavigation(snapshot, options) &&
+    !isRenderingMatchingNavigationPayload(snapshot, payloadMeta)
+  ) {
+    throw snapshot.pending!.promise;
+  }
+
+  return snapshot;
+}
+
+/**
+ * Suspense-aware boundary for client-side RSC navigations.
+ *
+ * Wrap server-backed UI with this component inside your own <Suspense> fallback
+ * to avoid showing stale props while a relevant navigation is in flight.
+ */
+export function NavigationPending({
+  children,
+  searchParams,
+  watch,
+  when,
+}: NavigationPendingProps) {
+  useNavigationPending({ searchParams, watch, when });
+
+  return <>{children}</>;
+}

--- a/sdk/src/runtime/client/navigationState.ts
+++ b/sdk/src/runtime/client/navigationState.ts
@@ -72,6 +72,19 @@ function toUrl(url: string | URL) {
   return new URL(url, readWindowUrl());
 }
 
+function toNavigationDocumentHref(url: string | URL) {
+  const nextUrl = toUrl(url);
+  nextUrl.hash = "";
+  return nextUrl.href;
+}
+
+export function isSameNavigationDocumentUrl(
+  left: string | URL,
+  right: string | URL,
+) {
+  return toNavigationDocumentHref(left) === toNavigationDocumentHref(right);
+}
+
 function createDeferred() {
   let resolve!: () => void;
   const promise = new Promise<void>((resolvePromise) => {
@@ -122,8 +135,7 @@ export function isPendingNavigationCommit(href?: string | URL) {
     return true;
   }
 
-  const committedUrl = toUrl(href);
-  return committedUrl.href === pendingNavigation.pendingUrl.href;
+  return isSameNavigationDocumentUrl(href, pendingNavigation.pendingUrl);
 }
 
 export function commitPendingNavigation(href?: string | URL) {

--- a/sdk/src/runtime/client/navigationState.ts
+++ b/sdk/src/runtime/client/navigationState.ts
@@ -1,0 +1,171 @@
+export interface NavigationSnapshot {
+  /** URL represented by the React tree that has committed to the screen. */
+  currentUrl: URL;
+  /** The latest client navigation that has updated history but not committed. */
+  pending: PendingNavigationSnapshot | null;
+}
+
+export interface PendingNavigationSnapshot {
+  id: number;
+  /** URL represented by the currently visible React tree when navigation began. */
+  currentUrl: URL;
+  /** URL that the pending RSC navigation is rendering. */
+  pendingUrl: URL;
+  /** Resolves when this pending navigation commits, is superseded, or is aborted. */
+  promise: Promise<void>;
+}
+
+interface PendingNavigationInternal extends PendingNavigationSnapshot {
+  resolve: () => void;
+}
+
+type NavigationListener = () => void;
+
+const listeners = new Set<NavigationListener>();
+
+let nextNavigationId = 0;
+let currentUrl = readWindowUrl();
+let pendingNavigation: PendingNavigationInternal | null = null;
+let snapshot = createSnapshot();
+
+function readWindowUrl() {
+  if (typeof window !== "undefined" && window.location?.href) {
+    return new URL(window.location.href);
+  }
+
+  return new URL("http://localhost/");
+}
+
+function cloneUrl(url: URL) {
+  return new URL(url.href);
+}
+
+function createSnapshot(): NavigationSnapshot {
+  return {
+    currentUrl: cloneUrl(currentUrl),
+    pending: pendingNavigation
+      ? {
+          id: pendingNavigation.id,
+          currentUrl: cloneUrl(pendingNavigation.currentUrl),
+          pendingUrl: cloneUrl(pendingNavigation.pendingUrl),
+          promise: pendingNavigation.promise,
+        }
+      : null,
+  };
+}
+
+function updateSnapshot() {
+  snapshot = createSnapshot();
+}
+
+function notifyListeners() {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+function toUrl(url: string | URL) {
+  if (url instanceof URL) {
+    return cloneUrl(url);
+  }
+
+  return new URL(url, readWindowUrl());
+}
+
+function createDeferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}
+
+export function subscribeNavigationState(listener: NavigationListener) {
+  listeners.add(listener);
+
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function getNavigationSnapshot() {
+  return snapshot;
+}
+
+export function beginPendingNavigation(url: string | URL) {
+  const supersededNavigation = pendingNavigation;
+  const targetUrl = toUrl(url);
+  const { promise, resolve } = createDeferred();
+
+  pendingNavigation = {
+    id: ++nextNavigationId,
+    currentUrl: cloneUrl(currentUrl),
+    pendingUrl: targetUrl,
+    promise,
+    resolve,
+  };
+
+  updateSnapshot();
+  notifyListeners();
+  supersededNavigation?.resolve();
+
+  return pendingNavigation;
+}
+
+export function isPendingNavigationCommit(href?: string | URL) {
+  if (!pendingNavigation) {
+    return false;
+  }
+
+  if (href === undefined) {
+    return true;
+  }
+
+  const committedUrl = toUrl(href);
+  return committedUrl.href === pendingNavigation.pendingUrl.href;
+}
+
+export function commitPendingNavigation(href?: string | URL) {
+  if (!isPendingNavigationCommit(href)) {
+    return false;
+  }
+
+  const committedNavigation = pendingNavigation!;
+  pendingNavigation = null;
+  currentUrl = cloneUrl(committedNavigation.pendingUrl);
+
+  updateSnapshot();
+  notifyListeners();
+  committedNavigation.resolve();
+
+  return true;
+}
+
+export function abortPendingNavigation(id?: number) {
+  if (!pendingNavigation) {
+    return false;
+  }
+
+  if (id !== undefined && pendingNavigation.id !== id) {
+    return false;
+  }
+
+  const abortedNavigation = pendingNavigation;
+  pendingNavigation = null;
+
+  updateSnapshot();
+  notifyListeners();
+  abortedNavigation.resolve();
+
+  return true;
+}
+
+export function resetNavigationStateForTests(href = "http://localhost/") {
+  pendingNavigation?.resolve();
+  pendingNavigation = null;
+  nextNavigationId = 0;
+  currentUrl = new URL(href);
+  updateSnapshot();
+  notifyListeners();
+}

--- a/sdk/src/runtime/client/types.ts
+++ b/sdk/src/runtime/client/types.ts
@@ -15,6 +15,12 @@ export type RscActionResponse<Result> = {
   actionResult: Result;
 };
 
+export type RscPayloadMeta = {
+  source: "initial" | "action" | "navigation" | "query";
+  /** Browser URL represented by this RSC payload, without the internal __rsc marker. */
+  href?: string;
+};
+
 export type ActionResponseData = {
   status: number;
   headers: {
@@ -37,14 +43,17 @@ export function isActionResponse(value: unknown): value is ActionResponseMeta {
 }
 
 export type TransportContext = {
-  setRscPayload: <Result>(v: Promise<RscActionResponse<Result>>) => void;
+  setRscPayload: <Result>(
+    v: Promise<RscActionResponse<Result>>,
+    meta?: RscPayloadMeta,
+  ) => void;
   handleResponse?: (response: Response) => boolean; // Returns false to stop normal processing
   /**
    * Optional callback invoked after a new RSC payload has been committed on the client.
    * This is useful for features like client-side navigation that want to run logic
    * after hydration/updates, e.g. warming navigation caches.
    */
-  onHydrated?: () => void;
+  onHydrated?: (meta?: RscPayloadMeta) => void;
   /**
    * Optional callback invoked when an action returns a Response.
    * Return true to signal that the response has been handled and

--- a/sdk/src/runtime/lib/realtime/client.ts
+++ b/sdk/src/runtime/lib/realtime/client.ts
@@ -80,7 +80,10 @@ export const realtimeTransport =
       });
 
       listenForUpdates(ws!, (response) => {
-        processResponse(response);
+        processResponse(response, {
+          source: "action",
+          href: window.location.href,
+        });
       });
     };
 
@@ -99,14 +102,13 @@ export const realtimeTransport =
     const realtimeCallServer = async <T>(
       id: string | null,
       args: unknown[] | null,
-      _source?: "action" | "navigation" | "query",
+      source: "action" | "navigation" | "query" = "action",
       _method?: "GET" | "POST",
     ): Promise<T | undefined> => {
       try {
         const socket = ensureWs();
-        const { encodeReply } = await import(
-          "react-server-dom-webpack/client.browser"
-        );
+        const { encodeReply } =
+          await import("react-server-dom-webpack/client.browser");
 
         // Note(peterp, 2025-07-02): We need to send the "current URL" per message,
         // in case the user has enabled client side navigation.
@@ -128,7 +130,10 @@ export const realtimeTransport =
         const promisedResponse = respondToRequest(requestId, socket);
         socket.send(message);
 
-        return await processResponse(await promisedResponse);
+        return await processResponse(await promisedResponse, {
+          source,
+          href: window.location.href,
+        });
       } catch (e) {
         console.error("[Realtime] Error calling server", e);
         return undefined;
@@ -137,10 +142,17 @@ export const realtimeTransport =
 
     const processResponse = async <T>(
       response: Response,
+      meta?: { source: "action" | "navigation" | "query"; href: string },
     ): Promise<T | undefined> => {
       try {
         let streamForRsc: ReadableStream<Uint8Array>;
         let shouldContinue = true;
+        const isStaleNavigationResponse = () =>
+          meta?.source === "navigation" && meta.href !== window.location.href;
+
+        if (isStaleNavigationResponse()) {
+          return undefined;
+        }
 
         if (transportContext.handleResponse) {
           const [stream1, stream2] = response.body!.tee();
@@ -159,7 +171,11 @@ export const realtimeTransport =
           callServer: realtimeCallServer as any,
         }) as Promise<RscActionResponse<unknown>>;
 
-        transportContext.setRscPayload(rscPayload);
+        if (isStaleNavigationResponse()) {
+          return undefined;
+        }
+
+        transportContext.setRscPayload(rscPayload, meta);
         const rawActionResult = (await rscPayload).actionResult;
 
         if (isActionResponse(rawActionResult)) {


### PR DESCRIPTION
## Problem

Client-side navigation changes the URL before the new server-rendered React tree is on screen. During that short gap, a page can still show the old table rows or old pagination, even though the address bar already shows the new search or page. Apps had no built-in way to say, “hide this part until the matching navigation has really committed.”

## Solution

This adds `NavigationPending` and `useNavigationPending` to `rwsdk/client`. Apps can put `NavigationPending` inside their own `<Suspense fallback>` to show normal loading UI while a matching navigation is pending. The navigation runtime now tracks pending URLs and resolves them only when the matching RSC payload commits.

## Technical Summary

- Track one active navigation at a time with a small URL snapshot and commit promise. Newer navigations supersede older ones so old promises do not hang.
- Treat “committed” as the matching RSC payload reaching the visible React tree, not just the fetch finishing.
- Let apps scope pending UI by all navigations, selected search params, explicit URL parts, or a custom predicate.
- Ignore stale navigation responses when the browser has already moved to a newer URL, so an old response cannot update the tree late.
- Keep loading UI app-owned through React Suspense instead of adding a framework-specific fallback API.

Fixes #1240
