### PR TITLE
Export NavigationPending from client SSR entry

### DIFF
--- a/sdk/src/runtime/entries/clientSSR.test.ts
+++ b/sdk/src/runtime/entries/clientSSR.test.ts
@@ -1,0 +1,31 @@
+import React from "react";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { NavigationPending, useNavigationPending } from "./clientSSR";
+
+function NavigationSnapshotProbe() {
+  const snapshot = useNavigationPending();
+
+  return React.createElement(
+    "span",
+    null,
+    snapshot.pending === null ? "not-pending" : "pending",
+  );
+}
+
+describe("clientSSR entry", () => {
+  it("exports a no-op NavigationPending boundary for SSR/workerd builds", () => {
+    const html = renderToString(
+      React.createElement(NavigationPending, null, "ready"),
+    );
+
+    expect(html).toContain("ready");
+  });
+
+  it("exports a non-pending navigation snapshot hook for SSR/workerd builds", () => {
+    const html = renderToString(React.createElement(NavigationSnapshotProbe));
+
+    expect(html).toContain("not-pending");
+  });
+});

--- a/sdk/src/runtime/entries/clientSSR.ts
+++ b/sdk/src/runtime/entries/clientSSR.ts
@@ -1,6 +1,26 @@
 import "./types/ssr";
+
+import type {
+  NavigationPendingOptions,
+  NavigationPendingProps,
+} from "../client/navigationPending.js";
+import type { NavigationSnapshot } from "../client/navigationState.js";
+
 export * from "../lib/streams/consumeEventStream";
 
 export const navigate = () => {
   /* stub */
 };
+
+export function useNavigationPending(
+  _options: NavigationPendingOptions = {},
+): NavigationSnapshot {
+  return {
+    currentUrl: new URL("http://localhost/"),
+    pending: null,
+  };
+}
+
+export function NavigationPending({ children }: NavigationPendingProps) {
+  return children ?? null;
+}


### PR DESCRIPTION
## Problem

`NavigationPending` is part of the public `rwsdk/client` API, and the TypeScript types say it is available. But the worker/SSR client entry did not export it. That meant an app could typecheck, then fail during a production build when the worker bundle tried to import it.

## Solution

The worker/SSR client entry now exports `NavigationPending` and `useNavigationPending`. In that environment there is no browser navigation in progress, so the boundary simply renders its children and the hook returns a non-pending snapshot.

## Technical Summary

- Keep `rwsdk/client` named exports consistent across browser and worker/SSR package conditions.
- Use no-op SSR behavior instead of importing browser navigation state into the worker/SSR entry. This keeps SSR rendering simple and safe.
- Add direct coverage for the worker/SSR entry exports so a public type/export mismatch is caught before release.
- Fixes #1246.
