### PR TITLE
fix(client): recover failed client navigations instead of stranding the URL

### DIFF
--- a/docs/architecture/clientNavigationCommitIntegrity.md
+++ b/docs/architecture/clientNavigationCommitIntegrity.md
@@ -29,9 +29,15 @@ Server-action payloads keep the transition path. Actions do not change the URL, 
 
 The pending-navigation tracker described in [Client Navigation Pending Boundaries](./clientNavigationPending.md) records, for each navigation, that a commit is outstanding, and resolves that record only when the payload actually commits to the visible tree — not when the fetch finishes. A navigation whose commit never arrives is therefore an observable state: the pending record simply never resolves.
 
+### Recovering from failed navigations
+
+When the payload request itself fails — a network error, or a stream that dies mid-decode — the navigation's promise chain rejects. Because history was already updated, a rejection left alone strands the browser: the address bar shows the new route, the screen shows the old page, and the framework's own guards against redundant work then block every retry of that route.
+
+A failed navigation is therefore recovered immediately: the pending record is abandoned, the framework's bookkeeping is rolled back to the page that is actually on screen (so a later back/forward to the failed target is treated as a real navigation, not a hash-only change), and the default recovery performs a hard navigation to the intended URL, logged with the original error. Apps that prefer their own policy — an error toast, a redirect to an error page — can take over through `onNavigationError`, in which case the framework performs no recovery of its own.
+
 ### The commit watchdog
 
-Observing a missing commit is not enough; the framework must also leave the state. Apps can arm a commit budget (`navigationTimeoutMs`). If a navigation is still uncommitted when its budget expires, the framework abandons the client-side attempt and performs a hard navigation to the pending URL. A full page load always produces a page whose content matches its URL, so recovery restores agreement no matter what prevented the commit — scheduler loss, a hung request, a decode failure, a render error, or a cause not yet known. Apps can substitute their own recovery through `onNavigationTimeout` — for example, surfacing an error — instead of the hard navigation.
+Error recovery handles navigations that fail loudly. What remains is the navigation that neither commits nor errors: a request that hangs forever, a payload that a custom transport never delivers, a render that never completes, or a cause not yet known. Observing a missing commit is not enough; the framework must also leave the state. Apps can arm a commit budget (`navigationTimeoutMs`). If a navigation is still uncommitted when its budget expires, the framework abandons the client-side attempt and performs a hard navigation to the pending URL. A full page load always produces a page whose content matches its URL, so recovery restores agreement no matter what prevented the commit. Apps can substitute their own recovery through `onNavigationTimeout` — for example, surfacing an error — instead of the hard navigation.
 
 The watchdog is opt-in. Recovery is a full page load, and a budget that is too tight turns slow-but-healthy navigations into reloads; whether that trade is acceptable depends on the application's latency profile, so the application chooses the budget, or chooses not to arm the watchdog at all.
 
@@ -47,6 +53,7 @@ An alternative design would defer the history push until the payload commits, ma
 ## Correctness Invariants
 
 - A resolved navigation payload must not be dropped by render scheduling.
+- A navigation that throws must not strand the browser: it recovers immediately, ending at a page whose content and URL agree.
 - A pending navigation resolves when it commits, is superseded, is aborted, is redirected away, or — if the watchdog is armed — its budget expires.
 - Watchdog recovery must always end at a page whose content and URL agree; that is why the default recovery is a hard navigation rather than a retry of the client-side pipeline.
 - Action payloads never change the commit semantics of navigation payloads, and vice versa.

