### PR TITLE
fix(client-navigation): skip non-HTTP and cross-origin links

### DIFF
--- a/docs/architecture/clientSideNavigation.md
+++ b/docs/architecture/clientSideNavigation.md
@@ -23,7 +23,7 @@ RedwoodSDK's client-side navigation intercepts clicks on internal links and fetc
 
 1.  **Initialization**: The developer calls `initClientNavigation()` in their `src/client.tsx` file. This sets up a global click event listener on the `document`.
 
-2.  **Event Interception**: When a user clicks anywhere on the page, the event listener checks if the click target is an `<a>` tag with an `href` attribute pointing to a same-origin URL. It also performs several checks to ensure it doesn't interfere with expected browser behaviors, such as ignoring clicks with modifier keys (e.g., `Cmd+click` to open in a new tab), links with a `target` attribute, or download links.
+2.  **Event Interception**: When someone clicks anywhere on the page, the event listener looks for an `<a>` tag with a relative `href` that resolves to an HTTP(S) URL on the current site. The listener leaves other links to the browser, including non-HTTP schemes, links to other sites, and absolute HTTP(S) links that name the current site. It also leaves modified clicks (such as `Cmd+click`), links with another `target`, download links, and hash links to the browser.
 
 3.  **URL Update**: If the click is a candidate for client-side navigation, the default browser navigation is prevented. The new URL is then pushed to the browser's history using `window.history.pushState()`. This updates the URL in the address bar without triggering a page load.
 

--- a/playground/client-navigation/__tests__/e2e.test.mts
+++ b/playground/client-navigation/__tests__/e2e.test.mts
@@ -74,6 +74,42 @@ testDevAndDeploy("navigates on link click", async ({ page, url }) => {
   expect(page.url()).toContain("/about");
 });
 
+testDevAndDeploy(
+  "leaves an ordinary mailto link to the browser",
+  async ({ page, url }) => {
+    const pageErrors: Error[] = [];
+    page.on("pageerror", (error) => {
+      pageErrors.push(error);
+    });
+
+    await page.goto(url);
+    await waitForHydration(page);
+
+    await page.evaluate(() => {
+      const originalPushState = window.history.pushState.bind(window.history);
+      const pushStateUrls: string[] = [];
+      (
+        window as typeof window & { __pushStateUrls: string[] }
+      ).__pushStateUrls = pushStateUrls;
+      window.history.pushState = (data, unused, nextUrl) => {
+        pushStateUrls.push(String(nextUrl));
+        originalPushState(data, unused, nextUrl);
+      };
+    });
+
+    await page.click("#email-link");
+
+    const pushStateUrls = await page.evaluate(
+      () =>
+        (window as typeof window & { __pushStateUrls: string[] })
+          .__pushStateUrls,
+    );
+    expect(pushStateUrls).toEqual([]);
+    expect(pageErrors).toEqual([]);
+    expect(page.url()).toBe(new URL(url).href);
+  },
+);
+
 // Regression test for https://github.com/redwoodjs/sdk/issues/1104.
 // The browser's default scroll restoration runs before the RSC payload
 // commits, causing the old DOM to flash at the new scroll offset. We take

