### PR TITLE
fix(render): avoid false-positive tag split on chunk boundary during hoisting

### DIFF
--- a/sdk/src/runtime/lib/stitchDocumentAndAppStreams.test.ts
+++ b/sdk/src/runtime/lib/stitchDocumentAndAppStreams.test.ts
@@ -229,6 +229,90 @@ describe("stitchDocumentAndAppStreams", () => {
 
       expect(result.trim().startsWith(`<!DOCTYPE html>`)).toBe(true);
     });
+
+    it("does not split an unclosed title tag across a chunk boundary", async () => {
+      const outerHtml = `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+</head>
+<body>
+  ${startMarker}
+  <script src="/client.js"></script>
+</body>
+</html>`;
+
+      // The ">" of the closing </title> arrives in the next chunk. A naive
+      // regex scan of the first chunk can falsely treat the "</title" as a
+      // non-hoisted tag boundary, leaving the <title> unclosed in <head>.
+      const innerHtmlChunks = [
+        `<title>Page Title</title`,
+        `><div>App content</div>${endMarker}`,
+      ];
+
+      const result = await streamToString(
+        stitchDocumentAndAppStreams(
+          stringToStream(outerHtml),
+          createChunkedStream(innerHtmlChunks),
+          startMarker,
+          endMarker,
+        ),
+      );
+
+      expect(result).toContain(`<title>Page Title</title>`);
+      expect(result).toMatch(
+        /<head>[\s\S]*<title>Page Title<\/title>[\s\S]*<\/head>/,
+      );
+      expect(result).toContain(`<div>App content</div>`);
+
+      const titleIndex = result.indexOf(`<title>Page Title</title>`);
+      const headCloseIndex = result.indexOf(`</head>`);
+      const bodyIndex = result.indexOf(`<body>`);
+
+      expect(titleIndex).toBeLessThan(headCloseIndex);
+      expect(titleIndex).toBeLessThan(bodyIndex);
+    });
+
+    it("does not truncate a hoisted tag name across a chunk boundary", async () => {
+      const outerHtml = `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+</head>
+<body>
+  ${startMarker}
+  <script src="/client.js"></script>
+</body>
+</html>`;
+
+      // The "<title" tag name is split between chunks. A naive regex scan of
+      // the first chunk (ending at "<t") can falsely treat that "<" as a
+      // non-hoisted tag boundary and fail to hoist the title.
+      const innerHtmlChunks = [
+        `<t`,
+        `itle>Page Title</title><div>App content</div>${endMarker}`,
+      ];
+
+      const result = await streamToString(
+        stitchDocumentAndAppStreams(
+          stringToStream(outerHtml),
+          createChunkedStream(innerHtmlChunks),
+          startMarker,
+          endMarker,
+        ),
+      );
+
+      expect(result).toContain(`<title>Page Title</title>`);
+      expect(result).toMatch(
+        /<head>[\s\S]*<title>Page Title<\/title>[\s\S]*<\/head>/,
+      );
+      expect(result).toContain(`<div>App content</div>`);
+
+      const titleIndex = result.indexOf(`<title>Page Title</title>`);
+      const headCloseIndex = result.indexOf(`</head>`);
+
+      expect(titleIndex).toBeLessThan(headCloseIndex);
+    });
   });
 
   describe("basic stitching flow", () => {

--- a/sdk/src/runtime/lib/stitchDocumentAndAppStreams.ts
+++ b/sdk/src/runtime/lib/stitchDocumentAndAppStreams.ts
@@ -24,6 +24,25 @@ function splitStreamOnFirstNonHoistedTag(
   const nonHoistedTagPattern =
     /<(?!(?:\/)?(?:title|meta|link|style|base)[\s>\/])(?![!?])/i;
 
+  // Longest hoistable name is 5 chars (title/style); a match candidate at
+  // index i needs buffer[i..] to have at least 1 (optional "/") + 5 (name)
+  // + 1 (terminating char) = 7 chars of context past "<" before it can be
+  // trusted as final. Otherwise the tag name may be mid-stream-truncated,
+  // causing a false-positive match on e.g. "<t" and severing <title>.
+  const MIN_TRAILING_CONTEXT = 7;
+  function findTrustedMatch(
+    buf: string,
+    streamDone: boolean,
+  ): RegExpMatchArray | null {
+    const match = buf.match(nonHoistedTagPattern);
+    if (!match || typeof match.index !== "number") return null;
+    if (streamDone) return match; // no more data coming; trust it
+    // buf.length - match.index counts the "<" itself, so subtract 1 to
+    // get the number of confirmed characters *after* it.
+    if (buf.length - match.index - 1 < MIN_TRAILING_CONTEXT) return null; // ambiguous, wait for more data
+    return match;
+  }
+
   let sourceReader: ReadableStreamDefaultReader<Uint8Array>;
   let appBodyController: ReadableStreamDefaultController<Uint8Array> | null =
     null;
@@ -45,7 +64,7 @@ function splitStreamOnFirstNonHoistedTag(
 
           if (done) {
             if (buffer) {
-              const match = buffer.match(nonHoistedTagPattern);
+              const match = findTrustedMatch(buffer, true);
               if (match && typeof match.index === "number") {
                 const hoistedPart = buffer.slice(0, match.index);
                 controller.enqueue(encoder.encode(hoistedPart));
@@ -62,7 +81,7 @@ function splitStreamOnFirstNonHoistedTag(
           }
 
           buffer += decoder.decode(value, { stream: true });
-          const match = buffer.match(nonHoistedTagPattern);
+          const match = findTrustedMatch(buffer, false);
 
           if (match && typeof match.index === "number") {
             const hoistedPart = buffer.slice(0, match.index);
@@ -89,11 +108,20 @@ function splitStreamOnFirstNonHoistedTag(
             }
           } else {
             const flushIndex = buffer.lastIndexOf("\n");
-            if (flushIndex !== -1) {
+            // Never flush past a point that could still be part of
+            // an ambiguous, not-yet-trusted candidate tag. Only
+            // flush content strictly before the last unresolved
+            // "<" in the buffer, so a truncated tag name can never
+            // be split across a flush boundary.
+            const earliestOpenBracket = buffer.lastIndexOf("<");
+            const safeFlushLimit =
+              earliestOpenBracket === -1 ? buffer.length : earliestOpenBracket;
+            const effectiveFlushIndex = Math.min(flushIndex, safeFlushLimit - 1);
+            if (flushIndex !== -1 && effectiveFlushIndex >= 0) {
               controller.enqueue(
-                encoder.encode(buffer.slice(0, flushIndex + 1)),
+                encoder.encode(buffer.slice(0, effectiveFlushIndex + 1)),
               );
-              buffer = buffer.slice(flushIndex + 1);
+              buffer = buffer.slice(effectiveFlushIndex + 1);
             }
             await pump();
           }


### PR DESCRIPTION
`<title>`, `<meta>`, `<link>`, `<style>`, and `<base>` tags rendered by the React app are hoisted into `<head>` by buffering the app stream and scanning for the first non-hoisted tag. The scanner used a regex that could produce false-positive matches when a stream chunk boundary landed in the middle of a tag name.

For example, if a chunk ended at `<t `or at `</title` (before the closing >), the regex would match the < as the start of a non-hoisted tag and split the stream there. This either dropped the title into the body or, worse, left an unclosed `<title>` in `<head>`, which caused the browser to swallow the rest of the document and broke hydration.

### Changes
Added a findTrustedMatch helper in splitStreamOnFirstNonHoistedTag that only trusts a regex match when there is enough trailing context (7 characters past <) to confirm the full tag name, or when the stream has ended.
Tightened the flush logic so we never flush content past the last unresolved < in the buffer, preventing a truncated tag from being split across a flush boundary.

### Verification
Added regression unit tests in sdk/src/runtime/lib/stitchDocumentAndAppStreams.test.ts covering:
- Closing </title> split before >
- <title tag name split as <t / itle>
- pnpm test src/runtime/lib/stitchDocumentAndAppStreams.test.ts → 22 passed
-  pnpm test → 610 passed, 1 skipped
- pnpm --filter rwsdk build succeeds

No playground example was added because this is a core stream-transformation bug that only reproduces under specific production chunk boundaries; the unit tests directly exercise the affected function with controlled chunk boundaries.

Fixes #1257