### PR TITLE
fix(use-synced-state/hibernation): allow missing value in getState/update responses

### DIFF
--- a/docs/architecture/useSyncedStateHibernation.md
+++ b/docs/architecture/useSyncedStateHibernation.md
@@ -64,6 +64,8 @@ Messages are JSON envelopes with a protocol version and a `kind` discriminator:
 
 Client message kinds are `getState`, `setState`, `subscribe`, and `unsubscribe`. Server message kinds are `getState`, `setState`, `subscribe`, `unsubscribe`, `update`, and `error`. The protocol is intentionally simple and does not support chunked streaming, because the payloads are small key/value operations.
 
+Because messages are serialized with `JSON.stringify`, an `undefined` value is omitted from the envelope. A `getState` response for an unset key, or an `update` for a state that was set to `undefined`, therefore arrives without a `value` property. The client treats a missing `value` as `undefined` rather than rejecting the message as malformed.
+
 ## Identity Extraction and Key Transformation
 
 Applications register an identity extractor with `SyncedStateServer.registerIdentityExtractor`. It runs in the Worker at upgrade time and must return a small JSON-serializable value from `requestInfo`:

--- a/sdk/src/use-synced-state/hibernation/__tests__/client-core.test.ts
+++ b/sdk/src/use-synced-state/hibernation/__tests__/client-core.test.ts
@@ -281,6 +281,44 @@ describe("client-core", () => {
     await expect(getStatePromise).rejects.toThrow("WebSocket closed");
   });
 
+  it("resolves getState with undefined when the server has no state", async () => {
+    const client = createClient();
+    const getStatePromise = client.getState("counter");
+
+    await waitForOpen(clients[0] as unknown as WebSocket);
+
+    const serverSocket = await waitForCondition(() => serverSockets[0]);
+    await waitForCondition(() =>
+      serverMessages[0].length >= 1 ? serverMessages[0] : undefined,
+    );
+
+    expect(serverMessages[0][0]).toMatchObject({
+      v: 1,
+      kind: "getState",
+      key: "counter",
+    });
+
+    // When the server has no state it sends a getState response with no value
+    // property (because JSON.stringify omits undefined values).
+    send(serverSocket, {
+      kind: "getState",
+      key: "counter",
+      id: serverMessages[0][0].id,
+    } as ServerMessage);
+
+    await wait(0);
+    await vi.advanceTimersByTimeAsync(PENDING_REQUEST_TIMEOUT_MS + 1000);
+
+    await expect(getStatePromise).resolves.toBeUndefined();
+
+    // The pending timeout should not fire; the socket should stay open.
+    const firstSocket = clients[0] as unknown as WebSocket;
+    const closeSpy = vi.fn();
+    firstSocket.once("close", closeSpy);
+    await vi.advanceTimersByTimeAsync(PENDING_REQUEST_TIMEOUT_MS + 1000);
+    expect(closeSpy).not.toHaveBeenCalled();
+  });
+
   it("queues messages sent before the socket opens", async () => {
     const client = createClient();
     const getStatePromise = client.getState("counter");

--- a/sdk/src/use-synced-state/hibernation/protocol.mts
+++ b/sdk/src/use-synced-state/hibernation/protocol.mts
@@ -23,11 +23,11 @@ export type ClientMessage =
 
 // Messages sent by the DO back to the client.
 export type ServerMessage =
-  | { kind: "getState"; key: string; value: SyncedStateValue | undefined; id: string }
+  | { kind: "getState"; key: string; value?: SyncedStateValue | undefined; id: string }
   | { kind: "setState"; key: string; id: string }
   | { kind: "subscribe"; key: string; id: string }
   | { kind: "unsubscribe"; key: string; id: string }
-  | { kind: "update"; key: string; value: SyncedStateValue }
+  | { kind: "update"; key: string; value?: SyncedStateValue }
   | { kind: "error"; message: string; id?: string };
 
 export function packMessage(message: SyncedStateMessage): string {
@@ -62,13 +62,18 @@ function isClientMessage(message: SyncedStateMessage): message is ClientMessage 
 function isServerMessage(message: SyncedStateMessage): message is ServerMessage {
   switch (message.kind) {
     case "getState":
-      return "id" in message && typeof message.id === "string" && "value" in message;
+      return (
+        "id" in message &&
+        typeof message.id === "string" &&
+        "key" in message &&
+        typeof message.key === "string"
+      );
     case "setState":
     case "subscribe":
     case "unsubscribe":
       return "id" in message && typeof message.id === "string";
     case "update":
-      return "value" in message;
+      return "key" in message && typeof message.key === "string";
     case "error":
       return "message" in message && typeof message.message === "string";
     default:


### PR DESCRIPTION
## Problem

We started seeing `Error/useSyncedState request timed out` after ~30 seconds of idle in a non-prod application using the hibernation transport. This began after upgrading to rwsdk 1.5.3.

## Root cause

When `useSyncedState` mounts, it sends a `getState` request for the key. If the Durable Object has no stored state for that key, the server replies with a `getState` response whose `value` is `undefined`. Because `JSON.stringify` omits `undefined` fields, the wire message arrives without a `value` property.

The client protocol validator in `sdk/src/use-synced-state/hibernation/protocol.mts` required `"value" in message` for every `getState` response, so it rejected the server reply as malformed. The pending promise stayed in `connection.pending` until the 30-second pending-request timer fired, producing the Sentry error. The idle socket was not being closed; the 30-second window belonged to the initial `getState` request, not to a connection idle timeout.

## Solution

- Make `value` optional on `ServerMessage` `getState` and `update` kinds.
- Validate `getState` responses by `id` and `key`, and `update` messages by `key`, instead of requiring the `value` property to be present.
- Treat a missing `value` as `undefined`.
- Update `docs/architecture/useSyncedStateHibernation.md` to document this behavior.

## Testing

- Added a regression test in `sdk/src/use-synced-state/hibernation/__tests__/client-core.test.ts` that sends a `getState` response without a `value` property, advances past the 30-second timeout, and asserts the promise resolves to `undefined`. It fails with `useSyncedState request timed out` before the fix and passes after.
- `cd sdk && pnpm build` passes.
- `cd sdk && pnpm test` passes: 591 passed, 1 skipped.

## Verification plan

1. Bump the consumer's non-prod environment to the SDK version containing this fix.
2. Open a page using `useSyncedState` with a key that has no stored state, and leave it idle for at least 60 seconds.
3. Confirm no new `Error/useSyncedState request timed out` entries appear in Sentry or the browser console.
4. Confirm normal behavior: the component renders its initial value when no server state exists, and `setState` still syncs across tabs.
5. After non-prod is clean, enable hibernation in production with the same SDK version and monitor Sentry for 24–48 hours.