### PR TITLE
Fix docs rwsdk client SSR resolution

### DIFF
--- a/docs/vite.config.mts
+++ b/docs/vite.config.mts
@@ -3,10 +3,51 @@ import tailwindcss from "@tailwindcss/vite";
 import mdx from "fumadocs-mdx/vite";
 import * as MdxConfig from "./source.config";
 import { redwood } from "rwsdk/vite";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import babel from "@rolldown/plugin-babel";
 import path from "path";
+
+// The docs app SSR-renders client components that import rwsdk/client for
+// browser navigation. Keep those non-browser imports docs-local instead of
+// requiring the SDK workerd client entry to expose browser navigation APIs.
+function docsSsrRwsdkClientStub(): Plugin {
+  const virtualModuleId = "virtual:docs-rwsdk-client-ssr-stub";
+  const resolvedVirtualModuleId = `\0${virtualModuleId}`;
+
+  return {
+    name: "docs:rwsdk-client-ssr-stub",
+    enforce: "pre",
+    resolveId(source) {
+      if (source === "rwsdk/client" && this.environment.name !== "client") {
+        return resolvedVirtualModuleId;
+      }
+    },
+    load(id) {
+      if (id !== resolvedVirtualModuleId) {
+        return;
+      }
+
+      return `
+        export { default as React } from "react";
+        export const ClientOnly = ({ children }) => children ?? null;
+        export const initClient = () => {};
+        export const initClientNavigation = () => ({
+          handleResponse: () => {},
+          onHydrated: () => {},
+        });
+        export const navigate = () => {};
+        export const useNavigationPending = () => ({
+          currentUrl: new URL("http://localhost/"),
+          pending: null,
+        });
+        export function NavigationPending({ children }) {
+          return children ?? null;
+        }
+      `;
+    },
+  };
+}
 
 export default defineConfig({
   resolve: {
@@ -21,6 +62,7 @@ export default defineConfig({
     },
   },
   plugins: [
+    docsSsrRwsdkClientStub(),
     react(),
     babel({ presets: [reactCompilerPreset()] }),
     cloudflare({
@@ -34,10 +76,7 @@ export default defineConfig({
         "node_modules/fumadocs-ui/dist/**/!(og|next|waku|react-router|tanstack|mdx|*.server).js",
         "node_modules/fumadocs-core/dist/**/!(next|waku|react-router|tanstack|middleware).js",
       ],
-      directiveScanBlocklist: [
-        "fumadocs-core/dist/framework",
-        "fumadocs-ui/dist/provider",
-      ],
+      directiveScanBlocklist: ["fumadocs-core/dist/framework", "fumadocs-ui/dist/provider"],
     }),
     tailwindcss(),
     mdx(MdxConfig),


### PR DESCRIPTION
## Problem

The docs app SSR-renders some client components that import `rwsdk/client` for browser navigation. That made the docs worker and SSR builds depend on browser navigation exports from the SDK client entry. This is a docs-only need, not a reason to widen the SDK runtime API for non-browser builds.

## Solution

The docs Vite config now handles this locally. For non-client environments, it resolves `rwsdk/client` to a small virtual stub with safe no-op navigation exports. The real browser client build still uses the real `rwsdk/client` entry.

## Technical Summary

- Add a docs-only Vite plugin in `docs/vite.config.mts`.
- Stub `rwsdk/client` only when Vite is building a non-client environment.
- Keep browser navigation behavior unchanged by leaving the `client` environment untouched.
- Keep the workaround out of SDK runtime files and scoped to the docs app.
