### PR TITLE
fix(client): recover stale use-client lookup misses

### DIFF
--- a/docs/architecture/clientSideRecovery.md
+++ b/docs/architecture/clientSideRecovery.md
@@ -49,9 +49,9 @@ Applications that want to reload on disconnect can do so through `onStatusChange
 
 ## Hooking the failure path
 
-Every `"use client"` module is loaded through the framework's module lookup in `sdk/src/runtime/imports/client.ts`. `loadModule()` starts recovery when the requested ID is absent from that lookup. It also starts recovery when invoking a known lookup entry fails with a dynamic import error whose message matches `dynamically imported module`. Other errors are rethrown so application failures do not turn into reload attempts.
+Every `"use client"` module is resolved through the framework's module lookup in `sdk/src/runtime/imports/client.ts`, which delegates loading to `loadClientModule()` in `sdk/src/runtime/imports/loadClientModule.ts`. The loader starts recovery when the requested ID is absent from the lookup. It also starts recovery when a known lookup entry fails with a dynamic import error whose message matches `dynamically imported module`. Other errors are rethrown so application failures do not turn into reload attempts.
 
-Both recovery paths call `suspendForRecovery()`. It returns a promise that intentionally remains pending, which keeps React's Suspense boundary suspended while the controller waits to reload. It does not block the browser's main thread. When recovery reloads the page, the browser replaces the entire document and JavaScript environment, including the old React root and the pending promise.
+Both recovery paths call `suspendForRecovery()`. It returns a promise that intentionally remains pending, which keeps React waiting for the module load while the controller prepares to reload. It does not block the browser's main thread. When recovery reloads the page, the browser replaces the entire document and JavaScript environment, including the old React root and the pending promise.
 
 While recovery is waiting, the previous page can remain visible even though the address bar contains the destination URL, and navigation indicators can remain pending. During initial hydration, server-rendered HTML can remain visible without becoming interactive. If a deployment is permanently broken, a fresh document can encounter the same failure and start recovery again; this flow does not persist a reload-loop counter across documents.
 

--- a/docs/architecture/clientSideRecovery.md
+++ b/docs/architecture/clientSideRecovery.md
@@ -6,6 +6,8 @@ A RedwoodSDK application is split between a worker that runs on the server and a
 
 The most common way this surfaces is after a redeploy. RedwoodSDK ships client components as individual JavaScript files whose filenames include content hashes. A new build renames those files. A tab that was opened before the redeploy still references the old names, so when it later tries to load a chunk it has not yet needed, the browser fails to fetch it and React crashes into a blank page.
 
+A stale tab can also receive new page data during client-side navigation. If the new deployment added a client component, that response can refer to a module ID that is absent from the old tab's in-memory lookup. No JavaScript request is made in this case because the old client does not know which file contains the new module. Without recovery, the lookup error reaches React and produces the same blank page.
+
 This can also happen outside of deploys. A CDN or edge node can serve a stale HTML shell that references chunks the origin no longer has. A long-lived tab can sit idle long enough that its assets are evicted from the edge. In each case the tab is holding code that may no longer be valid, and the safest recovery is to reload once the application is confirmed reachable.
 
 ## Why immediate reload is not enough
@@ -18,7 +20,7 @@ The recovery flow therefore separates detection from the decision to reload. It 
 
 The recovery flow is exposed through `initClient()` as a single trigger:
 
-- `onModuleNotFound` fires when a `"use client"` dynamic import fails with a missing-chunk error.
+- `onModuleNotFound` fires when a `"use client"` module is absent from the stale client's lookup or its dynamic import fails with a missing-chunk error.
 
 It accepts either the built-in `"reloadWhenReady"` preset string or a callback that receives a `RecoveryController`. The SDK does not enable recovery by default, because an unexpected page reload can be worse than a stale tab, so the application opts in explicitly.
 
@@ -47,7 +49,11 @@ Applications that want to reload on disconnect can do so through `onStatusChange
 
 ## Hooking the failure path
 
