### PR TITLE
fix(use-synced-state): remove idle hibernation socket timeout

### DIFF
--- a/sdk/src/use-synced-state/hibernation/__tests__/client-core.test.ts
+++ b/sdk/src/use-synced-state/hibernation/__tests__/client-core.test.ts
@@ -281,21 +281,22 @@ describe("client-core", () => {
     expect(statusChanges.filter((s) => s === "connected")).toHaveLength(2);
   });
 
-  it("force-closes the socket when no message is received within the dead-connection timeout", async () => {
+  it("does not force-close an idle hibernation socket when no messages are received", async () => {
     const client = createClient();
     await client.subscribe("counter", () => {});
     await waitForOpen(clients[0] as unknown as WebSocket);
 
     const firstSocket = clients[0] as unknown as WebSocket;
-    const closePromise = new Promise<void>((res) => firstSocket.once("close", () => res()));
+    const closeSpy = vi.fn();
+    firstSocket.once("close", closeSpy);
 
     await vi.advanceTimersByTimeAsync(DEAD_CONNECTION_TIMEOUT_MS + 1000);
-    await closePromise;
 
-    expect(firstSocket.readyState).toBe(WebSocket.CLOSED);
+    expect(closeSpy).not.toHaveBeenCalled();
+    expect(firstSocket.readyState).toBe(WebSocket.OPEN);
   });
 
-  it("resets the dead-connection timer on incoming messages", async () => {
+  it("keeps the socket open across long idle windows between update messages", async () => {
     const client = createClient();
     await client.subscribe("counter", () => {});
     await waitForOpen(clients[0] as unknown as WebSocket);

--- a/sdk/src/use-synced-state/hibernation/connection/connection.ts
+++ b/sdk/src/use-synced-state/hibernation/connection/connection.ts
@@ -1,11 +1,7 @@
 import { manager } from "../state/clientManager.js";
 import { reconnect } from "../reconnect/reconnect.js";
 import { sendMessage, makeMessageId, unpackMessage, handleServerMessage } from "./messages.js";
-import {
-  resetDeadConnectionTimer,
-  cleanupConnectionTimers,
-  rejectPending,
-} from "./timer.js";
+import { rejectPending } from "./timer.js";
 import { type Connection, type WebSocketFactory } from "./types.js";
 
 export function getConnection(
@@ -38,13 +34,10 @@ function createConnection(
     connection.isOpen = true;
     manager.notifyStatusChange(endpoint, "connected");
     manager.resetBackoff(endpoint);
-    resetDeadConnectionTimer(connection, endpoint);
     resubscribeAndSync(connection, endpoint);
   });
 
   connection.ws.addEventListener("message", (event) => {
-    resetDeadConnectionTimer(connection, endpoint);
-
     const message = unpackMessage(event.data);
     if (!message) return;
 
@@ -53,7 +46,6 @@ function createConnection(
 
   connection.ws.addEventListener("close", () => {
     connection.isOpen = false;
-    cleanupConnectionTimers(connection);
     rejectPending(connection, "WebSocket closed");
 
     if (manager.getConnection(endpoint) === connection) {

--- a/sdk/src/use-synced-state/hibernation/connection/timer.ts
+++ b/sdk/src/use-synced-state/hibernation/connection/timer.ts
@@ -1,10 +1,8 @@
-import { manager } from "../state/clientManager.js";
-import { reconnect } from "../reconnect/reconnect.js";
 import { type Connection } from "./types.js";
 
 export const DEAD_CONNECTION_TIMEOUT_MS = 90_000;
 
-export function cleanupConnectionTimers(connection: Connection): void {
+export function stopDeadConnectionTimer(connection: Connection): void {
   if (connection.deadConnectionTimer) {
     clearTimeout(connection.deadConnectionTimer);
     connection.deadConnectionTimer = null;
@@ -16,25 +14,5 @@ export function rejectPending(connection: Connection, reason: string): void {
     pending.reject(new Error(reason));
   }
   connection.pending.clear();
-}
-
-export function resetDeadConnectionTimer(
-  connection: Connection,
-  endpoint: string,
-): void {
-  if (connection.deadConnectionTimer) {
-    clearTimeout(connection.deadConnectionTimer);
-  }
-  connection.deadConnectionTimer = setTimeout(() => {
-    try {
-      connection.ws.close();
-    } catch {}
-    connection.isOpen = false;
-    rejectPending(connection, "WebSocket timed out");
-    cleanupConnectionTimers(connection);
-    if (manager.getConnection(endpoint) === connection) {
-      manager.deleteConnection(endpoint);
-      reconnect(endpoint);
-    }
-  }, DEAD_CONNECTION_TIMEOUT_MS);
+  stopDeadConnectionTimer(connection);
 }


### PR DESCRIPTION
## Problem

The hibernation transport for `useSyncedState` was reconnecting every ~90 seconds on idle pages.

## Why it happened

The client kept a 90-second read timer. Every incoming WebSocket message reset it; if no message arrived within 90 seconds, the client force-closed the socket and reconnected.

That behaviour makes sense for a connection that should be chatty, but it is incompatible with hibernation sockets. A healthy hibernation socket is intentionally idle: the Durable Object sleeps, no application messages flow, and Cloudflare's platform-level WebSocket keepalives are control frames that do not fire JavaScript `message` events. So the timer treated every idle hibernation socket as dead and killed it.

## What changed

The client no longer treats silence as a dead connection. Idle hibernation sockets are left open, and reconnects only happen when the browser reports a real connection loss or the server sends an error. Pending in-flight requests are still cancelled if the socket actually closes.

## Verification

- Deployed the hibernation playground and observed a 135-second idle page: zero `WebSocket timed out` errors and no forced reconnects.

## Tradeoff

We lose proactive detection of silently half-open connections within 90 seconds. The browser's native close detection and Cloudflare's edge keepalives now handle that. If faster dead-connection detection is needed, we should add a mechanism that does not treat healthy idle hibernation sockets as dead.