--- a/playground/client-navigation/src/app/pages/Home.tsx
+++ b/playground/client-navigation/src/app/pages/Home.tsx
@@ -39,6 +39,17 @@ export function Home({ ctx }: RequestInfo) {
         Go to About Page with Link
       </a>
 
+      <section style={{ marginTop: "2rem" }}>
+        <h2>Browser-handled links</h2>
+        <p>
+          This ordinary email link should ask the browser to open the configured
+          mail app.
+        </p>
+        <a href="mailto:someone@example.com" id="email-link">
+          Email someone@example.com
+        </a>
+      </section>
+
       <nav style={{ marginTop: "2rem" }}>
         <h2>Suspense Pages</h2>
         <a href="/suspense-one" id="suspense-one-link">

--- a/sdk/src/runtime/client/navigation.test.ts
+++ b/sdk/src/runtime/client/navigation.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { initClientNavigation, navigate, validateClickEvent } from "./navigation";
+import {
+  initClientNavigation,
+  navigate,
+  validateClickEvent,
+} from "./navigation";
 import {
   getNavigationSnapshot,
   resetNavigationStateForTests,
@@ -12,7 +16,7 @@ beforeEach(() => {
 
 // Mocking browser globals
 vi.stubGlobal("window", {
-  location: { href: "http://localhost/" },
+  location: { href: "http://localhost/", origin: "http://localhost" },
   addEventListener: vi.fn(),
   history: {
     scrollRestoration: "auto",
@@ -48,6 +52,12 @@ vi.stubGlobal(
 );
 
 describe("clientNavigation", () => {
+  beforeEach(() => {
+    window.location.href = "https://myapp.com/";
+    (window.location as unknown as { origin: string }).origin =
+      "https://myapp.com";
+  });
+
   let mockEvent: MouseEvent = {
     button: 0,
     metaKey: false,
@@ -55,14 +65,23 @@ describe("clientNavigation", () => {
     shiftKey: false,
     ctrlKey: false,
   } as unknown as MouseEvent;
-  let mockTarget = {
-    closest: () => {
-      return {
-        getAttribute: () => "/test",
-        hasAttribute: () => false,
-      };
-    },
-  } as unknown as HTMLElement;
+  function createMockTarget(
+    href: string,
+    options: { target?: string; download?: boolean } = {},
+  ) {
+    const link = {
+      getAttribute: (attribute: string) => (attribute === "href" ? href : null),
+      hasAttribute: (attribute: string) =>
+        attribute === "download" && options.download === true,
+      target: options.target ?? "",
+    };
+
+    return {
+      closest: () => link,
+    } as unknown as HTMLElement;
+  }
+
+  const mockTarget = createMockTarget("/test");
 
   it("should return true", () => {
     expect(validateClickEvent(mockEvent, mockTarget)).toBe(true);
@@ -74,11 +93,14 @@ describe("clientNavigation", () => {
     );
   });
 
-  it("none of the modifier keys are pressed", () => {
-    expect(
-      validateClickEvent({ ...mockEvent, metaKey: true }, mockTarget),
-    ).toBe(false);
-  });
+  it.each(["ctrlKey", "metaKey", "shiftKey", "altKey"] as const)(
+    "leaves clicks using %s to the browser",
+    (modifierKey) => {
+      expect(
+        validateClickEvent({ ...mockEvent, [modifierKey]: true }, mockTarget),
+      ).toBe(false);
+    },
+  );
 
   it("the target is not an anchor tag", () => {
     expect(
@@ -96,26 +118,54 @@ describe("clientNavigation", () => {
     ).toBe(false);
   });
 
-  it("should not include an #hash", () => {
+  it.each(["/about", "./about", "//myapp.com/about"])(
+    "allows the in-app href %s",
+    (href) => {
+      expect(validateClickEvent(mockEvent, createMockTarget(href))).toBe(true);
+    },
+  );
+
+  it.each([
+    "mailto:someone@example.com",
+    "tel:+27123456789",
+    "sms:+27123456789",
+    "data:text/plain,hello",
+    "blob:https://myapp.com/12345678-1234-1234-1234-123456789abc",
+    "https://external.example.com/about",
+    "//external.example.com/about",
+  ])("leaves the browser-owned href %s to the browser", (href) => {
+    expect(validateClickEvent(mockEvent, createMockTarget(href))).toBe(false);
+  });
+
+  it.each(["https://myapp.com/about", "HTTPS://myapp.com/about"])(
+    "keeps the absolute same-origin href %s as a full page load",
+    (href) => {
+      expect(validateClickEvent(mockEvent, createMockTarget(href))).toBe(false);
+    },
+  );
+
+  it("leaves hash links to the browser", () => {
     expect(
-      validateClickEvent(mockEvent, {
-        closest: () => ({
-          getAttribute: () => "/test#hash",
-          hasAttribute: () => false,
-        }),
-      } as unknown as HTMLElement),
+      validateClickEvent(mockEvent, createMockTarget("/about#details")),
     ).toBe(false);
   });
 
-  it("should be a relative link", () => {
+  it("leaves links with another target to the browser", () => {
     expect(
-      validateClickEvent(mockEvent, {
-        closest: () => ({
-          getAttribute: () => "/test",
-          hasAttribute: () => false,
-        }),
-      } as unknown as HTMLElement),
-    ).toBe(true);
+      validateClickEvent(
+        mockEvent,
+        createMockTarget("/about", { target: "_blank" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("leaves download links to the browser", () => {
+    expect(
+      validateClickEvent(
+        mockEvent,
+        createMockTarget("/report.pdf", { download: true }),
+      ),
+    ).toBe(false);
   });
 });
 
@@ -140,6 +190,7 @@ describe("full-reload opt-out (data-reload and shouldIntercept)", () => {
     vi.stubGlobal("window", {
       location: {
         href: "http://localhost/",
+        origin: "http://localhost",
         pathname: "/",
         search: "",
         replace: vi.fn(),
@@ -179,7 +230,7 @@ describe("full-reload opt-out (data-reload and shouldIntercept)", () => {
   }) {
     const fakeAnchor = {
       getAttribute: (attr: string) =>
-        attr === "href" ? props.href : props.target ?? null,
+        attr === "href" ? props.href : (props.target ?? null),
       hasAttribute: (attr: string) =>
         attr === "data-reload" ? Boolean(props.dataReload) : false,
       target: props.target ?? "",
@@ -206,7 +257,10 @@ describe("full-reload opt-out (data-reload and shouldIntercept)", () => {
   it("data-reload attribute prevents client-side interception", async () => {
     initClientNavigation();
 
-    const { fakeTarget } = createFakeAnchor({ href: "/admin", dataReload: true });
+    const { fakeTarget } = createFakeAnchor({
+      href: "/admin",
+      dataReload: true,
+    });
     const fakeClickEvent = createFakeClickEvent(fakeTarget);
 
     await capturedClickHandler!(fakeClickEvent);
@@ -342,6 +396,7 @@ describe("onNavigate callback (issue #1123 regression)", () => {
     vi.stubGlobal("window", {
       location: {
         href: "http://localhost/",
+        origin: "http://localhost",
         pathname: "/",
         search: "",
         replace: vi.fn(),
@@ -498,6 +553,7 @@ describe("initClientNavigation", () => {
     vi.stubGlobal("window", {
       location: {
         href: "http://localhost/",
+        origin: "http://localhost",
         pathname: "/",
         search: "",
         replace: vi.fn(),

--- a/sdk/src/runtime/client/navigation.ts
+++ b/sdk/src/runtime/client/navigation.ts
@@ -71,6 +71,40 @@ function shouldInterceptNavigation(
   return true;
 }
 
+function isAbsoluteHref(href: string) {
+  try {
+    new URL(href);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isClientNavigationHref(href: string) {
+  let url: URL;
+
+  try {
+    url = new URL(href, window.location.href);
+  } catch {
+    return false;
+  }
+
+  const isHttp = url.protocol === "http:" || url.protocol === "https:";
+  const isSameOrigin = url.origin === window.location.origin;
+
+  if (!isHttp || !isSameOrigin) {
+    return false;
+  }
+
+  if (isAbsoluteHref(href)) {
+    // context(justinvdm, 4 Sep 2026): Keep absolute HTTP(S) links as full page
+    // loads, even when they point to this app.
+    return false;
+  }
+
+  return true;
+}
+
 export function validateClickEvent(event: MouseEvent, target: HTMLElement) {
   // should this only work for left click?
   if (event.button !== 0) {
@@ -101,7 +135,7 @@ export function validateClickEvent(event: MouseEvent, target: HTMLElement) {
     return false;
   }
 
-  if (href.startsWith("http")) {
+  if (!isClientNavigationHref(href)) {
     return false;
   }
 

--- a/sdk/src/runtime/client/navigation.ts
+++ b/sdk/src/runtime/client/navigation.ts
@@ -97,7 +97,7 @@ function isClientNavigationHref(href: string) {
   }
 
   if (isAbsoluteHref(href)) {
-    // context(justinvdm, 4 Sep 2026): Keep absolute HTTP(S) links as full page
+    // context(chrsnym, 4 Sep 2026): Keep absolute HTTP(S) links as full page
     // loads, even when they point to this app.
     return false;
   }


### PR DESCRIPTION
## Problem

Client navigation intercepts ordinary links such as `mailto:` and
cross-origin links such as `//external.example.com/path`. These can
reach browser history handling, throw a SecurityError, and prevent
the browser from handling the link normally.

## Solution

Use the browser's URL parser to check the protocol and origin.
Only relative links resolving to same-origin HTTP(S) URLs remain
eligible for soft navigation.

Preserve full page loads for absolute HTTP(S) links, including
same-origin links. Existing hash, target, download, modifier-key,
and hard-reload controls remain unchanged.

Add unit coverage, an ordinary email link with an E2E regression
test, and update the navigation documentation.

Fixes #1287.

## Validation

From `sdk/`:

```sh
pnpm test
```

674 passed, 1 skipped.

From the repository root:

```sh
RWSDK_SKIP_DEPLOY=1 pnpm test:e2e client-navigation/__tests__/e2e.test.mts
pnpm test:e2e client-navigation/__tests__/e2e.test.mts -t "leaves an ordinary mailto link to the browser"
git diff --check
```

Development suite: 8 passed, 8 deployment variants skipped.
Focused regression: 2 passed across development and deployment.
Manual browser testing also passed.

Plain Prettier passed. The import-organizing plugin encountered
a local TypeScript error, so formatting used `--no-config`.

The full agent-ci run did not pass: local runner and credential
problems remain, as previously reported.