--- a/docs/architecture/clientNavigationCommitIntegrity.md
+++ b/docs/architecture/clientNavigationCommitIntegrity.md
@@ -33,7 +33,7 @@ The pending-navigation tracker described in [Client Navigation Pending Boundarie
 
 When the payload request itself fails — a network error, or a stream that dies mid-decode — the navigation's promise chain rejects. Because history was already updated, a rejection left alone strands the browser: the address bar shows the new route, the screen shows the old page, and the framework's own guards against redundant work then block every retry of that route.
 
-A failed navigation is therefore recovered immediately: the pending record is abandoned, the framework's bookkeeping is rolled back to the page that is actually on screen (so a later back/forward to the failed target is treated as a real navigation, not a hash-only change), and the default recovery performs a hard navigation to the intended URL, logged with the original error. Apps that prefer their own policy — an error toast, a redirect to an error page — can take over through `onNavigationError`, in which case the framework performs no recovery of its own.
+A failed navigation is therefore recovered immediately: the pending record is abandoned, the framework's bookkeeping is rolled back to the page that is actually on screen (so a later back/forward to the failed target is treated as a real navigation, not a hash-only change), and the default recovery performs a hard navigation to the intended URL, logged with the original error. Recovery then rethrows the original error, preserving the existing rejection contract for programmatic callers. Apps that prefer their own recovery policy — an error toast, a redirect to an error page — can take over through `onNavigationError`; the original rejection remains observable after their handler returns.
 
 ### The commit watchdog
 

--- a/playground/client-navigation/__tests__/nav-error-recovery.test.mts
+++ b/playground/client-navigation/__tests__/nav-error-recovery.test.mts
@@ -1,7 +1,7 @@
 import {
   poll,
   setupPlaygroundEnvironment,
-  testDeploy,
+  testDevAndDeploy,
   waitForHydration,
 } from "rwsdk/e2e";
 import { expect } from "vitest";
@@ -14,7 +14,7 @@ setupPlaygroundEnvironment(import.meta.url);
 // content. This test aborts the navigation fetch once and asserts the page
 // recovers to the target route.
 
-testDeploy(
+testDevAndDeploy(
   "failed client navigation recovers with a full page load",
   async ({ browser, url }) => {
     const context = await browser.createBrowserContext();

--- a/playground/client-navigation/__tests__/nav-error-recovery.test.mts
+++ b/playground/client-navigation/__tests__/nav-error-recovery.test.mts
@@ -1,0 +1,56 @@
+import {
+  poll,
+  setupPlaygroundEnvironment,
+  testDeploy,
+  waitForHydration,
+} from "rwsdk/e2e";
+import { expect } from "vitest";
+
+setupPlaygroundEnvironment(import.meta.url);
+
+// A client navigation whose RSC fetch fails must not strand the browser on
+// the new URL with the old page rendered. The default recovery is a hard
+// navigation to the intended URL, which always lands on matching URL and
+// content. This test aborts the navigation fetch once and asserts the page
+// recovers to the target route.
+
+testDeploy(
+  "failed client navigation recovers with a full page load",
+  async ({ browser, url }) => {
+    const context = await browser.createBrowserContext();
+    try {
+      const page = await context.newPage();
+      await page.goto(`${url}/list?v=a`);
+      await waitForHydration(page);
+
+      // Fail the next RSC navigation request once; let everything else through.
+      await page.setRequestInterception(true);
+      let aborted = false;
+      page.on("request", (request) => {
+        if (!aborted && request.url().includes("__rsc")) {
+          aborted = true;
+          request.abort();
+          return;
+        }
+        request.continue();
+      });
+
+      await page.click('[data-testid="toggle"]');
+
+      // Recovery is a full page load of /list?v=b, so the heading must reach
+      // "b" without any further intervention.
+      await poll(async () => {
+        const heading = await page
+          .$eval(
+            '[data-testid="current-v"]',
+            (el) => el.textContent?.trim() ?? null,
+          )
+          .catch(() => null);
+        expect(heading).toBe("b");
+        return true;
+      });
+    } finally {
+      await context.close();
+    }
+  },
+);

--- a/sdk/src/lib/e2e/dev.mts
+++ b/sdk/src/lib/e2e/dev.mts
@@ -11,6 +11,33 @@ const DEV_SERVER_CHECK_TIMEOUT = process.env.RWSDK_DEV_SERVER_CHECK_TIMEOUT
 
 const log = debug("rwsdk:e2e:dev");
 
+// context(justinvdm, 06 Aug 2026): Dev startup can run initialization
+// commands that start their own temporary servers (for example `dev:init` ->
+// `worker-run`) before Vite announces the real dev server. Accept only Vite's
+// own announcements; a bare localhost URL in initialization output may belong
+// to a helper server that exits before the tests run.
+const DEV_SERVER_URL_PATTERNS = [
+  // Standard Vite output: "Local:   http://localhost:5173/"
+  /Local:\s*(?:\u001b\[\d+m)?(https?:\/\/localhost:\d+)/i,
+  // Alternative Vite output: "➜  Local:   http://localhost:5173/"
+  /[➜→]\s*Local:\s*(?:\u001b\[\d+m)?(https?:\/\/localhost:\d+)/i,
+  // Unicode-safe arrow pattern
+  /[\u27A1\u2192\u279C]\s*Local:\s*(?:\u001b\[\d+m)?(https?:\/\/localhost:\d+)/i,
+  // Explicit debug announcement: "Debug: http://localhost:5173/__debug"
+  /Debug:\s*(?:\u001b\[\d+m)?(https?:\/\/localhost:\d+)\/__debug/i,
+];
+
+function parseDevServerUrl(output: string) {
+  for (const pattern of DEV_SERVER_URL_PATTERNS) {
+    const match = output.match(pattern);
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+
+  return null;
+}
+
 /**
  * Run the local development server and return the URL
  */
@@ -137,34 +164,9 @@ export async function runDevServer(
       allOutput += output; // Accumulate all output
 
       if (!url) {
-        // Multiple patterns to catch different package manager outputs
-        const patterns = [
-          // Standard Vite output: "Local:   http://localhost:5173/"
-          /Local:\s*(?:\u001b\[\d+m)?(https?:\/\/localhost:\d+)/i,
-          // Alternative Vite output: "➜  Local:   http://localhost:5173/"
-          /[➜→]\s*Local:\s*(?:\u001b\[\d+m)?(https?:\/\/localhost:\d+)/i,
-          // Unicode-safe arrow pattern
-          /[\u27A1\u2192\u279C]\s*Local:\s*(?:\u001b\[\d+m)?(https?:\/\/localhost:\d+)/i,
-          // Direct URL pattern: "http://localhost:5173"
-          /(https?:\/\/localhost:\d+)/i,
-          // Port-only pattern: "localhost:5173"
-          /localhost:(\d+)/i,
-          // Server ready messages
-          /server.*ready.*localhost:(\d+)/i,
-          /dev server.*localhost:(\d+)/i,
-        ];
-
-        for (const pattern of patterns) {
-          const match = output.match(pattern);
-          if (match) {
-            if (match[1] && match[1].startsWith("http")) {
-              url = match[1];
-              break;
-            } else if (match[1] && /^\d+$/.test(match[1])) {
-              url = `http://localhost:${match[1]}`;
-              break;
-            }
-          }
+        const detectedUrl = parseDevServerUrl(output);
+        if (detectedUrl) {
+          url = detectedUrl;
         }
       }
     };
@@ -226,35 +228,11 @@ export async function runDevServer(
 
         // Fallback: check accumulated output if stream listeners aren't working
         if (!url && allOutput) {
-          const patterns = [
-            /Local:\s*(?:\u001b\[\d+m)?(https?:\/\/localhost:\d+)/i,
-            /[➜→]\s*Local:\s*(?:\u001b\[\d+m)?(https?:\/\/localhost:\d+)/i,
-            /[\u27A1\u2192\u279C]\s*Local:\s*(?:\u001b\[\d+m)?(https?:\/\/localhost:\d+)/i,
-            /(https?:\/\/localhost:\d+)/i,
-            /localhost:(\d+)/i,
-          ];
-
-          for (const pattern of patterns) {
-            const match = allOutput.match(pattern);
-            if (match) {
-              if (match[1] && match[1].startsWith("http")) {
-                url = match[1];
-                log(
-                  "Found URL in accumulated output with pattern %s: %s",
-                  pattern.source,
-                  url,
-                );
-                return url;
-              } else if (match[1] && /^\d+$/.test(match[1])) {
-                url = `http://localhost:${match[1]}`;
-                log(
-                  "Found URL in accumulated output with port pattern %s: %s",
-                  pattern.source,
-                  url,
-                );
-                return url;
-              }
-            }
+          const detectedUrl = parseDevServerUrl(allOutput);
+          if (detectedUrl) {
+            url = detectedUrl;
+            log("Found dev server URL in accumulated output: %s", url);
+            return url;
           }
         }
 

--- a/sdk/src/runtime/client/client.tsx
+++ b/sdk/src/runtime/client/client.tsx
@@ -33,6 +33,8 @@ export type {
   NavigationSearchParamsWatch,
 } from "./navigationPending.js";
 export type {
+  NavigationErrorArgs,
+  NavigationErrorHandler,
   NavigationSnapshot,
   NavigationTimeoutArgs,
   NavigationTimeoutHandler,

--- a/sdk/src/runtime/client/navigation.ts
+++ b/sdk/src/runtime/client/navigation.ts
@@ -8,8 +8,11 @@ import {
   abortPendingNavigation,
   beginPendingNavigation,
   commitPendingNavigation,
-  configureNavigationTimeout,
+  configureNavigationRecovery,
+  getNavigationSnapshot,
   isPendingNavigationCommit,
+  recoverFromNavigationError,
+  type NavigationErrorArgs,
   type NavigationTimeoutArgs,
 } from "./navigationState.js";
 import {
@@ -48,6 +51,12 @@ export interface ClientNavigationOptions {
    * to the pending URL. Has no effect unless `navigationTimeoutMs` is set.
    */
   onNavigationTimeout?: (args: NavigationTimeoutArgs) => void;
+  /**
+   * Recovery handler invoked when a navigation throws (failed fetch or
+   * failed payload decode). Defaults to a hard navigation to the intended
+   * URL, logged with the original error.
+   */
+  onNavigationError?: (args: NavigationErrorArgs) => void;
 }
 
 function shouldInterceptNavigation(
@@ -186,7 +195,13 @@ export async function navigate(
     currentUrl = url;
   } catch (error) {
     abortPendingNavigation(pendingNavigation.id);
-    throw error;
+    // context(justinvdm, 30 Jul 2026): The navigation failed after history
+    // and currentPathKey were already advanced. Repair the bookkeeping so a
+    // later popstate to the failed target is not swallowed as a hash-only
+    // change, then recover instead of rethrowing into an unhandled
+    // rejection — a stranded URL with no recovery is strictly worse.
+    currentPathKey = getUrlPathKey(getNavigationSnapshot().currentUrl);
+    recoverFromNavigationError({ error, href: url.href });
   }
 }
 
@@ -234,9 +249,10 @@ export async function navigate(
 export function initClientNavigation(opts: ClientNavigationOptions = {}) {
   IS_CLIENT_NAVIGATION = true;
   clientNavigationOptions = opts;
-  configureNavigationTimeout({
+  configureNavigationRecovery({
     timeoutMs: opts.navigationTimeoutMs,
     onTimeout: opts.onNavigationTimeout,
+    onError: opts.onNavigationError,
   });
   scrollRestoration = createScrollRestoration();
   scrollRestoration.initialize();
@@ -300,7 +316,11 @@ export function initClientNavigation(opts: ClientNavigationOptions = {}) {
       await globalThis.__rsc_callServer(null, null, "navigation");
     } catch (error) {
       abortPendingNavigation(pendingNavigation.id);
-      throw error;
+      // context(justinvdm, 30 Jul 2026): Same failure repair as navigate() —
+      // the browser already changed the URL, so recover to the (now current)
+      // location and restore the bookkeeping for retries.
+      currentPathKey = getUrlPathKey(getNavigationSnapshot().currentUrl);
+      recoverFromNavigationError({ error, href: window.location.href });
     }
   });
 

--- a/sdk/src/runtime/client/navigation.ts
+++ b/sdk/src/runtime/client/navigation.ts
@@ -198,10 +198,13 @@ export async function navigate(
     // context(justinvdm, 30 Jul 2026): The navigation failed after history
     // and currentPathKey were already advanced. Repair the bookkeeping so a
     // later popstate to the failed target is not swallowed as a hash-only
-    // change, then recover instead of rethrowing into an unhandled
-    // rejection — a stranded URL with no recovery is strictly worse.
-    currentPathKey = getUrlPathKey(getNavigationSnapshot().currentUrl);
+    // change, then start recovery before preserving the existing rejection
+    // contract — a stranded URL with no recovery is strictly worse.
+    const committedUrl = getNavigationSnapshot().currentUrl;
+    currentPathKey = getUrlPathKey(committedUrl);
+    currentUrl = committedUrl;
     recoverFromNavigationError({ error, href: url.href });
+    throw error;
   }
 }
 
@@ -318,9 +321,13 @@ export function initClientNavigation(opts: ClientNavigationOptions = {}) {
       abortPendingNavigation(pendingNavigation.id);
       // context(justinvdm, 30 Jul 2026): Same failure repair as navigate() —
       // the browser already changed the URL, so recover to the (now current)
-      // location and restore the bookkeeping for retries.
-      currentPathKey = getUrlPathKey(getNavigationSnapshot().currentUrl);
+      // location and restore the bookkeeping for retries. Rethrowing keeps
+      // the existing failure semantics after recovery starts.
+      const committedUrl = getNavigationSnapshot().currentUrl;
+      currentPathKey = getUrlPathKey(committedUrl);
+      currentUrl = committedUrl;
       recoverFromNavigationError({ error, href: window.location.href });
+      throw error;
     }
   });
 
@@ -403,7 +410,12 @@ export function initClientNavigation(opts: ClientNavigationOptions = {}) {
     // then warm the navigation cache based on any <link rel="x-prefetch"> tags
     // rendered for the current location.
     onNavigationCommit(undefined, opts.cacheStorage);
-    void preloadFromLinkTags(undefined, undefined, opts.cacheStorage, opts.shouldIntercept);
+    void preloadFromLinkTags(
+      undefined,
+      undefined,
+      opts.cacheStorage,
+      opts.shouldIntercept,
+    );
   }
 
   // Return callbacks for use with initClient

--- a/sdk/src/runtime/client/navigationErrorRecovery.test.ts
+++ b/sdk/src/runtime/client/navigationErrorRecovery.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { initClientNavigation, navigate } from "./navigation";
+import { resetNavigationStateForTests } from "./navigationState";
+
+const assignMock = vi.fn();
+const listeners = new Map<string, (...args: any[]) => any>();
+
+const locationStub = {
+  _href: "http://localhost/",
+  get href() {
+    return this._href;
+  },
+  set href(value: string) {
+    this._href = value;
+  },
+  get pathname() {
+    return new URL(this._href).pathname;
+  },
+  get search() {
+    return new URL(this._href).search;
+  },
+  assign: assignMock,
+};
+
+vi.stubGlobal("window", {
+  location: locationStub,
+  addEventListener: (type: string, listener: (...args: any[]) => any) => {
+    listeners.set(type, listener);
+  },
+  history: {
+    scrollRestoration: "auto",
+    pushState: vi.fn(),
+    replaceState: vi.fn(),
+    state: {},
+  },
+  scrollX: 0,
+  scrollY: 0,
+  scrollTo: vi.fn(),
+});
+
+vi.stubGlobal("document", {
+  addEventListener: vi.fn(),
+  visibilityState: "visible",
+});
+
+const callServerMock = vi.fn();
+
+beforeEach(() => {
+  listeners.clear();
+  assignMock.mockClear();
+  callServerMock.mockReset();
+  (globalThis as any).__rsc_callServer = callServerMock;
+  locationStub._href = "http://localhost/";
+  resetNavigationStateForTests("http://localhost/");
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("navigation error recovery", () => {
+  it("recovers a failed navigate() with a hard navigation to the intended URL instead of rethrowing", async () => {
+    initClientNavigation({});
+    callServerMock.mockRejectedValue(new Error("boom"));
+
+    await expect(navigate("/settings")).resolves.toBeUndefined();
+
+    expect(assignMock).toHaveBeenCalledWith("http://localhost/settings");
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it("prefers a configured onNavigationError handler over the hard navigation", async () => {
+    const onNavigationError = vi.fn();
+    initClientNavigation({ onNavigationError });
+    const failure = new Error("boom");
+    callServerMock.mockRejectedValue(failure);
+
+    await navigate("/settings");
+
+    expect(onNavigationError).toHaveBeenCalledWith({
+      error: failure,
+      href: "http://localhost/settings",
+    });
+    expect(assignMock).not.toHaveBeenCalled();
+  });
+
+  it("repairs the optimistic path bookkeeping so a popstate retry of the failed target is not swallowed", async () => {
+    // A custom handler that does not reload leaves the app in the diverged
+    // state by choice; the framework's own bookkeeping must still allow a
+    // back/forward retry of the failed route.
+    initClientNavigation({ onNavigationError: () => {} });
+    callServerMock.mockRejectedValueOnce(new Error("boom"));
+
+    await navigate("/settings");
+    expect(callServerMock).toHaveBeenCalledTimes(1);
+
+    // Browser goes back/forward to the failed target.
+    locationStub._href = "http://localhost/settings";
+    callServerMock.mockResolvedValue(undefined);
+    await listeners.get("popstate")?.();
+
+    // Without the repair, the hash-only guard would have discarded this as a
+    // same-path change and no retry fetch would happen.
+    expect(callServerMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("recovers a failed popstate navigation with a hard navigation to the current location", async () => {
+    initClientNavigation({});
+    callServerMock.mockRejectedValue(new Error("boom"));
+
+    // The browser has already moved to the target when popstate fires.
+    locationStub._href = "http://localhost/settings";
+    await listeners.get("popstate")?.();
+
+    expect(assignMock).toHaveBeenCalledWith("http://localhost/settings");
+  });
+});

--- a/sdk/src/runtime/client/navigationErrorRecovery.test.ts
+++ b/sdk/src/runtime/client/navigationErrorRecovery.test.ts
@@ -61,11 +61,12 @@ afterEach(() => {
 });
 
 describe("navigation error recovery", () => {
-  it("recovers a failed navigate() with a hard navigation to the intended URL instead of rethrowing", async () => {
+  it("recovers a failed navigate() while preserving its rejection", async () => {
     initClientNavigation({});
-    callServerMock.mockRejectedValue(new Error("boom"));
+    const failure = new Error("boom");
+    callServerMock.mockRejectedValue(failure);
 
-    await expect(navigate("/settings")).resolves.toBeUndefined();
+    await expect(navigate("/settings")).rejects.toBe(failure);
 
     expect(assignMock).toHaveBeenCalledWith("http://localhost/settings");
     expect(console.error).toHaveBeenCalled();
@@ -77,7 +78,7 @@ describe("navigation error recovery", () => {
     const failure = new Error("boom");
     callServerMock.mockRejectedValue(failure);
 
-    await navigate("/settings");
+    await expect(navigate("/settings")).rejects.toBe(failure);
 
     expect(onNavigationError).toHaveBeenCalledWith({
       error: failure,
@@ -91,9 +92,10 @@ describe("navigation error recovery", () => {
     // state by choice; the framework's own bookkeeping must still allow a
     // back/forward retry of the failed route.
     initClientNavigation({ onNavigationError: () => {} });
-    callServerMock.mockRejectedValueOnce(new Error("boom"));
+    const failure = new Error("boom");
+    callServerMock.mockRejectedValueOnce(failure);
 
-    await navigate("/settings");
+    await expect(navigate("/settings")).rejects.toBe(failure);
     expect(callServerMock).toHaveBeenCalledTimes(1);
 
     // Browser goes back/forward to the failed target.
@@ -106,14 +108,43 @@ describe("navigation error recovery", () => {
     expect(callServerMock).toHaveBeenCalledTimes(2);
   });
 
-  it("recovers a failed popstate navigation with a hard navigation to the current location", async () => {
+  it("recovers a failed popstate navigation while preserving its rejection", async () => {
     initClientNavigation({});
-    callServerMock.mockRejectedValue(new Error("boom"));
+    const failure = new Error("boom");
+    callServerMock.mockRejectedValue(failure);
 
     // The browser has already moved to the target when popstate fires.
     locationStub._href = "http://localhost/settings";
-    await listeners.get("popstate")?.();
+    const handlePopState = listeners.get("popstate");
+    expect(handlePopState).toBeDefined();
+    await expect(handlePopState!()).rejects.toBe(failure);
 
     expect(assignMock).toHaveBeenCalledWith("http://localhost/settings");
+  });
+
+  it("restores the rendered URL used by interception after a failed popstate", async () => {
+    const shouldIntercept = vi.fn(
+      (_args: { toUrl: URL; fromUrl: URL; element?: HTMLElement | Element }) =>
+        true,
+    );
+    initClientNavigation({
+      onNavigationError: () => {},
+      shouldIntercept,
+    });
+    const failure = new Error("boom");
+    callServerMock.mockRejectedValueOnce(failure);
+    const handlePopState = listeners.get("popstate");
+    expect(handlePopState).toBeDefined();
+
+    locationStub._href = "http://localhost/settings";
+    await expect(handlePopState!()).rejects.toBe(failure);
+
+    locationStub._href = "http://localhost/profile";
+    callServerMock.mockResolvedValue(undefined);
+    await handlePopState!();
+
+    expect(shouldIntercept.mock.calls[1]?.[0].fromUrl.href).toBe(
+      "http://localhost/",
+    );
   });
 });

--- a/sdk/src/runtime/client/navigationState.test.ts
+++ b/sdk/src/runtime/client/navigationState.test.ts
@@ -4,7 +4,7 @@ import {
   abortPendingNavigation,
   beginPendingNavigation,
   commitPendingNavigation,
-  configureNavigationTimeout,
+  configureNavigationRecovery,
   getNavigationSnapshot,
   resetNavigationStateForTests,
 } from "./navigationState";
@@ -36,7 +36,7 @@ describe("navigation commit watchdog", () => {
   });
 
   it("recovers with a hard navigation when a navigation never commits", () => {
-    configureNavigationTimeout({ timeoutMs: 10_000 });
+    configureNavigationRecovery({ timeoutMs: 10_000 });
     beginPendingNavigation("http://localhost/results?page=2");
 
     vi.advanceTimersByTime(10_000);
@@ -46,7 +46,7 @@ describe("navigation commit watchdog", () => {
   });
 
   it("does not fire when the navigation commits in time", () => {
-    configureNavigationTimeout({ timeoutMs: 10_000 });
+    configureNavigationRecovery({ timeoutMs: 10_000 });
     const pending = beginPendingNavigation("http://localhost/results?page=2");
     commitPendingNavigation(pending.pendingUrl);
 
@@ -56,7 +56,7 @@ describe("navigation commit watchdog", () => {
   });
 
   it("does not fire when the navigation is aborted in time", () => {
-    configureNavigationTimeout({ timeoutMs: 10_000 });
+    configureNavigationRecovery({ timeoutMs: 10_000 });
     const pending = beginPendingNavigation("http://localhost/results?page=2");
     abortPendingNavigation(pending.id);
 
@@ -66,7 +66,7 @@ describe("navigation commit watchdog", () => {
   });
 
   it("does not fire for a superseded navigation; the newer navigation gets the timeout", () => {
-    configureNavigationTimeout({ timeoutMs: 10_000 });
+    configureNavigationRecovery({ timeoutMs: 10_000 });
     beginPendingNavigation("http://localhost/results?page=2");
     vi.advanceTimersByTime(5_000);
     beginPendingNavigation("http://localhost/results?page=3");
@@ -80,7 +80,7 @@ describe("navigation commit watchdog", () => {
 
   it("prefers a configured onTimeout handler over the hard navigation", () => {
     const onTimeout = vi.fn();
-    configureNavigationTimeout({ timeoutMs: 2_000, onTimeout });
+    configureNavigationRecovery({ timeoutMs: 2_000, onTimeout });
 
     beginPendingNavigation("http://localhost/results?page=2");
     vi.advanceTimersByTime(2_000);
@@ -92,7 +92,7 @@ describe("navigation commit watchdog", () => {
   });
 
   it("does not fire for a handler configured without a timeout", () => {
-    configureNavigationTimeout({ onTimeout: vi.fn() });
+    configureNavigationRecovery({ onTimeout: vi.fn() });
 
     beginPendingNavigation("http://localhost/results?page=2");
     vi.advanceTimersByTime(60_000);

--- a/sdk/src/runtime/client/navigationState.ts
+++ b/sdk/src/runtime/client/navigationState.ts
@@ -39,18 +39,50 @@ export interface NavigationTimeoutArgs {
 
 export type NavigationTimeoutHandler = (args: NavigationTimeoutArgs) => void;
 
+export interface NavigationErrorArgs {
+  /** The error thrown by the failed navigation. */
+  error: unknown;
+  /** URL the navigation was trying to reach. */
+  href: string;
+}
+
+export type NavigationErrorHandler = (args: NavigationErrorArgs) => void;
+
 let navigationTimeoutMs = 0;
 let navigationTimeoutHandler: NavigationTimeoutHandler | null = null;
+let navigationErrorHandler: NavigationErrorHandler | null = null;
 let navigationTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
-export function configureNavigationTimeout(options: {
+export function configureNavigationRecovery(options: {
   /** Milliseconds a navigation may stay uncommitted before recovery runs. Unset or 0 disables the watchdog. */
   timeoutMs?: number;
-  /** Recovery handler. Defaults to a hard navigation to the pending URL. Has no effect unless timeoutMs is set. */
+  /** Watchdog recovery handler. Defaults to a hard navigation to the pending URL. Has no effect unless timeoutMs is set. */
   onTimeout?: NavigationTimeoutHandler;
+  /** Error recovery handler. Defaults to a hard navigation to the intended URL. */
+  onError?: NavigationErrorHandler;
 }) {
   navigationTimeoutMs = options.timeoutMs ?? 0;
   navigationTimeoutHandler = options.onTimeout ?? null;
+  navigationErrorHandler = options.onError ?? null;
+}
+
+// context(justinvdm, 30 Jul 2026): One recovery policy for a navigation that
+// failed — whether the watchdog timed out or the fetch/commit threw. The
+// default is a hard navigation to the intended URL, which always lands on
+// matching URL and content. Without this, a thrown navigation strands the
+// browser on the new URL with the old page rendered, and the framework's own
+// retry guards make the state permanent.
+export function recoverFromNavigationError(args: NavigationErrorArgs) {
+  if (navigationErrorHandler) {
+    navigationErrorHandler(args);
+    return;
+  }
+
+  console.error(
+    "[rwsdk] client navigation failed — recovering with a full page load",
+    args.error,
+  );
+  window.location.assign(args.href);
 }
 
 function clearNavigationTimeout() {
@@ -245,6 +277,7 @@ export function resetNavigationStateForTests(href = "http://localhost/") {
   clearNavigationTimeout();
   navigationTimeoutMs = 0;
   navigationTimeoutHandler = null;
+  navigationErrorHandler = null;
   pendingNavigation?.resolve();
   pendingNavigation = null;
   nextNavigationId = 0;


### PR DESCRIPTION
## Problem

`navigate()` and the SPA `popstate` handler update history — and the framework's internal URL trackers — before the RSC fetch. If the fetch or payload decode then throws (a network hiccup, an expired auth token, a long-lived tab fetching chunks that no longer exist after a deploy), the catch path only rethrows into an unhandled rejection. The browser is left stranded: the address bar shows the new route, the screen shows the old page, and the state is permanent — the path tracker was already advanced, so a back/forward retry of the failed route is swallowed as a hash-only change, and shells that guard on `target === location.href` never resend. Only a manual reload restores agreement. Reported in #1276 with a precise write-up.

This is the loud-failure sibling of the silent commit loss fixed in #1273: any navigation whose commit never completes used to leave a terminal URL/content desync, whether it failed silently (abandoned transition) or loudly (thrown error).

## Solution

The catch paths now recover before rethrowing:

1. **The pending navigation is abandoned and the bookkeeping is rolled back** — both internal URL trackers are restored from the committed-page snapshot. A later back/forward to the failed target is therefore treated as a real navigation rather than a hash-only change, and the next interception callback receives the page actually rendered as its `fromUrl`.

2. **Recovery runs by default** — a hard navigation to the intended URL, logged with the original error. A full page load always lands on matching URL and content. Apps that prefer their own policy — an error toast, a redirect — can take over through a new `onNavigationError({ error, href })` option on `initClientNavigation`, in which case the framework performs no hard navigation of its own.

3. **The original error is rethrown after recovery starts** — `navigate()` retains its existing rejection semantics, and programmatic callers can still observe the exact failure.

This shares one recovery policy with the commit watchdog shipped in #1273: a navigation that fails loudly (throws) recovers immediately, and a navigation that fails silently (no commit, no error) is caught by the opt-in watchdog timeout. Because a thrown navigation is a definitive failure — no false-positive risk, unlike a timeout on a slow-but-healthy navigation — error recovery is on by default while the watchdog remains opt-in.

## Compatibility

The default hard load is still an observable failure-path change: an app that currently catches a `navigate()` rejection and intentionally remains in the existing document will now see hard-load recovery begin before its catch handler runs. Strictly, that is a behavioral breaking change. Such an app can configure `onNavigationError` to retain control of recovery. The Promise contract itself is preserved: `navigate()` continues to reject with the original error.

## CI harness fix included

The first four Dev E2E attempts for this branch all failed in `database-do` with the same dead-port pattern. Reproducing the CI ordering locally showed that dev startup can run initialization commands that start a temporary helper server (`dev:init` → `worker-run`) before Vite announces the app server. The e2e dev-server launcher accepted the first bare `localhost:<port>` it saw, so it could bind tests to the helper server; when that helper exited, every navigation failed with `ECONNREFUSED`.

The final commit makes the launcher recognize only Vite's explicit `Local:` or `Debug:` announcements. This is a one-file harness fix, included here because it blocks reliable verification of this PR.

## Testing

- New e2e regression test `nav-error-recovery.test.mts`: aborts the in-flight navigation fetch once and asserts the page recovers to the target route with matching URL and content. It runs in both dev and production-preview modes. Verified against unfixed code (times out stuck) and this change (recovers).
- New unit tests in `navigationErrorRecovery.test.ts`: default recovery with preserved rejection, custom handler precedence with preserved rejection, path-key repair allowing a popstate retry, popstate recovery, and restoration of the rendered `fromUrl` after a failed popstate.
- Full client unit suite: 79/79 pass. Existing client-navigation e2e: pass.

Fixes #1276