-The dynamic import path is caught inside `sdk/src/runtime/imports/client.ts`. Every `"use client"` module is loaded through the framework's module lookup. When `loadModule()` catches a dynamic import failure whose message matches `dynamically imported module`, it starts recovery and returns a never-resolving promise. That promise keeps React's Suspense boundary suspended until the reload, so the tab does not crash before recovery completes.
+Every `"use client"` module is loaded through the framework's module lookup in `sdk/src/runtime/imports/client.ts`. `loadModule()` starts recovery when the requested ID is absent from that lookup. It also starts recovery when invoking a known lookup entry fails with a dynamic import error whose message matches `dynamically imported module`. Other errors are rethrown so application failures do not turn into reload attempts.
+
+Both recovery paths call `suspendForRecovery()`. It returns a promise that intentionally remains pending, which keeps React's Suspense boundary suspended while the controller waits to reload. It does not block the browser's main thread. When recovery reloads the page, the browser replaces the entire document and JavaScript environment, including the old React root and the pending promise.
+
+While recovery is waiting, the previous page can remain visible even though the address bar contains the destination URL, and navigation indicators can remain pending. During initial hydration, server-rendered HTML can remain visible without becoming interactive. If a deployment is permanently broken, a fresh document can encounter the same failure and start recovery again; this flow does not persist a reload-loop counter across documents.
 
 ## Configuring recovery
 
@@ -81,6 +87,6 @@ The health check is a full HTML GET with `cache: "no-store"`. This is heavier th
 
 ## What is not covered
 
-This mechanism is intentionally scoped to the missing-client-chunk path.
+This mechanism is intentionally scoped to missing client modules.
 
 It does not intercept ordinary RSC or action fetches that fail for other reasons, such as validation errors or transient network blips. It does not queue requests transparently. It does not use a service worker. It does not maintain a persistent connection or try to remap old module names to new asset names. It also does not add any server-side stale detection, build-version plumbing, or dedicated health endpoint. The recovery is driven entirely by what the client can observe and by whether the current route is loadable.

--- a/docs/architecture/clientSideRecovery.md
+++ b/docs/architecture/clientSideRecovery.md
@@ -47,11 +47,11 @@ Only one recovery controller runs at a time. If a second failure occurs while re
 
 Applications that want to reload on disconnect can do so through `onStatusChange` or other application-level hooks; it is not part of the built-in recovery flow.
 
-## Hooking the failure path
+## How module failures trigger recovery
 
-Every `"use client"` module is resolved through the framework's module lookup in `sdk/src/runtime/imports/client.ts`, which delegates loading to `loadClientModule()` in `sdk/src/runtime/imports/loadClientModule.ts`. The loader starts recovery when the requested ID is absent from the lookup. It also starts recovery when a known lookup entry fails with a dynamic import error whose message matches `dynamically imported module`. Other errors are rethrown so application failures do not turn into reload attempts.
+Recovery begins in two situations. First, a stale tab can receive page data from a newer deployment that refers to a client module absent from the tab's in-memory lookup. Second, a module can be present in the lookup but fail to load, for example because its old content-hashed JavaScript file is no longer available after a deployment. Errors unrelated to loading client modules continue to surface normally so application failures do not turn into reload attempts.
 
-Both recovery paths call `suspendForRecovery()`. It returns a promise that intentionally remains pending, which keeps React waiting for the module load while the controller prepares to reload. It does not block the browser's main thread. When recovery reloads the page, the browser replaces the entire document and JavaScript environment, including the old React root and the pending promise.
+In either case, the framework starts recovery and intentionally leaves the module load pending. This keeps the failure from reaching React while the framework waits to reload, without blocking the browser's main thread. When recovery reloads the page, the browser replaces the entire document and JavaScript environment, including the old React tree and the pending module load.
 
 While recovery is waiting, the previous page can remain visible even though the address bar contains the destination URL, and navigation indicators can remain pending. During initial hydration, server-rendered HTML can remain visible without becoming interactive. If a deployment is permanently broken, a fresh document can encounter the same failure and start recovery again; this flow does not persist a reload-loop counter across documents.
 

