### PR TITLE
Fix SSR bridge lazy barrel bundling

### DIFF
--- a/sdk/src/vite/configPlugin.mts
+++ b/sdk/src/vite/configPlugin.mts
@@ -9,6 +9,17 @@ import { ConfigurableEsbuildOptions } from "./runDirectivesScan.mjs";
 
 import { ssrBridgeWrapPlugin } from "./ssrBridgeWrapPlugin.mjs";
 
+export const SSR_BRIDGE_ROLLDOWN_EXPERIMENTAL = {
+  // Rolldown's lazy barrel optimization can keep code that references imports it
+  // already pruned when `codeSplitting` is false. The SSR bridge intentionally
+  // disables code splitting, so keep lazy barrel off for this build until the
+  // upstream issue is fixed.
+  // See:
+  // - https://github.com/rolldown/rolldown/issues/9691#issuecomment-4666238497
+  // - https://github.com/rolldown/rolldown/issues/9964
+  lazyBarrel: false,
+};
+
 export const configPlugin = ({
   silent,
   projectRootDir,
@@ -197,6 +208,7 @@ export const configPlugin = ({
             },
             outDir: path.dirname(INTERMEDIATE_SSR_BRIDGE_PATH),
             rolldownOptions: {
+              experimental: SSR_BRIDGE_ROLLDOWN_EXPERIMENTAL,
               output: {
                 // context(justinvdm, 15 Sep 2025): The SSR bundle is a
                 // pre-compiled artifact. When the linker pass bundles it into

--- a/sdk/src/vite/configPlugin.test.mts
+++ b/sdk/src/vite/configPlugin.test.mts
@@ -1,0 +1,96 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { build } from "vite";
+import { describe, expect, it } from "vitest";
+import { SSR_BRIDGE_ROLLDOWN_EXPERIMENTAL } from "./configPlugin.mjs";
+
+describe("SSR bridge Rolldown options", () => {
+  it("keeps side-effect-free barrels valid when code splitting is disabled", async () => {
+    const root = await mkdtemp(
+      path.join(tmpdir(), "rwsdk-ssr-bridge-lazy-barrel-"),
+    );
+
+    try {
+      await mkdir(path.join(root, "src", "lib"), { recursive: true });
+      await writeFile(
+        path.join(root, "package.json"),
+        JSON.stringify({ type: "module", private: true, sideEffects: false }),
+      );
+      await writeFile(
+        path.join(root, "src", "lib", "eg.js"),
+        `const primitives = { string: { tag: "s" }, number: { tag: "n" } };
+const higher = { object: (shape) => ({ tag: "o", shape, parse: () => true }) };
+export const eg = { ...primitives, ...higher };
+`,
+      );
+      await writeFile(
+        path.join(root, "src", "lib", "account.js"),
+        `import { eg } from "./eg.js";
+export const AccountSettings = eg.object({ a: eg.string, n: eg.number });
+export const AccountMeta = eg.object({ b: eg.string });
+`,
+      );
+      await writeFile(
+        path.join(root, "src", "lib", "index.js"),
+        `export * from "./account.js";
+export const objectKeys = (o) => Object.keys(o);
+`,
+      );
+      await writeFile(
+        path.join(root, "src", "story.js"),
+        `import { objectKeys } from "./lib/index.js";
+export const run = () => (objectKeys ? "ok" : "no");
+`,
+      );
+      await writeFile(
+        path.join(root, "src", "entry.cjs"),
+        `const { run } = require("./story.js");
+console.log(run());
+`,
+      );
+
+      await build({
+        configFile: false,
+        root,
+        logLevel: "silent",
+        build: {
+          ssr: true,
+          minify: true,
+          outDir: path.join(root, "dist"),
+          emptyOutDir: true,
+          lib: {
+            entry: {
+              index: path.join(root, "src", "entry.cjs"),
+            },
+            formats: ["es"],
+            fileName: () => "index.js",
+          },
+          rolldownOptions: {
+            experimental: SSR_BRIDGE_ROLLDOWN_EXPERIMENTAL,
+            output: {
+              codeSplitting: false,
+            },
+          },
+        },
+      });
+
+      const outputPath = path.join(root, "dist", "index.js");
+      const logs: string[] = [];
+      const originalLog = console.log;
+      console.log = (...args: unknown[]) => {
+        logs.push(args.join(" "));
+      };
+      try {
+        await import(pathToFileURL(outputPath).href);
+      } finally {
+        console.log = originalLog;
+      }
+
+      expect(logs).toContain("ok");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Problem

The SDK production build could make a broken Worker bundle.

A dependency barrel can be marked as side-effect free and still contain code that Rolldown keeps when code splitting is disabled. In the docs app, this happened through Base UI and `reselect`. The final bundle could contain names like `createSelectorCreator` and `lruMemoize` without the code that defines them, so Cloudflare rejected the Worker.

## Reproduction

On current `main`, the docs app cannot produce a deployable Worker build:

```bash
cd docs
pnpm run build
npx wrangler deploy --dry-run
```

The Vite build finishes, but the Worker validation fails with:

```txt
ReferenceError: createSelectorCreator is not defined
```

The generated bundle contains `createSelectorCreator` / `lruMemoize` references without matching definitions.

## Solution

The SSR bridge build now disables Rolldown's lazy barrel optimization. The SSR bridge already needs `codeSplitting: false`, and Rolldown maintainers recommend `experimental.lazyBarrel: false` as the temporary workaround for this bug shape.

I also added a small regression test that mirrors the side-effect-free barrel shape that causes the bad output.

## Technical Summary

- Scope the workaround to the SSR bridge build, where the dangling references were emitted.
- Keep `codeSplitting: false` unchanged because the SSR bridge depends on a single wrapped module for the linker pass.
- Disable `experimental.lazyBarrel` for that build, matching the upstream Rolldown workaround for `codeSplitting: false`: https://github.com/rolldown/rolldown/issues/9691#issuecomment-4666238497
- Related upstream bug class: https://github.com/rolldown/rolldown/issues/9964