--- a/playground/module-not-found-recovery/__tests__/e2e.test.mts
+++ b/playground/module-not-found-recovery/__tests__/e2e.test.mts
@@ -12,8 +12,12 @@ import { expect } from "vitest";
 setupPlaygroundEnvironment(import.meta.url);
 
 testDeploy(
-  "reproduces dynamic module failure after redeploy",
+  "recovers stale client modules after redeploy",
   async ({ page, url, deployment, projectDir }) => {
+    if (!deployment) {
+      throw new Error("Expected a deployment test environment");
+    }
+
     const { get } = trackPageErrors(page);
 
     await page.goto(url, {
@@ -25,9 +29,7 @@ testDeploy(
     // Sanity check: the home page loads.
     expect(await page.content()).toContain("Home");
 
-    // Modify the Widget component so its client chunk hash changes on the
-    // next deploy. The route still exists, but a stale tab's lookup map still
-    // points to the old hashed chunk.
+    // First cover a stale lookup entry whose old client chunk disappeared.
     const widgetPath = path.join(projectDir, "src/app/pages/Widget.tsx");
     const original = await fs.readFile(widgetPath, "utf-8");
     const buildB = original.replace("Widget build A", "Widget build B");
@@ -35,25 +37,119 @@ testDeploy(
 
     await deployment.redeploy();
 
-    // The tab is still running build A. Navigate to /widget using the stale
-    // client router; the RSC response loads but the corresponding client chunk
-    // no longer exists. The recovery flow should detect the failure, wait until
-    // /widget is loadable, and reload the page.
+    // The tab is still running build A. Its lookup points to the old Widget
+    // chunk, which is no longer available after build B is deployed.
     await page.click("#link-to-widget");
 
-    // Wait for the recovery reload to land on the new build.
     await poll(async () => {
       const content = await page.content();
-      return content.includes("Widget build B");
+      expect(content).toContain("Widget build B");
+      return true;
     });
 
     expect(page.url()).toContain("/widget");
-
-    // The missing chunk should appear as a failed network request before the
-    // recovery reload completes.
-    const { failedRequests } = get();
     expect(
-      failedRequests.some((r) => r.includes("Widget")),
+      get().failedRequests.some((request) => request.includes("Widget")),
     ).toBe(true);
+
+    // Load build B normally, then keep that document open while build C adds
+    // a client module that build B's in-memory lookup has never seen.
+    await page.goto(url, {
+      waitUntil: "domcontentloaded",
+      timeout: 30000,
+    });
+    await waitForHydration(page);
+    await page.evaluate(() => {
+      (window as any).__RWSDK_STALE_DOCUMENT__ = true;
+    });
+
+    const consoleErrors: string[] = [];
+    const pageErrors: string[] = [];
+    const documentRequests: string[] = [];
+
+    page.on("console", (message) => {
+      if (message.type() === "error") {
+        consoleErrors.push(message.text());
+      }
+    });
+    page.on("pageerror", (error) => {
+      pageErrors.push(error instanceof Error ? error.message : String(error));
+    });
+    page.on("request", (request) => {
+      if (request.resourceType() === "document") {
+        documentRequests.push(request.url());
+      }
+    });
+
+    const newWidgetPath = path.join(projectDir, "src/app/pages/NewWidget.tsx");
+    await fs.writeFile(
+      newWidgetPath,
+      `"use client";
+
+import { useState } from "react";
+
+export function NewWidget() {
+  const [clicks, setClicks] = useState(0);
+
+  return (
+    <button id="new-widget" onClick={() => setClicks((count) => count + 1)}>
+      New widget clicks: {clicks}
+    </button>
+  );
+}
+`,
+    );
+    await fs.writeFile(
+      widgetPath,
+      `import { NewWidget } from "./NewWidget";
+
+export function Widget() {
+  return (
+    <div>
+      <h1>Widget Page</h1>
+      <NewWidget />
+    </div>
+  );
+}
+`,
+    );
+
+    await deployment.redeploy();
+
+    // Build C's RSC response refers to NewWidget. The stale build B client
+    // should suspend the lookup miss and recover with a full document reload.
+    await page.click("#link-to-widget");
+
+    await poll(async () => {
+      const text = await page
+        .$eval("#new-widget", (element) => element.textContent)
+        .catch(() => null);
+      expect(text).toContain("New widget clicks: 0");
+      return true;
+    });
+
+    expect(page.url()).toContain("/widget");
+    expect(
+      documentRequests.some((requestUrl) =>
+        new URL(requestUrl).pathname.endsWith("/widget"),
+      ),
+    ).toBe(true);
+    expect(
+      await page.evaluate(() => (window as any).__RWSDK_STALE_DOCUMENT__),
+    ).toBeUndefined();
+    expect([...consoleErrors, ...pageErrors].join("\n")).not.toContain(
+      "No module found for",
+    );
+
+    await waitForHydration(page);
+    await page.click("#new-widget");
+    await poll(async () => {
+      const text = await page.$eval(
+        "#new-widget",
+        (element) => element.textContent,
+      );
+      expect(text).toContain("New widget clicks: 1");
+      return true;
+    });
   },
 );

--- a/sdk/src/runtime/client/recovery.ts
+++ b/sdk/src/runtime/client/recovery.ts
@@ -266,6 +266,15 @@ export function startRecovery(reason: "module-not-found"): void {
   void run();
 }
 
+export function suspendForRecovery(reason: "module-not-found"): Promise<never> {
+  startRecovery(reason);
+
+  // context(chrsnymn, 12 Aug 2026): Keep this module load pending until
+  // recovery reloads the document. Returning the missing-module error would
+  // let React fail the render before recovery can replace the stale page.
+  return new Promise<never>(() => {});
+}
+
 export function isDynamicImportFailure(error: unknown): boolean {
   return (
     error instanceof TypeError &&

--- a/sdk/src/runtime/imports/client.ts
+++ b/sdk/src/runtime/imports/client.ts
@@ -1,36 +1,14 @@
 import React from "react";
 import { ClientOnly } from "../client/client";
-import {
-  isDynamicImportFailure,
-  isRecoveryConfigured,
-  startRecovery,
-} from "../client/recovery.js";
 import { memoizeOnId } from "../lib/memoizeOnId";
+import { loadClientModule } from "./loadClientModule.js";
 
 // @ts-ignore
 import { useClientLookup } from "virtual:use-client-lookup.js";
 
-export const loadModule = memoizeOnId(async (id: string) => {
-  const moduleFn = useClientLookup[id];
-
-  if (!moduleFn) {
-    throw new Error(
-      `(client) No module found for '${id}' in module lookup for "use client" directive`,
-    );
-  }
-
-  try {
-    return await moduleFn();
-  } catch (error) {
-    if (isDynamicImportFailure(error) && isRecoveryConfigured()) {
-      startRecovery("module-not-found");
-      // Stall this import forever so React doesn't crash before the recovery
-      // flow reloads the page.
-      return new Promise(() => {});
-    }
-    throw error;
-  }
-});
+export const loadModule = memoizeOnId((id: string) =>
+  loadClientModule({ id, moduleFn: useClientLookup[id] }),
+);
 
 // context(justinvdm, 2 Dec 2024): re memoize(): React relies on the same promise instance being returned for the same id
 export const clientWebpackRequire = memoizeOnId(async (id: string) => {

--- a/sdk/src/runtime/imports/loadClientModule.test.ts
+++ b/sdk/src/runtime/imports/loadClientModule.test.ts
@@ -1,0 +1,77 @@
+import { setTimeout as delay } from "node:timers/promises";
+import { describe, expect, it, vi } from "vitest";
+import { loadClientModule } from "./loadClientModule.js";
+
+async function getPromiseState(promise: Promise<unknown>) {
+  return Promise.race([
+    promise.then(
+      () => "resolved",
+      () => "rejected",
+    ),
+    delay(10, "pending"),
+  ]);
+}
+
+describe("loadClientModule", () => {
+  it("preserves the lookup error when recovery is not configured", async () => {
+    const id = "/src/app/pages/Missing.tsx";
+
+    await expect(
+      loadClientModule({
+        id,
+        moduleFn: undefined,
+        recoveryConfigured: () => false,
+      }),
+    ).rejects.toThrow(
+      `(client) No module found for '${id}' in module lookup for "use client" directive`,
+    );
+  });
+
+  it("suspends a lookup miss while recovery is configured", async () => {
+    const pending = new Promise<never>(() => {});
+    const suspend = vi.fn(() => pending);
+
+    const result = loadClientModule({
+      id: "/src/app/pages/NewComponent.tsx",
+      moduleFn: undefined,
+      recoveryConfigured: () => true,
+      suspend,
+    });
+
+    expect(suspend).toHaveBeenCalledWith("module-not-found");
+    expect(await getPromiseState(result)).toBe("pending");
+  });
+
+  it("suspends a failed dynamic import while recovery is configured", async () => {
+    const pending = new Promise<never>(() => {});
+    const suspend = vi.fn(() => pending);
+
+    const result = loadClientModule({
+      id: "/src/app/pages/ChangedComponent.tsx",
+      moduleFn: async () => {
+        throw new TypeError("Failed to fetch dynamically imported module");
+      },
+      recoveryConfigured: () => true,
+      suspend,
+    });
+
+    await Promise.resolve();
+    expect(suspend).toHaveBeenCalledWith("module-not-found");
+    expect(await getPromiseState(result)).toBe("pending");
+  });
+
+  it("rethrows other module errors", async () => {
+    const error = new Error("Application module failed");
+
+    await expect(
+      loadClientModule({
+        id: "/src/app/pages/BrokenComponent.tsx",
+        moduleFn: async () => {
+          throw error;
+        },
+        recoveryConfigured: () => true,
+        suspend: vi.fn(),
+      }),
+    ).rejects.toBe(error);
+  });
+});

--- a/sdk/src/runtime/imports/loadClientModule.ts
+++ b/sdk/src/runtime/imports/loadClientModule.ts
@@ -1,0 +1,38 @@
+import {
+  isDynamicImportFailure,
+  isRecoveryConfigured,
+  suspendForRecovery,
+} from "../client/recovery.js";
+
+type LoadClientModuleOptions = {
+  id: string;
+  moduleFn: (() => Promise<any>) | undefined;
+  recoveryConfigured?: () => boolean;
+  suspend?: typeof suspendForRecovery;
+};
+
+export async function loadClientModule({
+  id,
+  moduleFn,
+  recoveryConfigured = isRecoveryConfigured,
+  suspend = suspendForRecovery,
+}: LoadClientModuleOptions) {
+  if (!moduleFn) {
+    if (recoveryConfigured()) {
+      return suspend("module-not-found");
+    }
+
+    throw new Error(
+      `(client) No module found for '${id}' in module lookup for "use client" directive`,
+    );
+  }
+
+  try {
+    return await moduleFn();
+  } catch (error) {
+    if (isDynamicImportFailure(error) && recoveryConfigured()) {
+      return suspend("module-not-found");
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION

## Problem

After a deployment adds a new `"use client"` component, a browser tab still running the previous build can encounter a white screen during client-side navigation.

The new deployment's RSC response refers to the new component, but the stale browser tab's in-memory `useClientLookup` does not contain its module ID. `loadModule()` currently throws immediately:

```text
(client) No module found for '<id>' in module lookup for "use client" directive
```

This happens before the existing dynamic-import recovery path. As a result, `onModuleNotFound: "reloadWhenReady"` is never triggered, the error reaches React, and the page becomes blank until manually reloaded.

## Solution

Route missing lookup entries through the existing client recovery flow when `onModuleNotFound` is configured.

- Extract the module-loading decision into `loadClientModule()`.
- If the requested ID is absent from `useClientLookup`, start recovery instead of throwing into React.
- Reuse `suspendForRecovery()` for both lookup misses and failed dynamic imports.
- Keep the module load pending while the recovery controller checks the current route and reloads the document.
- Preserve the existing lookup error when recovery is not configured.
- Continue rethrowing unrelated module errors so application bugs do not become reload attempts.

The pending promise does not block the browser. Once recovery reloads the page, the old document, React root, module state, and pending promise are discarded together.

## Testing

### Unit coverage

Added tests for:

- preserving the lookup error when recovery is not configured;
- suspending a lookup miss when recovery is configured;
- suspending a failed dynamic import;
- rethrowing unrelated module errors.

```sh
CI=true pnpm --dir sdk exec vitest run \
  --config vitest.config.mts \
  src/runtime/imports/loadClientModule.test.ts
```

Result: 4 tests passed.

### Production redeploy E2E

Extended the existing `module-not-found-recovery` playground test to cover both stale-deployment failure modes:

1. The stale lookup points to an old client chunk that no longer exists.
2. A new deployment adds a client component whose ID is absent from the stale lookup.

The second case is reproduced naturally across production builds. The test confirms that:

- recovery performs a full document reload;
- state belonging to the stale document is discarded;
- the lookup error does not reach React as an uncaught error;
- the new component renders and remains interactive after recovery.

```sh
CI=true GITHUB_EVENT_NAME=pull_request RWSDK_SEQUENTIAL=1 \
  pnpm test:e2e module-not-found-recovery
```

Result: 1 test passed.

### Additional verification

```sh
CI=true pnpm --filter module-not-found-recovery types
```

The SDK production build also passes as part of the E2E command.

## Documentation

Updated the client-side recovery architecture document to cover:

- stale lookup entries;
- why the module promise intentionally remains pending;
- how the reload disposes of the old promise;
- visible pending-navigation behavior;
- the remaining reload-loop limitation for permanently broken deployments.

Fixes #1279
